### PR TITLE
Restrict small and large shields max amount

### DIFF
--- a/app/Http/Controllers/Abstracts/AbstractUnitsController.php
+++ b/app/Http/Controllers/Abstracts/AbstractUnitsController.php
@@ -99,12 +99,16 @@ abstract class AbstractUnitsController extends OGameController
                 // Check if the current planet has enough resources to build this building.
                 $enough_resources = $planet->hasResources($objects->getObjectPrice($object->machine_name, $planet));
 
+                // Get maximum build amount of this building
+                $max_build_amount = $objects->getObjectMaxBuildAmount($object->machine_name, $planet, $requirements_met);
+
                 $view_model = new UnitViewModel();
                 $view_model->object = $object;
                 $view_model->count = $count;
                 $view_model->amount = $amount;
                 $view_model->requirements_met = $requirements_met;
                 $view_model->enough_resources = $enough_resources;
+                $view_model->max_build_amount = $max_build_amount;
                 $view_model->currently_building = (!empty($build_active) && $build_active->object->machine_name == $object->machine_name);
                 $view_model->currently_building_amount = (!empty($build_active) && $build_active->object->machine_name == $object->machine_name) ? $build_active->object_amount_remaining : 0;
 

--- a/app/Services/ObjectService.php
+++ b/app/Services/ObjectService.php
@@ -373,6 +373,11 @@ class ObjectService
             return 0;
         }
 
+        // Objects only be able to be built once
+        if ($machine_name === 'small_shield_dome' || $machine_name === 'large_shield_dome') {
+            return $planet->getObjectAmount($machine_name) ? 0 : 1;
+        }
+
         $price = $this->getObjectPrice($machine_name, $planet);
 
         // Calculate max build amount based on price

--- a/app/ViewModels/UnitViewModel.php
+++ b/app/ViewModels/UnitViewModel.php
@@ -11,6 +11,7 @@ class UnitViewModel
     public int $amount;
     public bool $requirements_met;
     public bool $enough_resources;
+    public int $max_build_amount;
     public bool $currently_building;
     public int $currently_building_amount;
 }

--- a/resources/views/ingame/ajax/object.blade.php
+++ b/resources/views/ingame/ajax/object.blade.php
@@ -163,7 +163,7 @@
 
             </div>
 
-            @if ($object_type == \OGame\GameObjects\Models\Enums\GameObjectType::Ship || $object_type == \OGame\GameObjects\Models\Enums\GameObjectType::Defense)
+            @if ($max_build_amount && ($object_type == \OGame\GameObjects\Models\Enums\GameObjectType::Ship || $object_type == \OGame\GameObjects\Models\Enums\GameObjectType::Defense))
                 <div class="build_amount">
                     <label for="build_amount">Number:</label>
                     <input type="text" name="build_amount" id="build_amount" min="0" max="{{ $max_build_amount }}" onfocus="clearInput(this);" onkeyup="checkIntInput(this, 1, {{ $max_build_amount }});event.stopPropagation();">
@@ -181,7 +181,7 @@
             <div class="build-it_wrap">
                 <div class="ipiHintable" data-ipi-hint="ipiTechnologyUpgradedeuteriumSynthesizer">
                     <button class="upgrade"
-                            @if (!$enough_resources || !$requirements_met || $build_queue_max)
+                            @if (!$enough_resources || !$requirements_met || $build_queue_max || !$max_build_amount)
                                 disabled
                             @else
                             @endif

--- a/resources/views/ingame/shipyard/unit-item.blade.php
+++ b/resources/views/ingame/shipyard/unit-item.blade.php
@@ -20,6 +20,9 @@
     @elseif (!$building->enough_resources)
         data-status="disabled"
     title="{{ $building->object->title }}<br/>@lang('Not enough resources!')"
+    @elseif (!$building->max_build_amount)
+        data-status="disabled"
+    title="{{ $building->object->title }}<br/>@lang('Maximum number reached!')"
     @else
         data-status="on"
     title="{{ $building->object->title }}"

--- a/tests/Unit/ObjectServiceTest.php
+++ b/tests/Unit/ObjectServiceTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Unit;
+
+use OGame\Services\ObjectService;
+use Tests\UnitTestCase;
+
+class ObjectServiceTest extends UnitTestCase
+{
+    public function testGetObjectMaxBuildAmount(): void
+    {
+        $objectService = new ObjectService();
+        $this->createAndSetPlanetModel([]);
+
+        // Test with requirement not met
+        $maxBuildAmount = $objectService->getObjectMaxBuildAmount('plasma_turret', $this->planetService, false);
+        $this->assertEquals(0, $maxBuildAmount);
+
+        // Test with object limited to one instance
+        $maxBuildAmount = $objectService->getObjectMaxBuildAmount('small_shield_dome', $this->planetService, true);
+        $this->assertEquals(1, $maxBuildAmount);
+
+        $this->createAndSetPlanetModel([
+            'small_shield_dome' => 1,
+        ]);
+
+        // Test with object limited to one instance which already exists
+        $maxBuildAmount = $objectService->getObjectMaxBuildAmount('small_shield_dome', $this->planetService, true);
+        $this->assertEquals(0, $maxBuildAmount);
+
+        $this->createAndSetPlanetModel([
+            'metal' => 24000,
+            'crystal' => 6000
+        ]);
+
+        // Test it calculates max amount correctly
+        $maxBuildAmount = $objectService->getObjectMaxBuildAmount('anti_ballistic_missile', $this->planetService, true);
+        $this->assertEquals(3, $maxBuildAmount);
+    }
+}


### PR DESCRIPTION
Changes:
Limit small and large shields maximum amount to one.
Disable build button when maximum number of shields is reached.
Hide number of items to be build input field when maximum number of shields is reached.
Show maximum number reached icon in structure selector when maximum number of shields is reached.
Add unit test for object service max build amount calculation

Related issue:
https://github.com/lanedirt/OGameX/issues/212