### PR TITLE
Add database management 

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,9 @@ For local development you can run the default docker-compose file that is includ
   ```
   $ docker compose up -d
   ```
-  > Note: The default setup binds to ports 80/443. Modify `docker-compose.yml` if needed.
+  > Note: The default setup binds to ports 80/443. Modify `docker-compose.yml` if needed. PhpMyAdmin is also included for database management and is bound to port 8080. Modify docker-compose.yml if needed.
+
+
   
 4. Access the "ogame-app" Docker container:
   ```
@@ -210,6 +212,9 @@ You should review all settings before deploying this project to a publicly acces
   $ php artisan migrate --force
   $ php artisan cache:clear && php artisan config:cache && php artisan route:cache && php artisan view:cache
   ```
+  > Note: The default setup binds to ports 80/443. PhpMyAdmin is also included for database management and is bound to port 8080, however to access it you need to explicitly specify your IP addresses via ./docker/phpmyadmin/.htaccess for safety purposes. Modify docker-compose.yml or .htaccess if needed.
+
+
 
 After completing the setup, visit https://localhost to access OGameX. You first need to create an account (no email validation), afterwards you can login using that account.
 > Note: The production version runs in forced-HTTPS (redirect) mode by default using a self-signed SSL certificate. If you want to access the application via HTTP, open `.env` and change `APP_ENV` from `production` to `local`.

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -71,6 +71,19 @@ services:
     networks:
       - app-network
 
+#PHPMYADMIN
+  phpmyadmin:
+    image: phpmyadmin
+    restart: always
+    ports:
+      - 8080:80
+    environment:
+      - PMA_ARBITRARY=1
+      - PMA_HOST=ogame-db
+    networks:
+      - app-network
+    volumes:
+      - ./docker/phpmyadmin/phpmyadmin.conf:/etc/apache2/conf-available/.htaccess
 #Docker Networks
 networks:
   app-network:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -83,7 +83,7 @@ services:
     networks:
       - app-network
     volumes:
-      - ./docker/phpmyadmin/phpmyadmin.conf:/etc/apache2/conf-available/.htaccess
+      - ./docker/phpmyadmin/.htaccess:/var/www/html/.htaccess
 #Docker Networks
 networks:
   app-network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,17 @@ services:
     networks:
       - app-network
 
+  #PHPMYADMIN
+  phpmyadmin:
+    image: phpmyadmin
+    restart: always
+    ports:
+      - 8080:80
+    environment:
+      - PMA_ARBITRARY=1
+      - PMA_HOST=ogame-db
+    networks:
+      - app-network
 #Docker Networks
 networks:
   app-network:

--- a/docker/phpmyadmin/.htaccess
+++ b/docker/phpmyadmin/.htaccess
@@ -1,0 +1,3 @@
+Order Deny,Allow
+Deny from All
+Allow from 1.1.1.1


### PR DESCRIPTION
This closes https://github.com/lanedirt/OGameX/issues/441 

### Default Setup
I've added the default phpmyadmin setup into the dev docker setup,  and the default port will be `8080`  - this can be edited.

### Production
For the production setup, rather than leaving it out for production based on env, I've included it, but I've added a volume line that essentially locks it down by IP, this means that essentially no one can access it, unless its the IP address in the `.htaccess` ie for example `Allow from 1.1.1.1`. 
This should then give you the ability for it to setup and work, but be locked down to your own IP address etc, so not just anyone can access it. 

If you try to access it without the right IP, you get the following - therefore if you alter this in production, it'll only be locked to you allowing easy import and export ability : 
![image](https://github.com/user-attachments/assets/a7fd6927-e5c7-413d-a47d-73eba6d7aaa0)

You'd login with the DB / PASS the same as laravel.
