### PR TITLE
Populate shipyard queue on resources page for solar satellites

### DIFF
--- a/app/Http/Controllers/Abstracts/AbstractBuildingsController.php
+++ b/app/Http/Controllers/Abstracts/AbstractBuildingsController.php
@@ -161,7 +161,7 @@ abstract class AbstractBuildingsController extends OGameController
     {
         // If the technology is a solar satellite, execute the addBuildRequest method in ShipyardController.
         if ($request->input('technologyId') === '212') {
-            resolve(ShipyardController::class)->addBuildRequest($request, $player);
+            return resolve(ShipyardController::class)->addBuildRequest($request, $player);
         }
 
         // Explicitly verify CSRF token because this request supports both POST and GET.

--- a/app/Http/Controllers/ResourcesController.php
+++ b/app/Http/Controllers/ResourcesController.php
@@ -47,8 +47,8 @@ class ResourcesController extends AbstractBuildingsController
         ];
         $this->view_name = 'ingame.resources.index';
 
-        // Parse shipyard queue for this planet because the resources page
-        // shows both the building queue (handled by parent) but also the shipyard queue.
+        // Parse shipyard queue because the resources page shows both the
+        // building queue (handled by parent) but also the shipyard queue.
         $unitQueue = resolve(UnitQueueService::class);
         $unit_full_queue = $unitQueue->retrieveQueue($this->planet);
         $unit_build_active = $unit_full_queue->getCurrentlyBuildingFromQueue();
@@ -61,6 +61,7 @@ class ResourcesController extends AbstractBuildingsController
             $unit_queue_time_countdown = $unit_queue_time_end - (int)Carbon::now()->timestamp;
         }
 
+        // Append unit queue data to the default view output handled by parent.
         return parent::index($request, $player)->with([
             'unit_build_active' => $unit_build_active,
             'unit_build_queue' => $unit_build_queue,

--- a/resources/views/ingame/ajax/object.blade.php
+++ b/resources/views/ingame/ajax/object.blade.php
@@ -57,7 +57,7 @@
             </ul>
 
             <div class="costs">
-                @if ($object_type === \OGame\GameObjects\Models\Enums\GameObjectType::Ship)
+                @if ($object_type === \OGame\GameObjects\Models\Enums\GameObjectType::Ship || $object_type === \OGame\GameObjects\Models\Enums\GameObjectType::Defense)
                     <p>@lang('Costs per piece'):</p>
                 @else
                     <p>@lang('Required to improve to level') {!! $next_level !!}:</p>

--- a/resources/views/ingame/ajax/object.blade.php
+++ b/resources/views/ingame/ajax/object.blade.php
@@ -57,8 +57,11 @@
             </ul>
 
             <div class="costs">
-
-                <p>@lang('Required to improve to level') {!! $next_level !!}:</p>
+                @if ($object_type === \OGame\GameObjects\Models\Enums\GameObjectType::Ship)
+                    <p>@lang('Costs per piece'):</p>
+                @else
+                    <p>@lang('Required to improve to level') {!! $next_level !!}:</p>
+                @endif
 
                 <ul class="ipiHintable" data-ipi-hint="">
                     @if (!empty($price->metal->get()))

--- a/resources/views/ingame/resources/index.blade.php
+++ b/resources/views/ingame/resources/index.blade.php
@@ -24,7 +24,7 @@
             </div>
             <div id="technologies">
                 <h3>
-                    Resource buildings
+                    @lang('Resource buildings')
                 </h3>
                 <ul id="producers" class="icons">
                     @php /** @var OGame\ViewModels\BuildingViewModel $building */ @endphp
@@ -71,9 +71,13 @@
                                 <div class="cooldownBackground"></div>
                                 <time-counter><time class="countdown buildingCountdown" id="countdownbuildingDetails" data-segments="2">...</time></time-counter>
                             @endif
-                            <span class="level" data-value="{{ $building->current_level }}" data-bonus="0">
-                            <span class="stockAmount">{{ $building->current_level }}</span>
-                            <span class="bonus"></span>
+                            @if ($building->object->type === \OGame\GameObjects\Models\Enums\GameObjectType::Ship)
+                                <span class="amount" data-value="{{ $building->current_level }}" data-bonus="0">
+                            @else
+                                <span class="level" data-value="{{ $building->current_level }}" data-bonus="0">
+                            @endif
+                                <span class="stockAmount">{{ $building->current_level }}</span>
+                                <span class="bonus"></span>
                             </span>
                         </span></li>
                     @endforeach

--- a/resources/views/ingame/resources/index.blade.php
+++ b/resources/views/ingame/resources/index.blade.php
@@ -99,7 +99,6 @@
                 </div>
             </div>
             <div class="productionBoxShips boxColumn ship">
-
                 <div id="productionboxshipyardcomponent"
                      class="productionboxshipyard injectedComponent parent supplies">
                     <div class="content-box-s">
@@ -107,20 +106,10 @@
                             <h3>Shipyard</h3>
                         </div>
                         <div class="content">
-                            <table cellspacing="0" cellpadding="0" class="construction active">
-                                <tbody>
-                                <tr>
-                                    <td colspan="2" class="idle">
-                                        <a class="tooltip js_hideTipOnMobile tpd-hideOnClickOutside" title=""
-                                           href="#TODO_page=ingame&amp;component=shipyard">
-                                            No ships/defense in construction.
-                                            <br>
-                                            (To shipyard)
-                                        </a>
-                                    </td>
-                                </tr>
-                                </tbody>
-                            </table>
+                            {{-- Unit is actively being built. --}}
+                            @include ('ingame.shared.buildqueue.unit-active', ['build_active' => $unit_build_active, 'build_queue_countdown' => $unit_queue_time_countdown])
+                            {{-- Unit queue has items. --}}
+                            @include ('ingame.shared.buildqueue.unit-queue', ['build_queue' => $unit_build_queue])
                         </div>
                         <div class="footer"></div>
                     </div>

--- a/resources/views/ingame/resources/index.blade.php
+++ b/resources/views/ingame/resources/index.blade.php
@@ -60,7 +60,8 @@
                             @elseif (!$building->requirements_met)
                             @elseif (!$building->enough_resources)
                             @elseif ($build_queue_max)
-                            @elseif ($building->object->type != \OGame\GameObjects\Models\Enums\GameObjectType::Ship)
+                            @elseif ($building->object->type === \OGame\GameObjects\Models\Enums\GameObjectType::Ship || $building->object->type === \OGame\GameObjects\Models\Enums\GameObjectType::Defense)
+                            @else
                                 <button
                                         class="upgrade tooltip hideOthers js_hideTipOnMobile"
                                         aria-label="Expand {!! $building->object->title !!} on level {!! ($building->current_level + 1) !!}" title="Expand {!! $building->object->title !!} on level {!! ($building->current_level + 1) !!}"
@@ -71,7 +72,7 @@
                                 <div class="cooldownBackground"></div>
                                 <time-counter><time class="countdown buildingCountdown" id="countdownbuildingDetails" data-segments="2">...</time></time-counter>
                             @endif
-                            @if ($building->object->type === \OGame\GameObjects\Models\Enums\GameObjectType::Ship)
+                            @if ($building->object->type === \OGame\GameObjects\Models\Enums\GameObjectType::Ship || $building->object->type === \OGame\GameObjects\Models\Enums\GameObjectType::Defense)
                                 <span class="amount" data-value="{{ $building->current_level }}" data-bonus="0">
                             @else
                                 <span class="level" data-value="{{ $building->current_level }}" data-bonus="0">
@@ -107,7 +108,7 @@
                      class="productionboxshipyard injectedComponent parent supplies">
                     <div class="content-box-s">
                         <div class="header">
-                            <h3>Shipyard</h3>
+                            <h3>@lang('Shipyard')</h3>
                         </div>
                         <div class="content">
                             {{-- Unit is actively being built. --}}

--- a/resources/views/ingame/shared/buildqueue/unit-active.blade.php
+++ b/resources/views/ingame/shared/buildqueue/unit-active.blade.php
@@ -68,7 +68,7 @@
         <tbody>
         <tr>
             <td colspan="2" class="idle">
-                <a class="tooltip js_hideTipOnMobile " title="@lang('At the moment there are no ships or defense built on this planet. Click here to get to the shipyard.')" href="#ingame&amp;component=shipyard">
+                <a class="tooltip js_hideTipOnMobile " title="@lang('At the moment there are no ships or defense built on this planet. Click here to get to the shipyard.')" href="{{ route('shipyard.index') }}">
                     @lang('No ships/defense in construction.')
                     <br>
                     @lang('(To shipyard)')

--- a/resources/views/ingame/shipyard/unit-item.blade.php
+++ b/resources/views/ingame/shipyard/unit-item.blade.php
@@ -26,25 +26,23 @@
     @else
         data-status="on"
     title="{{ $building->object->title }}"
-        @endif
+    @endif
 >
-
-                        <span class="icon sprite @if ($building->object->type == \OGame\GameObjects\Models\Enums\GameObjectType::Defense)
-                            sprite_medium medium
-                         @else
-                            sprite_small small
-                         @endif{{ $building->object->class_name }}">
-                            @if ($building->currently_building)
-                                <span class="targetamount" data-value="54" data-bonus="0">
-                                    {{ $building->amount + $building->currently_building_amount }}
-                                </span>
-                                <div class="cooldownBackground"></div>
-                                <time-counter><time class="countdown buildingCountdown" id="countdownbuildingDetails" data-segments="2">...</time></time-counter>
-                            @endif
-                            <span class="amount"
-                              data-value="{{ $building->amount }}"
-                              data-bonus="0">
-                                <span class="stockAmount">{{ $building->amount }}</span>
-                                <span class="bonus"></span>
-                            </span>
-                        </span>
+    <span class="icon sprite @if ($building->object->type == \OGame\GameObjects\Models\Enums\GameObjectType::Defense)
+        sprite_medium medium
+        @else
+        sprite_small small
+        @endif{{ $building->object->class_name }}">
+        @if ($building->currently_building)
+            <span class="targetamount" data-value="54" data-bonus="0">
+                {{ $building->amount + $building->currently_building_amount }}
+            </span>
+            <div class="cooldownBackground"></div>
+            <time-counter><time class="countdown buildingCountdown" id="countdownbuildingDetails" data-segments="2">...</time></time-counter>
+        @endif
+            <span class="amount" data-value="{{ $building->amount }}" data-bonus="0">
+            <span class="stockAmount">{{ $building->amount }}</span>
+            <span class="bonus"></span>
+        </span>
+    </span>
+</li>


### PR DESCRIPTION
Fixes:
- #457 

Remaining todo's:
- [x] When solar satellite are building, when one unit is done the actual unit count is not updated on the resources page. This does work when building units from shipyard/defense page. Check what is missing to make this work. --> class where count is shown should be "amount" for unit objects instead of "level".
