### PR TITLE
Fix issue on building techinfo

### DIFF
--- a/app/Http/Controllers/TechtreeController.php
+++ b/app/Http/Controllers/TechtreeController.php
@@ -87,24 +87,24 @@ class TechtreeController extends OGameController
 
         $production_table = [];
         if (!empty($object->production)) {
-            $production_amount_current_level = $planet->getBuildingProduction($object->machine_name, $current_level)->sum();
+            $production_amount_current_level = $planet->getBuildingProduction($object->machine_name, $current_level,true)->sum();
 
             // Create production table array value
             // TODO: add unittest to verify that production calculation is correctly for various buildings.
             $min_level = (($current_level - 2) > 1) ? $current_level - 2 : 1;
             for ($i = $min_level; $i < $min_level + 15; $i++) {
-                $production_amount_previous_level = $planet->getBuildingProduction($object->machine_name, $i - 1)->sum();
-                $production_amount = $planet->getBuildingProduction($object->machine_name, $i)->sum();
+                $production_amount_previous_level = $planet->getBuildingProduction($object->machine_name, $i - 1, true)->sum();
+                $production_amount = $planet->getBuildingProduction($object->machine_name, $i, true)->sum();
 
                 $production_table[] = [
                     'level' => $i,
                     'production' => $production_amount,
                     'production_difference' => $production_amount - $production_amount_current_level,
                     'production_difference_per_level' => ($i === $current_level) ? 0 : (($i - 1 < $current_level) ? ($production_amount - $production_amount_previous_level) * -1 : $production_amount - $production_amount_previous_level),
-                    'energy_balance' => $planet->getBuildingProduction($object->machine_name, $i)->energy->get(),
-                    'energy_difference' => ($i == $current_level) ? 0 : ($planet->getBuildingProduction($object->machine_name, $i)->energy->get() - $planet->getBuildingProduction($object->machine_name, $current_level)->energy->get()),
-                    'deuterium_consumption' => $planet->getBuildingProduction($object->machine_name, $i)->deuterium->get(),
-                    'deuterium_consumption_per_level' => ($i == $current_level) ? 0 : ($planet->getBuildingProduction($object->machine_name, $i)->deuterium->get() - $planet->getBuildingProduction($object->machine_name, $current_level)->deuterium->get()),
+                    'energy_balance' => $planet->getBuildingProduction($object->machine_name, $i, true)->energy->get(),
+                    'energy_difference' => ($i == $current_level) ? 0 : ($planet->getBuildingProduction($object->machine_name, $i, true)->energy->get() - $planet->getBuildingProduction($object->machine_name, $current_level,true)->energy->get()),
+                    'deuterium_consumption' => $planet->getBuildingProduction($object->machine_name, $i, true)->deuterium->get(),
+                    'deuterium_consumption_per_level' => ($i == $current_level) ? 0 : ($planet->getBuildingProduction($object->machine_name, $i, true)->deuterium->get() - $planet->getBuildingProduction($object->machine_name, $current_level, true)->deuterium->get()),
                     'protected' => 0,
                 ];
             }

--- a/app/Http/Controllers/TechtreeController.php
+++ b/app/Http/Controllers/TechtreeController.php
@@ -87,7 +87,7 @@ class TechtreeController extends OGameController
 
         $production_table = [];
         if (!empty($object->production)) {
-            $production_amount_current_level = $planet->getBuildingProduction($object->machine_name, $current_level,true)->sum();
+            $production_amount_current_level = $planet->getBuildingProduction($object->machine_name, $current_level, true)->sum();
 
             // Create production table array value
             // TODO: add unittest to verify that production calculation is correctly for various buildings.
@@ -102,9 +102,9 @@ class TechtreeController extends OGameController
                     'production_difference' => $production_amount - $production_amount_current_level,
                     'production_difference_per_level' => ($i === $current_level) ? 0 : (($i - 1 < $current_level) ? ($production_amount - $production_amount_previous_level) * -1 : $production_amount - $production_amount_previous_level),
                     'energy_balance' => $planet->getBuildingProduction($object->machine_name, $i, true)->energy->get(),
-                    'energy_difference' => ($i == $current_level) ? 0 : ($planet->getBuildingProduction($object->machine_name, $i, true)->energy->get() - $planet->getBuildingProduction($object->machine_name, $current_level,true)->energy->get()),
+                    'energy_difference' => ($i === $current_level) ? 0 : ($planet->getBuildingProduction($object->machine_name, $i, true)->energy->get() - $planet->getBuildingProduction($object->machine_name, $current_level, true)->energy->get()),
                     'deuterium_consumption' => $planet->getBuildingProduction($object->machine_name, $i, true)->deuterium->get(),
-                    'deuterium_consumption_per_level' => ($i == $current_level) ? 0 : ($planet->getBuildingProduction($object->machine_name, $i, true)->deuterium->get() - $planet->getBuildingProduction($object->machine_name, $current_level, true)->deuterium->get()),
+                    'deuterium_consumption_per_level' => ($i === $current_level) ? 0 : ($planet->getBuildingProduction($object->machine_name, $i, true)->deuterium->get() - $planet->getBuildingProduction($object->machine_name, $current_level, true)->deuterium->get()),
                     'protected' => 0,
                 ];
             }

--- a/app/Services/PlanetService.php
+++ b/app/Services/PlanetService.php
@@ -1156,9 +1156,12 @@ class PlanetService
      * @param string $machine_name
      *  The machine name of the building to calculate the production for.
      *
-     * @param int $building_level
+     * @param int|null $building_level
      *  Optional parameter to calculate the production for a specific level
      *  of a building. Defaults to the current level.
+     *
+     * @param bool $force_factor
+     * Optional parameter use to force/simulate the production at 100%
      *
      * @return Resources
      * @throws Exception

--- a/app/Services/PlanetService.php
+++ b/app/Services/PlanetService.php
@@ -1163,7 +1163,7 @@ class PlanetService
      * @return Resources
      * @throws Exception
      */
-    public function getBuildingProduction(string $machine_name, int $building_level = 0): Resources
+    public function getBuildingProduction(string $machine_name, int|null $building_level = null, bool $force_factor = false): Resources
     {
         $building = $this->objects->getBuildingObjectsWithProductionByMachineName($machine_name);
 
@@ -1177,7 +1177,7 @@ class PlanetService
             $resource_production_factor = $this->getResourceProductionFactor();
         }
 
-        $building_percentage = $this->getBuildingPercent($machine_name); // Implement building percentage.
+        $building_percentage = !$force_factor ? $this->getBuildingPercent($machine_name) : 100; // Implement building percentage.
         $planet_temperature = $this->getPlanetTempAvg();
         $energy_technology_level = 0; // Implement energy technology level getter.
         $universe_resource_multiplier = $this->settingsService->economySpeed();


### PR DESCRIPTION
When the ressource factor is reduce or put to 0, the techinfo table of the building production is devide by the percentage

![image](https://github.com/lanedirt/OGameX/assets/3535011/9bc393c6-f283-473c-97d0-e6e3e0a36032)
