### PR TITLE
fix - max_build_amount return 0 when requirements_met is false

### DIFF
--- a/app/Http/Traits/ObjectAjaxTrait.php
+++ b/app/Http/Traits/ObjectAjaxTrait.php
@@ -45,7 +45,7 @@ trait ObjectAjaxTrait
         $price = $objects->getObjectPrice($object->machine_name, $planet);
 
         // Get max build amount of this object (unit).
-        $max_build_amount = $objects->getObjectMaxBuildAmount($object->machine_name, $planet);
+        $max_build_amount = $objects->getObjectMaxBuildAmount($object->machine_name, $planet, $requirements_met);
 
         // Switch
         $production_time = '';

--- a/app/Services/ObjectService.php
+++ b/app/Services/ObjectService.php
@@ -360,11 +360,17 @@ class ObjectService
      *
      * @param string $machine_name
      * @param PlanetService $planet
+     * @param bool $requirements_met
      * @return int
      * @throws Exception
      */
-    public function getObjectMaxBuildAmount(string $machine_name, PlanetService $planet): int
+    public function getObjectMaxBuildAmount(string $machine_name, PlanetService $planet, bool $requirements_met): int
     {
+        // If requirements are false, the max build amount is 0
+        if (!$requirements_met) {
+            return 0;
+        }
+
         $price = $this->getObjectPrice($machine_name, $planet);
 
         // Calculate max build amount based on price

--- a/app/Services/UnitQueueService.php
+++ b/app/Services/UnitQueueService.php
@@ -157,11 +157,14 @@ class UnitQueueService
 
         $object = $this->objects->getUnitObjectById($object_id);
 
+        // Check if user satisifes requirements to build this object.
+        $requirements_met = $this->objects->objectRequirementsMet($object->machine_name, $planet, $planet->getPlayer());
+
         // Sanity check: check if the planet has enough resources to build
         // the amount requested. If not, then adjust the ordered amount.
         // E.g. if a player orders 100 units but can only afford 60 units,
         // 60 units will be added to the queue and resources will be deducted.
-        $max_build_amount = $this->objects->getObjectMaxBuildAmount($object->machine_name, $planet);
+        $max_build_amount = $this->objects->getObjectMaxBuildAmount($object->machine_name, $planet, $requirements_met);
         if ($requested_build_amount > $max_build_amount) {
             $requested_build_amount = $max_build_amount;
         }

--- a/tests/Feature/UnitQueueTest.php
+++ b/tests/Feature/UnitQueueTest.php
@@ -8,7 +8,6 @@ use Illuminate\Support\Carbon;
 use OGame\Models\Resources;
 use OGame\Services\SettingsService;
 use Tests\AccountTestCase;
-use OGame\Services\PlayerService;
 
 /**
  * Test that the unit queue works as expected.
@@ -32,10 +31,6 @@ class UnitQueueTest extends AccountTestCase
         $this->planetSetObjectLevel('research_lab', 1);
         $this->playerSetResearchLevel('energy_technology', 1);
         $this->playerSetResearchLevel('combustion_drive', 1);
-
-        //refresh player
-        $playerService = app()->make(PlayerService::class, ['player_id' => $this->currentUserId]);
-        $playerService->load($this->currentUserId);
     }
 
     /**

--- a/tests/Feature/UnitQueueTest.php
+++ b/tests/Feature/UnitQueueTest.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Carbon;
 use OGame\Models\Resources;
 use OGame\Services\SettingsService;
 use Tests\AccountTestCase;
+use OGame\Services\PlayerService;
 
 /**
  * Test that the unit queue works as expected.
@@ -31,6 +32,10 @@ class UnitQueueTest extends AccountTestCase
         $this->planetSetObjectLevel('research_lab', 1);
         $this->playerSetResearchLevel('energy_technology', 1);
         $this->playerSetResearchLevel('combustion_drive', 1);
+
+        //refresh player
+        $playerService = app()->make(PlayerService::class, ['player_id' => $this->currentUserId]);
+        $playerService->load($this->currentUserId);
     }
 
     /**


### PR DESCRIPTION
Fixes #125 

I had to reload the player data in `UnitQueueTest.php` because the getResearchLevel in ` PlayerService.php ` was returning 0. This occurred because $this->user_tech hadn't been loaded with the researches yet.

Please let me know if there are any issues 👍