### PR TITLE
adds resource adjust ability on dev page

### DIFF
--- a/app/Http/Controllers/Admin/DeveloperShortcutsController.php
+++ b/app/Http/Controllers/Admin/DeveloperShortcutsController.php
@@ -5,6 +5,7 @@ namespace OGame\Http\Controllers\Admin;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\View\View;
 use OGame\Http\Controllers\OGameController;
+use OGame\Models\Enums\ResourceType;
 use OGame\Services\ObjectService;
 use OGame\Services\PlayerService;
 use OGame\Services\SettingsService;
@@ -93,6 +94,24 @@ class DeveloperShortcutsController extends OGameController
         }
 
 
+        return redirect()->route('admin.developershortcuts.index')->with('success', __('Changes saved!'));
+    }
+
+    public function updateResources(\Illuminate\Http\Request $request, PlayerService $playerService): RedirectResponse
+    {
+        // Handle resource addition / subtraction
+        foreach (ResourceType::cases() as $resourceType) {
+            if ($request->has('resource_' . $resourceType->value)) {
+                foreach ($request->post() as $req_key => $request_item) {
+                    if (str_contains($req_key, 'resource_')) {
+                        $resourceName = str_replace("resource_", "", $req_key);
+                        if (isset($request->amount_of_resources)) {
+                            $playerService->planets->current()->addResource($resourceName, $request->amount_of_resources);
+                        }
+                    }
+                }
+            }
+        }
         return redirect()->route('admin.developershortcuts.index')->with('success', __('Changes saved!'));
     }
 }

--- a/app/Http/Controllers/Admin/DeveloperShortcutsController.php
+++ b/app/Http/Controllers/Admin/DeveloperShortcutsController.php
@@ -101,7 +101,7 @@ class DeveloperShortcutsController extends OGameController
     {
         // Handle resource addition / subtraction
         foreach (ResourceType::cases() as $resourceType) {
-            if ($request->has('resource_' . $resourceType->value)) {
+            if ($request->has('resource_' . $resourceType->value) && is_array($request->post())) {
                 foreach ($request->post() as $req_key => $request_item) {
                     if (str_contains($req_key, 'resource_')) {
                         $resourceName = str_replace("resource_", "", $req_key);

--- a/app/Http/Controllers/Admin/DeveloperShortcutsController.php
+++ b/app/Http/Controllers/Admin/DeveloperShortcutsController.php
@@ -101,14 +101,11 @@ class DeveloperShortcutsController extends OGameController
     {
         // Handle resource addition / subtraction
         foreach (ResourceType::cases() as $resourceType) {
-            if ($request->has('resource_' . $resourceType->value) && is_array($request->post())) {
-                foreach ($request->post() as $req_key => $request_item) {
-                    if (str_contains($req_key, 'resource_')) {
-                        $resourceName = str_replace("resource_", "", $req_key);
-                        if (isset($request->amount_of_resources)) {
-                            $playerService->planets->current()->addResource($resourceName, $request->amount_of_resources);
-                        }
-                    }
+            if ($request->has('resource_' . $resourceType->value)) {
+                $type = $request->get('resource_' . $resourceType->value);
+                $resourceName = str_replace("resource_", "", $type);
+                if (isset($request->amount_of_resources)) {
+                    $playerService->planets->current()->addResource($resourceName, $request->amount_of_resources);
                 }
             }
         }

--- a/app/Http/Controllers/Admin/DeveloperShortcutsController.php
+++ b/app/Http/Controllers/Admin/DeveloperShortcutsController.php
@@ -102,10 +102,8 @@ class DeveloperShortcutsController extends OGameController
         // Handle resource addition / subtraction
         foreach (ResourceType::cases() as $resourceType) {
             if ($request->has('resource_' . $resourceType->value)) {
-                $type = $request->get('resource_' . $resourceType->value);
-                $resourceName = str_replace("resource_", "", $type);
                 if (isset($request->amount_of_resources)) {
-                    $playerService->planets->current()->addResource($resourceName, $request->amount_of_resources);
+                    $playerService->planets->current()->addResource($resourceType, $request->amount_of_resources);
                 }
             }
         }

--- a/app/Models/Enums/ResourceType.php
+++ b/app/Models/Enums/ResourceType.php
@@ -7,7 +7,7 @@ namespace OGame\Models\Enums;
  */
 enum ResourceType: string
 {
-    case Energy = 'metal';
+    case Metal = 'metal';
 
     case Crystal = 'crystal';
 

--- a/app/Models/Enums/ResourceType.php
+++ b/app/Models/Enums/ResourceType.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace OGame\Models\Enums;
+
+/**
+ * Enum that represents the type of resources.
+ */
+enum ResourceType: string
+{
+    case Energy = 'metal';
+
+    case Crystal = 'crystal';
+
+    case Deuterium = 'deuterium';
+
+}

--- a/app/Services/PlanetService.php
+++ b/app/Services/PlanetService.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\DB;
 use OGame\Factories\PlayerServiceFactory;
 use OGame\GameObjects\Models\Enums\GameObjectType;
 use OGame\GameObjects\Models\Units\UnitCollection;
+use OGame\Models\Enums\ResourceType;
 use OGame\Models\FleetMission;
 use OGame\Models\Planet;
 use OGame\Models\Planet\Coordinate;
@@ -988,6 +989,27 @@ class PlanetService
         if ($save_planet) {
             $this->save();
         }
+    }
+
+    /**
+     * @param string $resourceName
+     * @param int|float $amount
+     * @param bool $save_planet
+     * @return void
+     * @throws Exception
+     */
+    public function addResource(string $resourceName, int|float $amount, bool $save_planet = true): void
+    {
+
+        if (in_array($resourceName, array_column(ResourceType::cases(), "value")) && isset($this->planet->{$resourceName})) {
+            $this->planet->{$resourceName} += $amount;
+            if ($save_planet) {
+                $this->save();
+            }
+        } else {
+            throw new Exception('Invalid Resource');
+        }
+
     }
 
     /**

--- a/app/Services/PlanetService.php
+++ b/app/Services/PlanetService.php
@@ -992,7 +992,7 @@ class PlanetService
     }
 
     /**
-     * @param string $resourceName
+     * @param ResourceType $resource
      * @param int|float $amount
      * @param bool $save_planet
      * @return void

--- a/app/Services/PlanetService.php
+++ b/app/Services/PlanetService.php
@@ -998,11 +998,11 @@ class PlanetService
      * @return void
      * @throws Exception
      */
-    public function addResource(string $resourceName, int|float $amount, bool $save_planet = true): void
+    public function addResource(ResourceType $resource, int|float $amount, bool $save_planet = true): void
     {
 
-        if (in_array($resourceName, array_column(ResourceType::cases(), "value")) && isset($this->planet->{$resourceName})) {
-            $this->planet->{$resourceName} += $amount;
+        if (isset($this->planet->{$resource->value})) {
+            $this->planet->{$resource->value} += $amount;
             if ($save_planet) {
                 $this->save();
             }

--- a/resources/views/ingame/admin/developershortcuts.blade.php
+++ b/resources/views/ingame/admin/developershortcuts.blade.php
@@ -17,52 +17,73 @@
             <div class="header">
                 <h2>Developer shortcuts</h2>
             </div>
-            <form action="{{ route('admin.developershortcuts.update') }}" name="form" method="post">
-                {{ csrf_field() }}
-                <div class="content">
-                    <div class="buddylistContent">
-                        <p class="box_highlight textCenter no_buddies">@lang('Update current planet:')</p>
-                        <div class="group bborder" style="display: block;">
-                            <div class="fieldwrapper">
-                                <input type="submit" class="btn_blue" name="set_mines" value="Set all mines to level 30">
-                                <input type="submit" class="btn_blue" name="set_storages" value="Set all storages to level 15">
-                                <input type="submit" class="btn_blue" name="set_shipyard" value="Set all shipyard facilities to level 12">
-                                <input type="submit" class="btn_blue" name="set_research" value="Set all research to level 10">
-                            </div>
-                        </div>
-
-                        <p class="box_highlight textCenter no_buddies">@lang('Add X of unit to current planet:')</p>
-                        <div class="group bborder" style="display: block;">
-                            <div class="fieldwrapper">
-                                <label class="styled textBeefy">Amount of units to add:</label>
-                                <div class="thefield">
-                                    <input type="text" pattern="[0-9]*" class="textInput w50 textCenter textBeefy" value="1" size="2" name="amount_of_units">
+            <div class="content">
+                <div class="buddylistContent">
+                    <form action="{{ route('admin.developershortcuts.update') }}" name="form" method="post">
+                        {{ csrf_field() }}
+                                <p class="box_highlight textCenter no_buddies">@lang('Update current planet:')</p>
+                                <div class="group bborder" style="display: block;">
+                                    <div class="fieldwrapper">
+                                        <input type="submit" class="btn_blue" name="set_mines" value="Set all mines to level 30">
+                                        <input type="submit" class="btn_blue" name="set_storages" value="Set all storages to level 15">
+                                        <input type="submit" class="btn_blue" name="set_shipyard" value="Set all shipyard facilities to level 12">
+                                        <input type="submit" class="btn_blue" name="set_research" value="Set all research to level 10">
+                                    </div>
                                 </div>
-                            </div>
-                            <div class="fieldwrapper">
-                                @php /** @var OGame\GameObjects\Models\UnitObject $unit */ @endphp
-                                @foreach ($units as $unit)
-                                    <input type="submit" name="unit_{{ $unit->id }}" class="btn_blue" value="{{ $unit->title }}">
-                                @endforeach
-                                <input type="submit" class="btn_blue" value="Light fighter">
-                            </div>
-                        </div>
 
-                        <p class="box_highlight textCenter no_buddies">@lang('Reset planet')</p>
-                        <div class="group bborder" style="display: block;">
-                            <div class="fieldwrapper" style="margin-bottom: 50px;">
-                                <input type="submit" class="btn_blue" name="reset_buildings" value="Set all buildings to level 0">
-                                <input type="submit" class="btn_blue" name="reset_research" value="Set all research to level 0">
-                                <input type="submit" class="btn_blue" name="reset_units" value="Remove all units">
-                            </div>
-                        </div>
-                    </div>
 
-                    <div class="footer">
-                    </div>
+
+                                <p class="box_highlight textCenter no_buddies">@lang('Add X of unit to current planet:')</p>
+                                <div class="group bborder" style="display: block;">
+                                    <div class="fieldwrapper">
+                                        <label class="styled textBeefy">Amount of units to add:</label>
+                                        <div class="thefield">
+                                            <input type="text" pattern="[0-9]*" class="textInput w50 textCenter textBeefy" value="1" size="2" name="amount_of_units">
+                                        </div>
+                                    </div>
+                                    <div class="fieldwrapper">
+                                        @php /** @var OGame\GameObjects\Models\UnitObject $unit */ @endphp
+                                        @foreach ($units as $unit)
+                                            <input type="submit" name="unit_{{ $unit->id }}" class="btn_blue" value="{{ $unit->title }}">
+                                        @endforeach
+                                        <input type="submit" class="btn_blue" value="Light fighter">
+                                    </div>
+                                </div>
+
+                                <p class="box_highlight textCenter no_buddies">@lang('Reset planet')</p>
+                                <div class="group bborder" style="display: block;">
+                                    <div class="fieldwrapper" style="margin-bottom: 50px;">
+                                        <input type="submit" class="btn_blue" name="reset_buildings" value="Set all buildings to level 0">
+                                        <input type="submit" class="btn_blue" name="reset_research" value="Set all research to level 0">
+                                        <input type="submit" class="btn_blue" name="reset_units" value="Remove all units">
+                                    </div>
+                                </div>
+                            </form>
+
+                            <form action="{{ route('admin.developershortcuts.update-resources') }}" name="form" method="post">
+                                {{ csrf_field() }}
+                                <p class="box_highlight textCenter no_buddies">@lang('Add / Subtract X of resource to current planet:')</p>
+                                <div class="group bborder" style="display: block;">
+                                    <div class="fieldwrapper">
+                                        <div class="smallFont">You can enter positive or negative values to add or subtract to the selected resource.</div>
+                                        <label class="styled textBeefy">Amount of resources to add / subtract :</label>
+                                        <div class="thefield">
+                                            <input type="text" pattern="^([-+,0-9.]+)" class="textInput w50 textCenter textBeefy" value="1" size="2" name="amount_of_resources">
+                                        </div>
+                                    </div>
+                                    <div class="fieldwrapper" style="margin-bottom: 50px;">
+                                        @foreach (\OGame\Models\Enums\ResourceType::cases() as $resource)
+                                            <input type="submit" name="resource_{{ $resource->value }}" class="btn_blue" value="{{$resource->value}}">
+                                        @endforeach
+                                    </div>
+                                </div>
+                            </form>
+                        <div class="footer">
+                        </div>
                 </div>
-            </form>
-        </div>
+            </div>
+            </div>
+
         <script language="javascript">
             initBBCodes();
             initOverlays();

--- a/resources/views/ingame/admin/developershortcuts.blade.php
+++ b/resources/views/ingame/admin/developershortcuts.blade.php
@@ -73,7 +73,7 @@
                                     </div>
                                     <div class="fieldwrapper" style="margin-bottom: 50px;">
                                         @foreach (\OGame\Models\Enums\ResourceType::cases() as $resource)
-                                            <input type="submit" name="resource_{{ $resource->value }}" class="btn_blue" value="{{$resource->value}}">
+                                            <input type="submit" name="resource_{{ $resource->value }}" class="btn_blue" value="{{$resource->name}}">
                                         @endforeach
                                     </div>
                                 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -131,5 +131,6 @@ Route::middleware(['auth', 'globalgame', 'locale', 'admin'])->group(function () 
         // Developer shortcuts
         Route::get('/admin/developer-shortcuts', 'DeveloperShortcutsController@index')->name('admin.developershortcuts.index');
         Route::post('/admin/developer-shortcuts', 'DeveloperShortcutsController@update')->name('admin.developershortcuts.update');
+        Route::post('/admin/developer-shortcuts/resources', 'DeveloperShortcutsController@updateResources')->name('admin.developershortcuts.update-resources');
     });
 });

--- a/tests/Unit/PlanetServiceTest.php
+++ b/tests/Unit/PlanetServiceTest.php
@@ -84,10 +84,10 @@ class PlanetServiceTest extends UnitTestCase
         $this->planetService->deductResources(new Resources(9999, 9999, 9999, 0));
     }
 
-    public function testFailAddInvalidResource(): void
+    public function testTestErrorFailAddInvalidResource(): void
     {
 
-        $this->expectException(\Exception::class);
+        $this->expectException(\TypeError::class);
 
         $this->planetService->addResource('invalidResourceName', 100);
 
@@ -101,7 +101,7 @@ class PlanetServiceTest extends UnitTestCase
             'deuterium' => 3000,
         ]);
         foreach (ResourceType::cases() as $validResource) {
-            $this->planetService->addResource($validResource->value, 100, false);
+            $this->planetService->addResource($validResource, 100, false);
         }
         $this->assertEquals([
             'metal' => 1100,

--- a/tests/Unit/PlanetServiceTest.php
+++ b/tests/Unit/PlanetServiceTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit;
 
 use Illuminate\Contracts\Container\BindingResolutionException;
+use OGame\Models\Enums\ResourceType;
 use OGame\Models\Resources;
 use Tests\UnitTestCase;
 
@@ -10,6 +11,7 @@ class PlanetServiceTest extends UnitTestCase
 {
     /**
      * Set up common test components.
+     *
      * @throws BindingResolutionException
      */
     protected function setUp(): void
@@ -80,5 +82,35 @@ class PlanetServiceTest extends UnitTestCase
 
         // Call the method that should throw the exception
         $this->planetService->deductResources(new Resources(9999, 9999, 9999, 0));
+    }
+
+    public function testFailAddInvalidResource()
+    {
+
+        $this->expectException(\Exception::class);
+
+        $this->planetService->addResource('invalidResourceName', 100);
+
+    }
+
+    public function testAddValidResourceIndividually()
+    {
+        $this->createAndSetPlanetModel([
+            'metal' => 1000,
+            'crystal' => 2000,
+            'deuterium' => 3000,
+        ]);
+        foreach (ResourceType::cases() as $validResource) {
+            $this->planetService->addResource($validResource->value, 100, false);
+        }
+        $this->assertEquals([
+            'metal' => 1100,
+            'crystal' => 2100,
+            'deuterium' => 3100,
+        ], [
+            'metal' => $this->planetService->metal()->get(),
+            'crystal' => $this->planetService->crystal()->get(),
+            'deuterium' => $this->planetService->deuterium()->get(),
+        ]);
     }
 }

--- a/tests/Unit/PlanetServiceTest.php
+++ b/tests/Unit/PlanetServiceTest.php
@@ -84,7 +84,7 @@ class PlanetServiceTest extends UnitTestCase
         $this->planetService->deductResources(new Resources(9999, 9999, 9999, 0));
     }
 
-    public function testFailAddInvalidResource()
+    public function testFailAddInvalidResource(): void
     {
 
         $this->expectException(\Exception::class);
@@ -93,7 +93,7 @@ class PlanetServiceTest extends UnitTestCase
 
     }
 
-    public function testAddValidResourceIndividually()
+    public function testAddValidResourceIndividually(): void
     {
         $this->createAndSetPlanetModel([
             'metal' => 1000,

--- a/tests/Unit/PlanetServiceTest.php
+++ b/tests/Unit/PlanetServiceTest.php
@@ -84,15 +84,6 @@ class PlanetServiceTest extends UnitTestCase
         $this->planetService->deductResources(new Resources(9999, 9999, 9999, 0));
     }
 
-    public function testTestErrorFailAddInvalidResource(): void
-    {
-
-        $this->expectException(\TypeError::class);
-
-        $this->planetService->addResource('invalidResourceName', 100);
-
-    }
-
     public function testAddValidResourceIndividually(): void
     {
         $this->createAndSetPlanetModel([


### PR DESCRIPTION
Handles https://github.com/lanedirt/OGameX/issues/377

Image below : 
![image](https://github.com/user-attachments/assets/78c1a075-fec0-44a1-89a4-417b4cdd0c2d)

I've added a new `ResourceType` enum to handle the different types of resources, rather than just using an array of strings etc as made sense to have some kind of strict type. This may already be somewhere so let me know If I missed it!

I've added the logic into a separate form, route and controller logic rather than dumping it into the else statement, as it's then separate and more performant than it would be when doing unit additions.  (ie [here](https://github.com/lanedirt/OGameX/blob/35c42e3b832f02f649d17d151adbfec9a6a506ae/app/Http/Controllers/Admin/DeveloperShortcutsController.php#L85) )

Also added a new `AddResource` method to the planet service, rather than passing the resources object and changing which param to pass it, again this uses the enum too.

Included tests also :)  


Let me know if you'd like any adjustments, 