### PR TITLE
queue building instant reload

### DIFF
--- a/public/js/ingame.js
+++ b/public/js/ingame.js
@@ -62101,13 +62101,11 @@ class SimpleCountdownTimer {
         this.countdownDoneFunction();
       }
 
-      if (timeLeftInSeconds <= -1 && timeLeftInSeconds > -12 && Math.abs(timeLeftInSeconds % 3) === 0 || timeLeftInSeconds <= -12 && timeLeftInSeconds > -180 && Math.abs(timeLeftInSeconds % 10) === 0) {
         if (this.reloadPage != null) {
           reload_page(this.reloadPage);
         }
 
         timerHandler.removeCallback(this.timer);
-      }
     }
   }
 
@@ -62157,13 +62155,11 @@ class CountdownTimer {
         this.countdownDoneFunction();
       }
 
-      if (timeLeftInSeconds <= -1 && timeLeftInSeconds > -12 && Math.abs(timeLeftInSeconds % 3) === 0 || timeLeftInSeconds <= -12 && timeLeftInSeconds > -180 && Math.abs(timeLeftInSeconds % 10) === 0) {
         if (this.reloadPage != null && !isOverlayOpen() && (!this.primaryReloadViaWS || this.primaryReloadViaWS === true && ogame.frontendActions.connected !== true)) {
           reload_page(this.reloadPage);
         }
 
         timerHandler.removeCallback(this.timer);
-      }
     }
   }
 
@@ -72009,13 +72005,14 @@ function showGalaxy(galaxy, system, planet) {
 
 function openParentLocation(url) {
   try {
-    window.opener.document.location.href = url;
-  } catch (error) {
-    try {
-      window.parent.document.location.href = url;
-    } catch (error) {
       document.location.href = url;
-    }
+  } catch (error) {
+        try {
+          window.parent.document.location.href = url;
+        } catch (error) {
+            window.opener.document.location.href = url;
+
+        }
   }
 }
 

--- a/public/js/ingame.js
+++ b/public/js/ingame.js
@@ -62157,11 +62157,13 @@ class CountdownTimer {
         this.countdownDoneFunction();
       }
 
+      if (timeLeftInSeconds <= -1 && timeLeftInSeconds > -12 && Math.abs(timeLeftInSeconds % 3) === 0 || timeLeftInSeconds <= -12 && timeLeftInSeconds > -180 && Math.abs(timeLeftInSeconds % 10) === 0) {
         if (this.reloadPage != null && !isOverlayOpen() && (!this.primaryReloadViaWS || this.primaryReloadViaWS === true && ogame.frontendActions.connected !== true)) {
           reload_page(this.reloadPage);
         }
 
         timerHandler.removeCallback(this.timer);
+      }
     }
   }
 
@@ -72007,17 +72009,12 @@ function showGalaxy(galaxy, system, planet) {
 
 function openParentLocation(url) {
   try {
-    document.location.href = url;
+    window.opener.document.location.href = url;
   } catch (error) {
-      console.error('error switching location, see below for more')
-      console.error(error)
     try {
       window.parent.document.location.href = url;
     } catch (error) {
-        console.error('error switching location, see below for more')
-        console.error(error)
-        window.opener.document.location.href = url;
-
+      document.location.href = url;
     }
   }
 }

--- a/public/js/ingame.js
+++ b/public/js/ingame.js
@@ -62157,13 +62157,11 @@ class CountdownTimer {
         this.countdownDoneFunction();
       }
 
-      if (timeLeftInSeconds <= -1 && timeLeftInSeconds > -12 && Math.abs(timeLeftInSeconds % 3) === 0 || timeLeftInSeconds <= -12 && timeLeftInSeconds > -180 && Math.abs(timeLeftInSeconds % 10) === 0) {
         if (this.reloadPage != null && !isOverlayOpen() && (!this.primaryReloadViaWS || this.primaryReloadViaWS === true && ogame.frontendActions.connected !== true)) {
           reload_page(this.reloadPage);
         }
 
         timerHandler.removeCallback(this.timer);
-      }
     }
   }
 
@@ -72009,12 +72007,17 @@ function showGalaxy(galaxy, system, planet) {
 
 function openParentLocation(url) {
   try {
-    window.opener.document.location.href = url;
+    document.location.href = url;
   } catch (error) {
+      console.error('error switching location, see below for more')
+      console.error(error)
     try {
       window.parent.document.location.href = url;
     } catch (error) {
-      document.location.href = url;
+        console.error('error switching location, see below for more')
+        console.error(error)
+        window.opener.document.location.href = url;
+
     }
   }
 }

--- a/public/js/ingame.min.js
+++ b/public/js/ingame.min.js
@@ -62101,13 +62101,11 @@ class SimpleCountdownTimer {
         this.countdownDoneFunction();
       }
 
-      if (timeLeftInSeconds <= -1 && timeLeftInSeconds > -12 && Math.abs(timeLeftInSeconds % 3) === 0 || timeLeftInSeconds <= -12 && timeLeftInSeconds > -180 && Math.abs(timeLeftInSeconds % 10) === 0) {
         if (this.reloadPage != null) {
           reload_page(this.reloadPage);
         }
 
         timerHandler.removeCallback(this.timer);
-      }
     }
   }
 
@@ -62157,13 +62155,11 @@ class CountdownTimer {
         this.countdownDoneFunction();
       }
 
-      if (timeLeftInSeconds <= -1 && timeLeftInSeconds > -12 && Math.abs(timeLeftInSeconds % 3) === 0 || timeLeftInSeconds <= -12 && timeLeftInSeconds > -180 && Math.abs(timeLeftInSeconds % 10) === 0) {
         if (this.reloadPage != null && !isOverlayOpen() && (!this.primaryReloadViaWS || this.primaryReloadViaWS === true && ogame.frontendActions.connected !== true)) {
           reload_page(this.reloadPage);
         }
 
         timerHandler.removeCallback(this.timer);
-      }
     }
   }
 
@@ -72009,13 +72005,14 @@ function showGalaxy(galaxy, system, planet) {
 
 function openParentLocation(url) {
   try {
-    window.opener.document.location.href = url;
-  } catch (error) {
-    try {
-      window.parent.document.location.href = url;
-    } catch (error) {
       document.location.href = url;
-    }
+  } catch (error) {
+        try {
+          window.parent.document.location.href = url;
+        } catch (error) {
+            window.opener.document.location.href = url;
+
+        }
   }
 }
 

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,8 +1,8 @@
 {
-    "/css/ingame.css": "/css/ingame.css?id=e7ef1b854da89d884b1472c61761ade4",
-    "/css/outgame.css": "/css/outgame.css?id=0edfd34484fc3ec74eca0604a470461f",
-    "/js/ingame.js": "/js/ingame.js?id=bc8a886b5515fe7f94676b321180a6cc",
-    "/js/ingame.min.js": "/js/ingame.min.js?id=bc8a886b5515fe7f94676b321180a6cc",
-    "/js/outgame.js": "/js/outgame.js?id=5fa6ee5cdc34001db0bdccd06a7f676c",
-    "/js/outgame.min.js": "/js/outgame.min.js?id=5fa6ee5cdc34001db0bdccd06a7f676c"
+    "/css/ingame.css": "/css/ingame.css?id=fefc0ffd608b92a7e389108e6e21c2dc",
+    "/css/outgame.css": "/css/outgame.css?id=fb5fb2abb8522158f52a5f13a0b95b51",
+    "/js/ingame.js": "/js/ingame.js?id=92bc426ce03600ea817dbda7cdede93a",
+    "/js/ingame.min.js": "/js/ingame.min.js?id=92bc426ce03600ea817dbda7cdede93a",
+    "/js/outgame.js": "/js/outgame.js?id=19703d7224aa657c7c185910f3f3aab9",
+    "/js/outgame.min.js": "/js/outgame.min.js?id=19703d7224aa657c7c185910f3f3aab9"
 }

--- a/resources/js/ingame/e7c74974620fa35b197315ebdbb8c2.js
+++ b/resources/js/ingame/e7c74974620fa35b197315ebdbb8c2.js
@@ -32260,13 +32260,11 @@ class SimpleCountdownTimer {
         this.countdownDoneFunction();
       }
 
-      if (timeLeftInSeconds <= -1 && timeLeftInSeconds > -12 && Math.abs(timeLeftInSeconds % 3) === 0 || timeLeftInSeconds <= -12 && timeLeftInSeconds > -180 && Math.abs(timeLeftInSeconds % 10) === 0) {
         if (this.reloadPage != null) {
           reload_page(this.reloadPage);
         }
 
         timerHandler.removeCallback(this.timer);
-      }
     }
   }
 
@@ -32316,13 +32314,11 @@ class CountdownTimer {
         this.countdownDoneFunction();
       }
 
-      if (timeLeftInSeconds <= -1 && timeLeftInSeconds > -12 && Math.abs(timeLeftInSeconds % 3) === 0 || timeLeftInSeconds <= -12 && timeLeftInSeconds > -180 && Math.abs(timeLeftInSeconds % 10) === 0) {
         if (this.reloadPage != null && !isOverlayOpen() && (!this.primaryReloadViaWS || this.primaryReloadViaWS === true && ogame.frontendActions.connected !== true)) {
           reload_page(this.reloadPage);
         }
 
         timerHandler.removeCallback(this.timer);
-      }
     }
   }
 
@@ -42168,13 +42164,14 @@ function showGalaxy(galaxy, system, planet) {
 
 function openParentLocation(url) {
   try {
-    window.opener.document.location.href = url;
-  } catch (error) {
-    try {
-      window.parent.document.location.href = url;
-    } catch (error) {
       document.location.href = url;
-    }
+  } catch (error) {
+        try {
+          window.parent.document.location.href = url;
+        } catch (error) {
+            window.opener.document.location.href = url;
+
+        }
   }
 }
 


### PR DESCRIPTION
Should fix https://github.com/lanedirt/OGameX/issues/340

**Changes:**
- switch default to document.location.href - and added the others as fall backs, also added a console error log here to track it easier. (It was causing errors right away in Chrome, so not sure if this had some delay effect)

- remove if statement based on `timeLeftInSeconds` , as once it's 0 or below it should trigger - this seemed to delay the reload. Again, perhaps this was done for a particular reason? 

You can see a loom here that it now loads instantly : https://www.loom.com/share/3e90629b29f849fa8dba88ba7f35a2fd (obviously some delay due to local env)