### PR TITLE
Fix bug in unitqueue where ordering large quantities can result in lower than ordered amount

### DIFF
--- a/.github/workflows/run-tests-docker-compose-prod.yml
+++ b/.github/workflows/run-tests-docker-compose-prod.yml
@@ -40,7 +40,9 @@ jobs:
         run: docker compose exec -T ogame-app php artisan cache:clear && docker compose exec -T ogame-app php artisan config:cache && docker compose exec -T ogame-app php artisan route:cache && docker compose exec -T ogame-app php artisan view:cache
       - name: Run Tests
         run: docker compose exec -T ogame-app php artisan test
-      - name: Run custom Race Condition Tests
-        run: |
-          docker compose exec -T ogame-app php artisan test:race-condition-unitqueue
-          docker compose exec -T ogame-app php artisan test:race-condition-game-mission
+      # Note: Disabled for now, as it is not working as expected on GitHub Actions since a composer update.
+      # Throws error: Client error: `POST http://ogame-webserver/login` resulted in a `419 unknown status` response.
+      #- name: Run custom Race Condition Tests
+      #  run: |
+      #    docker compose exec -T ogame-app php artisan test:race-condition-unitqueue
+      #    docker compose exec -T ogame-app php artisan test:race-condition-game-mission

--- a/app/Factories/PlanetServiceFactory.php
+++ b/app/Factories/PlanetServiceFactory.php
@@ -48,11 +48,15 @@ class PlanetServiceFactory
      * it is advised to use makeForPlayer() method if playerService is already available.
      *
      * @param int $planetId
+     * @param bool $useCache Whether to use the cache or not. Defaults to true. Note: for certain usecases
+     * such as updating planets/missions after gaining a lock, its essential to set this to false in order
+     * to get the latest data from the database.
+     *
      * @return PlanetService|null
      */
-    public function make(int $planetId): PlanetService|null
+    public function make(int $planetId, bool $useCache = true): PlanetService|null
     {
-        if (!isset($this->instancesById[$planetId])) {
+        if (!$useCache || !isset($this->instancesById[$planetId])) {
             try {
                 $planetService = app()->make(PlanetService::class, ['player' => null, 'planet_id' => $planetId]);
                 $this->instancesById[$planetId] = $planetService;
@@ -62,7 +66,6 @@ class PlanetServiceFactory
                 }
             } catch (BindingResolutionException $e) {
                 return null;
-                /*throw new \RuntimeException('Class not found: ' . PlayerService::class);*/
             }
         }
 
@@ -75,11 +78,15 @@ class PlanetServiceFactory
      *
      * @param PlayerService $player
      * @param int $planetId
+     * @param bool $useCache Whether to use the cache or not. Defaults to true. Note: for certain usecases
+     *  such as updating planets/missions after gaining a lock, its essential to set this to false in order
+     *  to get the latest data from the database.
+     *
      * @return PlanetService
      */
-    public function makeForPlayer(PlayerService $player, int $planetId): PlanetService
+    public function makeForPlayer(PlayerService $player, int $planetId, bool $useCache = true): PlanetService
     {
-        if (!isset($this->instancesById[$planetId])) {
+        if (!$useCache || !isset($this->instancesById[$planetId])) {
             try {
                 $planetService = app()->make(PlanetService::class, ['player' => $player, 'planet_id' => $planetId]);
                 $this->instancesById[$planetId] = $planetService;
@@ -99,22 +106,26 @@ class PlanetServiceFactory
      * Returns a planetService for a given coordinate.
      *
      * @param Coordinate $coordinate
+     * @param bool $useCache Whether to use the cache or not. Defaults to true. Note: for certain usecases
+     *   such as updating planets/missions after gaining a lock, its essential to set this to false in order
+     *   to get the latest data from the database.
+     *
      * @return ?PlanetService
      */
-    public function makeForCoordinate(Coordinate $coordinate): ?PlanetService
+    public function makeForCoordinate(Coordinate $coordinate, bool $useCache = true): ?PlanetService
     {
-        if (!isset($this->instancesByCoordinate[$coordinate->asString()])) {
-            // Get the planet ID from the database.
-            $planet = Planet::where('galaxy', $coordinate->galaxy)
+        if (!$useCache || !isset($this->instancesByCoordinate[$coordinate->asString()])) {
+            $planetId = Planet::where('galaxy', $coordinate->galaxy)
                 ->where('system', $coordinate->system)
                 ->where('planet', $coordinate->position)
-                ->first();
-            if (!$planet) {
+                ->value('id');
+
+            if (!$planetId) {
                 return null;
             }
 
             try {
-                $planetService = app()->make(PlanetService::class, ['player' => null, 'planet_id' => $planet->id]);
+                $planetService = app()->make(PlanetService::class, ['player' => null, 'planet_id' => $planetId]);
                 $this->instancesByCoordinate[$coordinate->asString()] = $planetService;
                 $this->instancesById[$planetService->getPlanetId()] = $planetService;
                 return $this->instancesByCoordinate[$coordinate->asString()];
@@ -135,13 +146,21 @@ class PlanetServiceFactory
      */
     public function getPlanetDescription(Coordinate $coordinates): string
     {
-        if($coordinates->position >= 1 && $coordinates->position <= 3) { // Nearest planet from the sun
+        if ($coordinates->position >= 1 && $coordinates->position <= 3) {
+            // Nearest planet from the sun.
             return __('t_galaxy.planet.description.nearest');
-        } elseif(($coordinates->position >= 4 && $coordinates->position <= 6) || ($coordinates->position >= 10 && $coordinates->position <= 12)) { // Normal planet
+        } elseif ($coordinates->position >= 4 && $coordinates->position <= 6) {
+            // Normal planet.
             return __('t_galaxy.planet.description.normal');
-        } elseif($coordinates->position >= 7 && $coordinates->position <= 9) { // Biggest planet
+        } elseif ($coordinates->position >= 7 && $coordinates->position <= 9) {
+            // Biggest planet.
             return __('t_galaxy.planet.description.biggest');
-        } else { /*($coordinates->position >= 13 && $coordinates->position <= 15)*/ // Farthest planet from the sun
+        } elseif ($coordinates->position >= 10 && $coordinates->position <= 12) {
+            // Normal planet.
+            return __('t_galaxy.planet.description.normal');
+        } else {
+            // ($coordinates->position >= 13 && $coordinates->position <= 15)
+            // Farthest planet from the sun.
             return __('t_galaxy.planet.description.farthest');
         }
     }

--- a/app/Factories/PlanetServiceFactory.php
+++ b/app/Factories/PlanetServiceFactory.php
@@ -48,15 +48,15 @@ class PlanetServiceFactory
      * it is advised to use makeForPlayer() method if playerService is already available.
      *
      * @param int $planetId
-     * @param bool $useCache Whether to use the cache or not. Defaults to true. Note: for certain usecases
-     * such as updating planets/missions after gaining a lock, its essential to set this to false in order
-     * to get the latest data from the database.
+     * @param bool $reloadCache Whether to force retrieve the object and reload the cache. Defaults to false.
+     * Note: for certain usecases such as updating planets/missions after gaining a lock, its essential to set this to
+     * true in order to get the latest data from the database and update the cache accordingly to avoid stale data.
      *
      * @return PlanetService|null
      */
-    public function make(int $planetId, bool $useCache = true): PlanetService|null
+    public function make(int $planetId, bool $reloadCache = false): PlanetService|null
     {
-        if (!$useCache || !isset($this->instancesById[$planetId])) {
+        if ($reloadCache || !isset($this->instancesById[$planetId])) {
             try {
                 $planetService = app()->make(PlanetService::class, ['player' => null, 'planet_id' => $planetId]);
                 $this->instancesById[$planetId] = $planetService;

--- a/app/Factories/PlayerServiceFactory.php
+++ b/app/Factories/PlayerServiceFactory.php
@@ -19,11 +19,15 @@ class PlayerServiceFactory
      * Returns a playerService either from local instances cache or creates a new one.
      *
      * @param int $playerId
+     * @param bool $useCache Whether to use the cache or not. Defaults to true. Note: for certain usecases
+     *   such as updating planets/missions after gaining a lock, its essential to set this to false in order
+     *   to get the latest data from the database.
+     *
      * @return PlayerService
      */
-    public function make(int $playerId): PlayerService
+    public function make(int $playerId, bool $useCache = true): PlayerService
     {
-        if (!isset($this->instances[$playerId])) {
+        if (!$useCache || !isset($this->instances[$playerId])) {
             try {
                 $playerService = app()->make(PlayerService::class, ['player_id' => $playerId]);
                 $this->instances[$playerId] = $playerService;

--- a/app/Factories/PlayerServiceFactory.php
+++ b/app/Factories/PlayerServiceFactory.php
@@ -19,15 +19,15 @@ class PlayerServiceFactory
      * Returns a playerService either from local instances cache or creates a new one.
      *
      * @param int $playerId
-     * @param bool $useCache Whether to use the cache or not. Defaults to true. Note: for certain usecases
-     *   such as updating planets/missions after gaining a lock, its essential to set this to false in order
-     *   to get the latest data from the database.
-     *
+     * @param bool $reloadCache Whether to force retrieve the object and reload the cache. Defaults to false.
+     * * Note: for certain usecases such as updating planets/missions after gaining a lock, its essential to set this to
+     * * true in order to get the latest data from the database and update the cache accordingly to avoid stale data.
+ *
      * @return PlayerService
      */
-    public function make(int $playerId, bool $useCache = true): PlayerService
+    public function make(int $playerId, bool $reloadCache = false): PlayerService
     {
-        if (!$useCache || !isset($this->instances[$playerId])) {
+        if ($reloadCache || !isset($this->instances[$playerId])) {
             try {
                 $playerService = app()->make(PlayerService::class, ['player_id' => $playerId]);
                 $this->instances[$playerId] = $playerService;

--- a/app/GameMessages/Abstracts/GameMessage.php
+++ b/app/GameMessages/Abstracts/GameMessage.php
@@ -273,7 +273,6 @@ abstract class GameMessage
         // TODO: add unittests to cover the placeholder replacements.
         // Pattern to match [player]{playerId}[/player] placeholders
         $body = preg_replace_callback('/\[player\](\d+)\[\/player\]/', function ($matches) {
-            // Assuming getPlayerNameById is a method to get a player's name by ID
             if (!is_numeric($matches[1])) {
                 return "Unknown Player";
             }
@@ -296,7 +295,6 @@ abstract class GameMessage
         }, $body);
 
         $body = preg_replace_callback('/\[planet\](\d+)\[\/planet\]/', function ($matches) {
-            // Assuming getPlayerNameById is a method to get a player's name by ID
             if (!is_numeric($matches[1])) {
                 return "Unknown Planet";
             }
@@ -321,7 +319,6 @@ abstract class GameMessage
         }, $body);
 
         $body = preg_replace_callback('/\[coordinates\](\d+):(\d+):(\d+)\[\/coordinates\]/', function ($matches) {
-            // Assuming getPlayerNameById is a method to get a player's name by ID
             if (!is_numeric($matches[1]) || !is_numeric($matches[2]) || !is_numeric($matches[3])) {
                 return "Unknown Planet";
             }

--- a/app/GameMessages/BattleReport.php
+++ b/app/GameMessages/BattleReport.php
@@ -149,7 +149,7 @@ class BattleReport extends GameMessage
 
         // Load attacker player
         // TODO: add unit test for attacker/defender research levels.
-        $attacker = $this->playerServiceFactory->make($attackerPlayerId);
+        $attacker = $this->playerServiceFactory->make($attackerPlayerId, true);
         $attacker_weapons = $this->battleReportModel->attacker['weapon_technology'] * 10;
         $attacker_shields = $this->battleReportModel->attacker['shielding_technology'] * 10;
         $attacker_armor = $this->battleReportModel->attacker['armor_technology'] * 10;

--- a/app/GameMissions/Abstracts/GameMission.php
+++ b/app/GameMissions/Abstracts/GameMission.php
@@ -267,7 +267,7 @@ abstract class GameMission
         $mission->planet_id_to = $parentMission->planet_id_from;
 
         // Planet to service
-        $planetToService = $this->planetServiceFactory->make($mission->planet_id_to);
+        $planetToService = $this->planetServiceFactory->make($mission->planet_id_to, true);
 
         // Coordinates
         $coords = $planetToService->getPlanetCoordinates();

--- a/app/GameMissions/AttackMission.php
+++ b/app/GameMissions/AttackMission.php
@@ -44,8 +44,8 @@ class AttackMission extends GameMission
      */
     protected function processArrival(FleetMission $mission): void
     {
-        $defenderPlanet = $this->planetServiceFactory->make($mission->planet_id_to, false);
-        $origin_planet = $this->planetServiceFactory->make($mission->planet_id_from, false);
+        $defenderPlanet = $this->planetServiceFactory->make($mission->planet_id_to, true);
+        $origin_planet = $this->planetServiceFactory->make($mission->planet_id_from, true);
 
         // Trigger defender planet update to make sure the battle uses up-to-date info.
         $defenderPlanet->update();
@@ -89,7 +89,7 @@ class AttackMission extends GameMission
     protected function processReturn(FleetMission $mission): void
     {
         // Load the target planet
-        $target_planet = $this->planetServiceFactory->make($mission->planet_id_to);
+        $target_planet = $this->planetServiceFactory->make($mission->planet_id_to, true);
 
         // Attack return trip: add back the units to the source planet. Then we're done.
         $target_planet->addUnits($this->fleetMissionService->getFleetUnits($mission));

--- a/app/GameMissions/AttackMission.php
+++ b/app/GameMissions/AttackMission.php
@@ -44,8 +44,8 @@ class AttackMission extends GameMission
      */
     protected function processArrival(FleetMission $mission): void
     {
-        $defenderPlanet = $this->planetServiceFactory->make($mission->planet_id_to);
-        $origin_planet = $this->planetServiceFactory->make($mission->planet_id_from);
+        $defenderPlanet = $this->planetServiceFactory->make($mission->planet_id_to, false);
+        $origin_planet = $this->planetServiceFactory->make($mission->planet_id_from, false);
 
         // Trigger defender planet update to make sure the battle uses up-to-date info.
         $defenderPlanet->update();

--- a/app/GameMissions/ColonisationMission.php
+++ b/app/GameMissions/ColonisationMission.php
@@ -45,10 +45,10 @@ class ColonisationMission extends GameMission
     {
         // Sanity check: make sure the target coordinates are valid and the planet is (still) empty.
         $target_coordinates = new Coordinate($mission->galaxy_to, $mission->system_to, $mission->position_to);
-        $target_planet = $this->planetServiceFactory->makeForCoordinate($target_coordinates);
+        $target_planet = $this->planetServiceFactory->makeForCoordinate($target_coordinates, false);
 
         // Load the mission owner user
-        $player = $this->playerServiceFactory->make($mission->user_id);
+        $player = $this->playerServiceFactory->make($mission->user_id, false);
 
         if ($target_planet != null) {
             // TODO: add unittest for this behavior.

--- a/app/GameMissions/ColonisationMission.php
+++ b/app/GameMissions/ColonisationMission.php
@@ -45,10 +45,10 @@ class ColonisationMission extends GameMission
     {
         // Sanity check: make sure the target coordinates are valid and the planet is (still) empty.
         $target_coordinates = new Coordinate($mission->galaxy_to, $mission->system_to, $mission->position_to);
-        $target_planet = $this->planetServiceFactory->makeForCoordinate($target_coordinates, false);
+        $target_planet = $this->planetServiceFactory->makeForCoordinate($target_coordinates);
 
         // Load the mission owner user
-        $player = $this->playerServiceFactory->make($mission->user_id, false);
+        $player = $this->playerServiceFactory->make($mission->user_id, true);
 
         if ($target_planet != null) {
             // TODO: add unittest for this behavior.
@@ -100,7 +100,6 @@ class ColonisationMission extends GameMission
 
         // Create and start the return mission (if the colonisation mission had ships other than the colony ship itself).
         $this->startReturn($mission, new Resources(0, 0, 0, 0), $units);
-
     }
 
     /**
@@ -108,7 +107,7 @@ class ColonisationMission extends GameMission
      */
     protected function processReturn(FleetMission $mission): void
     {
-        $target_planet = $this->planetServiceFactory->make($mission->planet_id_to);
+        $target_planet = $this->planetServiceFactory->make($mission->planet_id_to, true);
 
         // Transport return trip: add back the units to the source planet. Then we're done.
         $target_planet->addUnits($this->fleetMissionService->getFleetUnits($mission));

--- a/app/GameMissions/DeploymentMission.php
+++ b/app/GameMissions/DeploymentMission.php
@@ -40,7 +40,7 @@ class DeploymentMission extends GameMission
      */
     protected function processArrival(FleetMission $mission): void
     {
-        $target_planet = $this->planetServiceFactory->make($mission->planet_id_to, false);
+        $target_planet = $this->planetServiceFactory->make($mission->planet_id_to, true);
 
         // Add resources to the target planet
         $resources = $this->fleetMissionService->getResources($mission);
@@ -75,7 +75,7 @@ class DeploymentMission extends GameMission
      */
     protected function processReturn(FleetMission $mission): void
     {
-        $target_planet = $this->planetServiceFactory->make($mission->planet_id_to);
+        $target_planet = $this->planetServiceFactory->make($mission->planet_id_to, true);
 
         // Transport return trip: add back the units to the source planet. Then we're done.
         $target_planet->addUnits($this->fleetMissionService->getFleetUnits($mission));

--- a/app/GameMissions/DeploymentMission.php
+++ b/app/GameMissions/DeploymentMission.php
@@ -40,7 +40,7 @@ class DeploymentMission extends GameMission
      */
     protected function processArrival(FleetMission $mission): void
     {
-        $target_planet = $this->planetServiceFactory->make($mission->planet_id_to);
+        $target_planet = $this->planetServiceFactory->make($mission->planet_id_to, false);
 
         // Add resources to the target planet
         $resources = $this->fleetMissionService->getResources($mission);

--- a/app/GameMissions/EspionageMission.php
+++ b/app/GameMissions/EspionageMission.php
@@ -47,8 +47,8 @@ class EspionageMission extends GameMission
      */
     protected function processArrival(FleetMission $mission): void
     {
-        $target_planet = $this->planetServiceFactory->make($mission->planet_id_to, false);
-        $origin_planet = $this->planetServiceFactory->make($mission->planet_id_from, false);
+        $target_planet = $this->planetServiceFactory->make($mission->planet_id_to, true);
+        $origin_planet = $this->planetServiceFactory->make($mission->planet_id_from, true);
 
         // Trigger target planet update to make sure the espionage report is accurate.
         $target_planet->update();
@@ -79,7 +79,7 @@ class EspionageMission extends GameMission
     protected function processReturn(FleetMission $mission): void
     {
         // Load the target planet
-        $target_planet = $this->planetServiceFactory->make($mission->planet_id_to);
+        $target_planet = $this->planetServiceFactory->make($mission->planet_id_to, true);
 
         // Espionage return trip: add back the units to the source planet. Then we're done.
         $target_planet->addUnits($this->fleetMissionService->getFleetUnits($mission));
@@ -107,10 +107,6 @@ class EspionageMission extends GameMission
      */
     private function createEspionageReport(FleetMission $mission, PlanetService $originPlanet, PlanetService $targetPlanet): int
     {
-        // TODO: make sure the target planet is updated with the latest resources before creating the report
-        // to ensure the report is accurate at the current point in time.
-        // TODO: add planet update call here and add a test to cover this.
-
         // Create new espionage report record.
         $report = new EspionageReport();
         $report->planet_galaxy = $targetPlanet->getPlanetCoordinates()->galaxy;

--- a/app/GameMissions/EspionageMission.php
+++ b/app/GameMissions/EspionageMission.php
@@ -47,8 +47,8 @@ class EspionageMission extends GameMission
      */
     protected function processArrival(FleetMission $mission): void
     {
-        $target_planet = $this->planetServiceFactory->make($mission->planet_id_to);
-        $origin_planet = $this->planetServiceFactory->make($mission->planet_id_from);
+        $target_planet = $this->planetServiceFactory->make($mission->planet_id_to, false);
+        $origin_planet = $this->planetServiceFactory->make($mission->planet_id_from, false);
 
         // Trigger target planet update to make sure the espionage report is accurate.
         $target_planet->update();

--- a/app/GameMissions/TransportMission.php
+++ b/app/GameMissions/TransportMission.php
@@ -33,8 +33,8 @@ class TransportMission extends GameMission
 
     protected function processArrival(FleetMission $mission): void
     {
-        $origin_planet = $this->planetServiceFactory->make($mission->planet_id_from, false);
-        $target_planet = $this->planetServiceFactory->make($mission->planet_id_to, false);
+        $origin_planet = $this->planetServiceFactory->make($mission->planet_id_from, true);
+        $target_planet = $this->planetServiceFactory->make($mission->planet_id_to, true);
 
         // Add resources to the target planet
         $target_planet->addResources($this->fleetMissionService->getResources($mission));
@@ -74,7 +74,7 @@ class TransportMission extends GameMission
     protected function processReturn(FleetMission $mission): void
     {
         // Load the target planet
-        $target_planet = $this->planetServiceFactory->make($mission->planet_id_to);
+        $target_planet = $this->planetServiceFactory->make($mission->planet_id_to, true);
 
         // Transport return trip: add back the units to the source planet.
         $target_planet->addUnits($this->fleetMissionService->getFleetUnits($mission));

--- a/app/GameMissions/TransportMission.php
+++ b/app/GameMissions/TransportMission.php
@@ -33,8 +33,8 @@ class TransportMission extends GameMission
 
     protected function processArrival(FleetMission $mission): void
     {
-        $origin_planet = $this->planetServiceFactory->make($mission->planet_id_from);
-        $target_planet = $this->planetServiceFactory->make($mission->planet_id_to);
+        $origin_planet = $this->planetServiceFactory->make($mission->planet_id_from, false);
+        $target_planet = $this->planetServiceFactory->make($mission->planet_id_to, false);
 
         // Add resources to the target planet
         $target_planet->addResources($this->fleetMissionService->getResources($mission));

--- a/app/Http/Middleware/GlobalGame.php
+++ b/app/Http/Middleware/GlobalGame.php
@@ -44,6 +44,12 @@ class GlobalGame
             $player->update();
 
             // Update current planet of player.
+            // TODO: due to how planet update locking works, in the "load player" call above
+            // the player object and all of its planets are loaded for the first time. Then here
+            // in the update call we retrieve the current planet again to ensure we have the latest data.
+            // This update mechanism could be improved by calling it directly in the place when the player and
+            // planet objects are loaded for the first time. This would save one select call to the database.
+            // So it's not a big deal, but it's a small performance improvement that could be done.
             $player->planets->current()->update();
 
             // Update all fleet missions of player that are associated with any of the player's planets.

--- a/app/Services/PlanetService.php
+++ b/app/Services/PlanetService.php
@@ -1150,6 +1150,7 @@ class PlanetService
         if ($this->planet->{$object->machine_name} < $amount) {
             throw new RuntimeException('Planet does not have enough units.');
         }
+
         $this->planet->{$object->machine_name} -= $amount;
 
         if ($save_planet) {

--- a/app/Services/PlanetService.php
+++ b/app/Services/PlanetService.php
@@ -785,6 +785,9 @@ class PlanetService
                 ->first();
 
             if ($planet) {
+                // Refresh the planet object to ensure we have the latest data after retrieving the lock above.
+                $this->reloadPlanet();
+
                 // ------
                 // 1. Update resources amount in planet based on hourly production values.
                 // ------
@@ -1124,7 +1127,12 @@ class PlanetService
     public function addUnits(UnitCollection $units, bool $save_planet = true): void
     {
         foreach ($units->units as $unit) {
-            $this->addUnit($unit->unitObject->machine_name, $unit->amount, $save_planet);
+            // Do not save the planet in this loop, but save it in the end if requested.
+            $this->addUnit($unit->unitObject->machine_name, $unit->amount, false);
+        }
+
+        if ($save_planet) {
+            $this->save();
         }
     }
 

--- a/app/Services/PlayerService.php
+++ b/app/Services/PlayerService.php
@@ -458,6 +458,13 @@ class PlayerService
                             throw new \Exception('Could not acquire update fleet mission update lock.');
                         }
                     }
+
+                    if ($missions->count() > 0) {
+                        // Update the current player object and all child planets to make sure any changes
+                        // to the fleet missions are reflected in the player/planet objects.
+                        $this->load($this->getId());
+                    }
+
                 } catch (Exception $e) {
                     throw new RuntimeException('Fleet mission service process error: ' . $e->getMessage());
                 }

--- a/composer.lock
+++ b/composer.lock
@@ -191,23 +191,23 @@
         },
         {
             "name": "dasprid/enum",
-            "version": "1.0.5",
+            "version": "1.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/DASPRiD/Enum.git",
-                "reference": "6faf451159fb8ba4126b925ed2d78acfce0dc016"
+                "reference": "8dfd07c6d2cf31c8da90c53b83c026c7696dda90"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/DASPRiD/Enum/zipball/6faf451159fb8ba4126b925ed2d78acfce0dc016",
-                "reference": "6faf451159fb8ba4126b925ed2d78acfce0dc016",
+                "url": "https://api.github.com/repos/DASPRiD/Enum/zipball/8dfd07c6d2cf31c8da90c53b83c026c7696dda90",
+                "reference": "8dfd07c6d2cf31c8da90c53b83c026c7696dda90",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.1 <9.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7 | ^8 | ^9",
+                "phpunit/phpunit": "^7 || ^8 || ^9 || ^10 || ^11",
                 "squizlabs/php_codesniffer": "*"
             },
             "type": "library",
@@ -235,9 +235,9 @@
             ],
             "support": {
                 "issues": "https://github.com/DASPRiD/Enum/issues",
-                "source": "https://github.com/DASPRiD/Enum/tree/1.0.5"
+                "source": "https://github.com/DASPRiD/Enum/tree/1.0.6"
             },
-            "time": "2023-08-25T16:18:39+00:00"
+            "time": "2024-08-09T14:30:48+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
@@ -1156,16 +1156,16 @@
         },
         {
             "name": "laravel/fortify",
-            "version": "v1.23.0",
+            "version": "v1.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/fortify.git",
-                "reference": "a654db53867e362d026f0727f01a5a3dc6b29593"
+                "reference": "fbe67f018c1fe26d00913de56a6d60589b4be9b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/fortify/zipball/a654db53867e362d026f0727f01a5a3dc6b29593",
-                "reference": "a654db53867e362d026f0727f01a5a3dc6b29593",
+                "url": "https://api.github.com/repos/laravel/fortify/zipball/fbe67f018c1fe26d00913de56a6d60589b4be9b2",
+                "reference": "fbe67f018c1fe26d00913de56a6d60589b4be9b2",
                 "shasum": ""
             },
             "require": {
@@ -1217,20 +1217,20 @@
                 "issues": "https://github.com/laravel/fortify/issues",
                 "source": "https://github.com/laravel/fortify"
             },
-            "time": "2024-08-02T07:38:37+00:00"
+            "time": "2024-08-20T14:43:56+00:00"
         },
         {
             "name": "laravel/framework",
-            "version": "v11.20.0",
+            "version": "v11.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "3cd7593dd9b67002fc416b46616f4d4d1da3e571"
+                "reference": "9d9d36708d56665b12185493f684abce38ad2d30"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/3cd7593dd9b67002fc416b46616f4d4d1da3e571",
-                "reference": "3cd7593dd9b67002fc416b46616f4d4d1da3e571",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/9d9d36708d56665b12185493f684abce38ad2d30",
+                "reference": "9d9d36708d56665b12185493f684abce38ad2d30",
                 "shasum": ""
             },
             "require": {
@@ -1423,20 +1423,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2024-08-06T14:39:21+00:00"
+            "time": "2024-08-20T15:00:52+00:00"
         },
         {
             "name": "laravel/prompts",
-            "version": "v0.1.24",
+            "version": "v0.1.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/prompts.git",
-                "reference": "409b0b4305273472f3754826e68f4edbd0150149"
+                "reference": "7b4029a84c37cb2725fc7f011586e2997040bc95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/prompts/zipball/409b0b4305273472f3754826e68f4edbd0150149",
-                "reference": "409b0b4305273472f3754826e68f4edbd0150149",
+                "url": "https://api.github.com/repos/laravel/prompts/zipball/7b4029a84c37cb2725fc7f011586e2997040bc95",
+                "reference": "7b4029a84c37cb2725fc7f011586e2997040bc95",
                 "shasum": ""
             },
             "require": {
@@ -1479,9 +1479,9 @@
             "description": "Add beautiful and user-friendly forms to your command-line applications.",
             "support": {
                 "issues": "https://github.com/laravel/prompts/issues",
-                "source": "https://github.com/laravel/prompts/tree/v0.1.24"
+                "source": "https://github.com/laravel/prompts/tree/v0.1.25"
             },
-            "time": "2024-06-17T13:58:22+00:00"
+            "time": "2024-08-12T22:06:33+00:00"
         },
         {
             "name": "laravel/serializable-closure",
@@ -1675,16 +1675,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.5.1",
+            "version": "2.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "ac815920de0eff6de947eac0a6a94e5ed0fb147c"
+                "reference": "b650144166dfa7703e62a22e493b853b58d874b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/ac815920de0eff6de947eac0a6a94e5ed0fb147c",
-                "reference": "ac815920de0eff6de947eac0a6a94e5ed0fb147c",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/b650144166dfa7703e62a22e493b853b58d874b0",
+                "reference": "b650144166dfa7703e62a22e493b853b58d874b0",
                 "shasum": ""
             },
             "require": {
@@ -1697,8 +1697,8 @@
             },
             "require-dev": {
                 "cebe/markdown": "^1.0",
-                "commonmark/cmark": "0.31.0",
-                "commonmark/commonmark.js": "0.31.0",
+                "commonmark/cmark": "0.31.1",
+                "commonmark/commonmark.js": "0.31.1",
                 "composer/package-versions-deprecated": "^1.8",
                 "embed/embed": "^4.4",
                 "erusev/parsedown": "^1.0",
@@ -1777,7 +1777,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-07-24T12:52:09+00:00"
+            "time": "2024-08-16T11:46:16+00:00"
         },
         {
             "name": "league/config",
@@ -2152,16 +2152,16 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "3.7.0",
+            "version": "3.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/briannesbitt/Carbon.git",
-                "reference": "cb4374784c87d0a0294e8513a52eb63c0aff3139"
+                "reference": "bbd3eef89af8ba66a3aa7952b5439168fbcc529f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/cb4374784c87d0a0294e8513a52eb63c0aff3139",
-                "reference": "cb4374784c87d0a0294e8513a52eb63c0aff3139",
+                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/bbd3eef89af8ba66a3aa7952b5439168fbcc529f",
+                "reference": "bbd3eef89af8ba66a3aa7952b5439168fbcc529f",
                 "shasum": ""
             },
             "require": {
@@ -2254,7 +2254,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-07-16T22:29:20+00:00"
+            "time": "2024-08-19T06:22:39+00:00"
         },
         {
             "name": "nette/schema",
@@ -2320,20 +2320,20 @@
         },
         {
             "name": "nette/utils",
-            "version": "v4.0.4",
+            "version": "v4.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/utils.git",
-                "reference": "d3ad0aa3b9f934602cb3e3902ebccf10be34d218"
+                "reference": "736c567e257dbe0fcf6ce81b4d6dbe05c6899f96"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/utils/zipball/d3ad0aa3b9f934602cb3e3902ebccf10be34d218",
-                "reference": "d3ad0aa3b9f934602cb3e3902ebccf10be34d218",
+                "url": "https://api.github.com/repos/nette/utils/zipball/736c567e257dbe0fcf6ce81b4d6dbe05c6899f96",
+                "reference": "736c567e257dbe0fcf6ce81b4d6dbe05c6899f96",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0 <8.4"
+                "php": "8.0 - 8.4"
             },
             "conflict": {
                 "nette/finder": "<3",
@@ -2400,9 +2400,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/utils/issues",
-                "source": "https://github.com/nette/utils/tree/v4.0.4"
+                "source": "https://github.com/nette/utils/tree/v4.0.5"
             },
-            "time": "2024-01-17T16:50:36+00:00"
+            "time": "2024-08-07T15:39:19+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -3057,16 +3057,16 @@
         },
         {
             "name": "psr/log",
-            "version": "3.0.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001"
+                "reference": "79dff0b268932c640297f5208d6298f71855c03e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/fe5ea303b0887d5caefd3d431c3e61ad47037001",
-                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/79dff0b268932c640297f5208d6298f71855c03e",
+                "reference": "79dff0b268932c640297f5208d6298f71855c03e",
                 "shasum": ""
             },
             "require": {
@@ -3101,9 +3101,9 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/3.0.0"
+                "source": "https://github.com/php-fig/log/tree/3.0.1"
             },
-            "time": "2021-07-14T16:46:02+00:00"
+            "time": "2024-08-21T13:31:24+00:00"
         },
         {
             "name": "psr/simple-cache",
@@ -3158,16 +3158,16 @@
         },
         {
             "name": "psy/psysh",
-            "version": "v0.12.3",
+            "version": "v0.12.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bobthecow/psysh.git",
-                "reference": "b6b6cce7d3ee8fbf31843edce5e8f5a72eff4a73"
+                "reference": "2fd717afa05341b4f8152547f142cd2f130f6818"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/b6b6cce7d3ee8fbf31843edce5e8f5a72eff4a73",
-                "reference": "b6b6cce7d3ee8fbf31843edce5e8f5a72eff4a73",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/2fd717afa05341b4f8152547f142cd2f130f6818",
+                "reference": "2fd717afa05341b4f8152547f142cd2f130f6818",
                 "shasum": ""
             },
             "require": {
@@ -3231,9 +3231,9 @@
             ],
             "support": {
                 "issues": "https://github.com/bobthecow/psysh/issues",
-                "source": "https://github.com/bobthecow/psysh/tree/v0.12.3"
+                "source": "https://github.com/bobthecow/psysh/tree/v0.12.4"
             },
-            "time": "2024-04-02T15:57:53+00:00"
+            "time": "2024-06-10T01:18:23+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -6511,30 +6511,38 @@
         },
         {
             "name": "composer/pcre",
-            "version": "3.1.4",
+            "version": "3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/pcre.git",
-                "reference": "04229f163664973f68f38f6f73d917799168ef24"
+                "reference": "1637e067347a0c40bbb1e3cd786b20dcab556a81"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/04229f163664973f68f38f6f73d917799168ef24",
-                "reference": "04229f163664973f68f38f6f73d917799168ef24",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/1637e067347a0c40bbb1e3cd786b20dcab556a81",
+                "reference": "1637e067347a0c40bbb1e3cd786b20dcab556a81",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4 || ^8.0"
             },
+            "conflict": {
+                "phpstan/phpstan": "<1.11.10"
+            },
             "require-dev": {
-                "phpstan/phpstan": "^1.3",
+                "phpstan/phpstan": "^1.11.10",
                 "phpstan/phpstan-strict-rules": "^1.1",
-                "symfony/phpunit-bridge": "^5"
+                "phpunit/phpunit": "^8 || ^9"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
                     "dev-main": "3.x-dev"
+                },
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
                 }
             },
             "autoload": {
@@ -6562,7 +6570,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/3.1.4"
+                "source": "https://github.com/composer/pcre/tree/3.3.0"
             },
             "funding": [
                 {
@@ -6578,7 +6586,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-27T13:40:54+00:00"
+            "time": "2024-08-19T19:43:53+00:00"
         },
         {
             "name": "doctrine/deprecations",
@@ -7702,16 +7710,16 @@
         },
         {
             "name": "phpmyadmin/sql-parser",
-            "version": "5.9.0",
+            "version": "5.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpmyadmin/sql-parser.git",
-                "reference": "011fa18a4e55591fac6545a821921dd1d61c6984"
+                "reference": "169a9f11f1957ea36607c9b29eac1b48679f1ecc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpmyadmin/sql-parser/zipball/011fa18a4e55591fac6545a821921dd1d61c6984",
-                "reference": "011fa18a4e55591fac6545a821921dd1d61c6984",
+                "url": "https://api.github.com/repos/phpmyadmin/sql-parser/zipball/169a9f11f1957ea36607c9b29eac1b48679f1ecc",
+                "reference": "169a9f11f1957ea36607c9b29eac1b48679f1ecc",
                 "shasum": ""
             },
             "require": {
@@ -7729,8 +7737,7 @@
                 "phpstan/extension-installer": "^1.1",
                 "phpstan/phpstan": "^1.9.12",
                 "phpstan/phpstan-phpunit": "^1.3.3",
-                "phpunit/php-code-coverage": "*",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "phpunit/phpunit": "^8.5 || ^9.6",
                 "psalm/plugin-phpunit": "^0.16.1",
                 "vimeo/psalm": "^4.11",
                 "zumba/json-serializer": "~3.0.2"
@@ -7786,7 +7793,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2024-01-20T20:34:02+00:00"
+            "time": "2024-08-13T19:01:01+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",
@@ -7837,16 +7844,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.11.7",
+            "version": "1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "52d2bbfdcae7f895915629e4694e9497d0f8e28d"
+                "reference": "384af967d35b2162f69526c7276acadce534d0e1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/52d2bbfdcae7f895915629e4694e9497d0f8e28d",
-                "reference": "52d2bbfdcae7f895915629e4694e9497d0f8e28d",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/384af967d35b2162f69526c7276acadce534d0e1",
+                "reference": "384af967d35b2162f69526c7276acadce534d0e1",
                 "shasum": ""
             },
             "require": {
@@ -7891,36 +7898,36 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-06T11:17:41+00:00"
+            "time": "2024-08-27T09:18:05+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "11.0.5",
+            "version": "11.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "19b6365ab8b59a64438c0c3f4241feeb480c9861"
+                "reference": "ebdffc9e09585dafa71b9bffcdb0a229d4704c45"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/19b6365ab8b59a64438c0c3f4241feeb480c9861",
-                "reference": "19b6365ab8b59a64438c0c3f4241feeb480c9861",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ebdffc9e09585dafa71b9bffcdb0a229d4704c45",
+                "reference": "ebdffc9e09585dafa71b9bffcdb0a229d4704c45",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^5.0",
+                "nikic/php-parser": "^5.1.0",
                 "php": ">=8.2",
-                "phpunit/php-file-iterator": "^5.0",
-                "phpunit/php-text-template": "^4.0",
-                "sebastian/code-unit-reverse-lookup": "^4.0",
-                "sebastian/complexity": "^4.0",
-                "sebastian/environment": "^7.0",
-                "sebastian/lines-of-code": "^3.0",
-                "sebastian/version": "^5.0",
-                "theseer/tokenizer": "^1.2.0"
+                "phpunit/php-file-iterator": "^5.0.1",
+                "phpunit/php-text-template": "^4.0.1",
+                "sebastian/code-unit-reverse-lookup": "^4.0.1",
+                "sebastian/complexity": "^4.0.1",
+                "sebastian/environment": "^7.2.0",
+                "sebastian/lines-of-code": "^3.0.1",
+                "sebastian/version": "^5.0.1",
+                "theseer/tokenizer": "^1.2.3"
             },
             "require-dev": {
                 "phpunit/phpunit": "^11.0"
@@ -7932,7 +7939,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "11.0-dev"
+                    "dev-main": "11.0.x-dev"
                 }
             },
             "autoload": {
@@ -7961,7 +7968,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/11.0.5"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/11.0.6"
             },
             "funding": [
                 {
@@ -7969,20 +7976,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-03T05:05:37+00:00"
+            "time": "2024-08-22T04:37:56+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "5.0.1",
+            "version": "5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "6ed896bf50bbbfe4d504a33ed5886278c78e4a26"
+                "reference": "118cfaaa8bc5aef3287bf315b6060b1174754af6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6ed896bf50bbbfe4d504a33ed5886278c78e4a26",
-                "reference": "6ed896bf50bbbfe4d504a33ed5886278c78e4a26",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/118cfaaa8bc5aef3287bf315b6060b1174754af6",
+                "reference": "118cfaaa8bc5aef3287bf315b6060b1174754af6",
                 "shasum": ""
             },
             "require": {
@@ -8022,7 +8029,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
                 "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/5.0.1"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/5.1.0"
             },
             "funding": [
                 {
@@ -8030,7 +8037,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-03T05:06:37+00:00"
+            "time": "2024-08-27T05:02:59+00:00"
         },
         {
             "name": "phpunit/php-invoker",
@@ -9241,16 +9248,16 @@
         },
         {
             "name": "spatie/backtrace",
-            "version": "1.6.1",
+            "version": "1.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/backtrace.git",
-                "reference": "8373b9d51638292e3bfd736a9c19a654111b4a23"
+                "reference": "1a9a145b044677ae3424693f7b06479fc8c137a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/backtrace/zipball/8373b9d51638292e3bfd736a9c19a654111b4a23",
-                "reference": "8373b9d51638292e3bfd736a9c19a654111b4a23",
+                "url": "https://api.github.com/repos/spatie/backtrace/zipball/1a9a145b044677ae3424693f7b06479fc8c137a9",
+                "reference": "1a9a145b044677ae3424693f7b06479fc8c137a9",
                 "shasum": ""
             },
             "require": {
@@ -9288,7 +9295,7 @@
                 "spatie"
             ],
             "support": {
-                "source": "https://github.com/spatie/backtrace/tree/1.6.1"
+                "source": "https://github.com/spatie/backtrace/tree/1.6.2"
             },
             "funding": [
                 {
@@ -9300,20 +9307,20 @@
                     "type": "other"
                 }
             ],
-            "time": "2024-04-24T13:22:11+00:00"
+            "time": "2024-07-22T08:21:24+00:00"
         },
         {
             "name": "spatie/error-solutions",
-            "version": "1.0.0",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/error-solutions.git",
-                "reference": "202108314a6988ede156fba1b3ea80a784c1734a"
+                "reference": "ae7393122eda72eed7cc4f176d1e96ea444f2d67"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/error-solutions/zipball/202108314a6988ede156fba1b3ea80a784c1734a",
-                "reference": "202108314a6988ede156fba1b3ea80a784c1734a",
+                "url": "https://api.github.com/repos/spatie/error-solutions/zipball/ae7393122eda72eed7cc4f176d1e96ea444f2d67",
+                "reference": "ae7393122eda72eed7cc4f176d1e96ea444f2d67",
                 "shasum": ""
             },
             "require": {
@@ -9366,7 +9373,7 @@
             ],
             "support": {
                 "issues": "https://github.com/spatie/error-solutions/issues",
-                "source": "https://github.com/spatie/error-solutions/tree/1.0.0"
+                "source": "https://github.com/spatie/error-solutions/tree/1.1.1"
             },
             "funding": [
                 {
@@ -9374,20 +9381,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-06-12T14:49:54+00:00"
+            "time": "2024-07-25T11:06:04+00:00"
         },
         {
             "name": "spatie/flare-client-php",
-            "version": "1.7.0",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/flare-client-php.git",
-                "reference": "097040ff51e660e0f6fc863684ac4b02c93fa234"
+                "reference": "180f8ca4c0d0d6fc51477bd8c53ce37ab5a96122"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/flare-client-php/zipball/097040ff51e660e0f6fc863684ac4b02c93fa234",
-                "reference": "097040ff51e660e0f6fc863684ac4b02c93fa234",
+                "url": "https://api.github.com/repos/spatie/flare-client-php/zipball/180f8ca4c0d0d6fc51477bd8c53ce37ab5a96122",
+                "reference": "180f8ca4c0d0d6fc51477bd8c53ce37ab5a96122",
                 "shasum": ""
             },
             "require": {
@@ -9405,7 +9412,7 @@
                 "phpstan/extension-installer": "^1.1",
                 "phpstan/phpstan-deprecation-rules": "^1.0",
                 "phpstan/phpstan-phpunit": "^1.0",
-                "spatie/phpunit-snapshot-assertions": "^4.0|^5.0"
+                "spatie/pest-plugin-snapshots": "^1.0|^2.0"
             },
             "type": "library",
             "extra": {
@@ -9435,7 +9442,7 @@
             ],
             "support": {
                 "issues": "https://github.com/spatie/flare-client-php/issues",
-                "source": "https://github.com/spatie/flare-client-php/tree/1.7.0"
+                "source": "https://github.com/spatie/flare-client-php/tree/1.8.0"
             },
             "funding": [
                 {
@@ -9443,7 +9450,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-06-12T14:39:14+00:00"
+            "time": "2024-08-01T08:27:26+00:00"
         },
         {
             "name": "spatie/ignition",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -16,6 +16,11 @@ parameters:
     ignoreErrors:
         - identifier: missingType.generics
 
+    # Required because of bug where PHPStan triggers regex in app/GameMessages/Abstracts/GameMessage.php
+    # as error: Negated boolean expression is always false. Check later if this is fixed by removing
+    # this line and running PHPStan again. If it does not throw any errors anymore, you can safely remove this.
+    treatPhpDocTypesAsCertain: false
+
 #    ignoreErrors:
 #        - '#PHPDoc tag @var#'
 #

--- a/tests/Feature/FleetDispatch/FleetDispatchColoniseTest.php
+++ b/tests/Feature/FleetDispatch/FleetDispatchColoniseTest.php
@@ -309,15 +309,20 @@ class FleetDispatchColoniseTest extends FleetDispatchTestCase
         // Increase time by 10 hours to ensure the arrival and return missions are done.
         Carbon::setTestNow($startTime->copy()->addHours(10));
 
+        // Reload the application to ensure all caches are cleared and changed units are reflected.
+        $this->reloadApplication();
+        $this->planetService->reloadPlanet();
+
         // Do a request to trigger the update logic.
         // Note: we only make one request here, as the arrival and return missions should be processed in the same request
         // since enough time has passed.
         $response = $this->get('/shipyard');
         $response->assertStatus(200);
 
+
         // Assert that the cargo ships have returned without the colony ship.
-        $this->assertObjectLevelOnPage($response, 'small_cargo', 5);
         $this->assertObjectLevelOnPage($response, 'colony_ship', 0);
+        $this->assertObjectLevelOnPage($response, 'small_cargo', 5);
     }
 
     /**

--- a/tests/Feature/UnitQueueTest.php
+++ b/tests/Feature/UnitQueueTest.php
@@ -180,9 +180,9 @@ class UnitQueueTest extends AccountTestCase
             $response->assertStatus(200);
         }
 
-        // Do it again but now with just microsecond differences.
+        // Do it again but now with just millisecond differences.
         for ($i = 0; $i < 20; $i++) {
-            Carbon::setTestNow($testTime->addMicroSeconds(rand(400000, 999999)));
+            Carbon::setTestNow($testTime->addMilliseconds(rand(400, 999)));
 
             $response = $this->get('/shipyard');
             $response->assertStatus(200);


### PR DESCRIPTION
The bug can not be reproduced (yet), but improvements can be made to further reduce the chance on race conditions.

Possible scenarios to check:

- [x] Add feature tests to simulate large orders and partial updates.
- [x] Race conditions during unit queue update. Check if race conditions can occur by checking callstack from PlanetService::updateUnitQueue(). --> Some conditions could cause race conditions because of outdated (cached) data being used for planet updates. E.g. first the planet data was retrieved with a db SELECT, after that the update lock is acquired, and finally the update takes place. This is changed now so that after the update lock is acquired the planet data is refreshed ensuring we have the latest data.

The race condition issue is improved but not fully fixed yet. Future work will be covered by #322.