### PR TITLE
Correct temp_min/max assignment during planet creation

### DIFF
--- a/app/Factories/PlanetServiceFactory.php
+++ b/app/Factories/PlanetServiceFactory.php
@@ -417,8 +417,8 @@ class PlanetServiceFactory
         $planet->field_max = 1;
 
         // TODO: temperature range should be dependent on the moon position.
-        $planet->temp_min = rand(0, 100);
-        $planet->temp_max = $planet->temp_min + 40;
+        $planet->temp_max = rand(0, 100);
+        $planet->temp_min = $planet->temp_max - 40;
 
         // Moons start with no resources.
         $planet->metal = 0;
@@ -438,8 +438,9 @@ class PlanetServiceFactory
         $planet->field_max = rand($planet_data['fields'][0], $planet_data['fields'][1]) + $this->settings->planetFieldsBonus();
         $planet->diameter = (int) (36.14 * $planet->field_max + 5697.23);
 
-        $planet->temp_min = rand($planet_data['temperature'][0], $planet_data['temperature'][1]);
-        $planet->temp_max = $planet->temp_min + 40;
+        // Random temperature between the min and max values is assigned to temp_max, then temp_min is calculated as temp_max - 40.
+        $planet->temp_max = rand($planet_data['temperature'][0], $planet_data['temperature'][1]);
+        $planet->temp_min = $planet->temp_max - 40;
 
         // Starting resources for planets.
         $planet->metal = 500;

--- a/app/Services/PlanetService.php
+++ b/app/Services/PlanetService.php
@@ -706,6 +706,11 @@ class PlanetService
         $nanitefactory_level = $this->getObjectLevel('nano_factory');
         $universe_speed = $this->settingsService->economySpeed();
 
+        // Sanity check: if universe speed is 0, set it to 1 to prevent division by zero.
+        if ($universe_speed == 0) {
+            $universe_speed = 1;
+        }
+
         // The actual formula which return time in seconds
         $time_hours =
             (
@@ -760,6 +765,11 @@ class PlanetService
         $nanitefactory_level = $this->getObjectLevel('nano_factory');
         $universe_speed = $this->settingsService->economySpeed();
 
+        // Sanity check: if universe speed is 0, set it to 1 to prevent division by zero.
+        if ($universe_speed == 0) {
+            $universe_speed = 1;
+        }
+
         // The actual formula which return time in seconds
         $time_hours =
             (
@@ -792,6 +802,11 @@ class PlanetService
 
         // Research speed is = (economy x research speed).
         $universe_speed = $this->settingsService->economySpeed() * $this->settingsService->researchSpeed();
+
+        // Sanity check: if universe speed is 0, set it to 1 to prevent division by zero.
+        if ($universe_speed == 0) {
+            $universe_speed = 1;
+        }
 
         // The actual formula which return time in seconds
         $time_hours =

--- a/tests/Feature/FleetDispatch/FleetDispatchAttackTest.php
+++ b/tests/Feature/FleetDispatch/FleetDispatchAttackTest.php
@@ -420,6 +420,11 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
      */
     public function testDispatchFleetCombatUnitsLostAndResourceGained(): void
     {
+        // Disable all resource generation in server settings to ensure we're not affected by it
+        // when comparing resources before and after battle.
+        $settingsService = resolve(SettingsService::class);
+        $settingsService->set('economy_speed', 0);
+
         // Send fleet to a nearby foreign planet.
         // Attack with 200 light fighters, defend with 100 rocket launchers.
         // We expect attacker to win in +/- 4 rounds, while losing 10-50 light fighters.
@@ -428,20 +433,16 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
 
         $unitCollection = new UnitCollection();
         $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 200);
-        $foreignPlanet = $this->sendMissionToOtherPlayerPlanet($unitCollection, new Resources(0, 0, 0, 0));
-
-        // Clear existing units from foreign planet.
-        $foreignPlanet->removeUnits($foreignPlanet->getShipUnits(), true);
-        $foreignPlanet->removeUnits($foreignPlanet->getDefenseUnits(), true);
+        $foreignPlanet = $this->sendMissionToOtherPlayerCleanPlanet($unitCollection, new Resources(0, 0, 0, 0));
 
         // Give the foreign planet some units to defend itself.
         $foreignPlanet->addUnit('rocket_launcher', 100);
 
+        // Increase time by 24 hours to ensure the mission is done and fleets have returned.
+        $this->travel(24)->hours();
+
         // Reload application to make sure the planet is not cached.
         $this->reloadApplication();
-
-        // Increase time by 2 hours to ensure the mission is done.
-        $this->travel(2)->hours();
 
         // Get amount of resources of the foreign planet before the battle.
         $attackerResourcesBefore = $this->planetService->getResources();
@@ -451,9 +452,10 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
         $response = $this->get('/overview');
         $response->assertStatus(200);
 
-        // Assert that attacker has less than 200 light fighters after battle.
+        // Assert that attacker has more than 0 but less than 200 light fighters after battle.
         $this->planetService->reloadPlanet();
-        $this->assertLessThan(200, $this->planetService->getObjectAmount('light_fighter'), 'Attacker still has 150 light fighters after battle while it was expected they lost some.');
+        $this->assertGreaterThan(0, $this->planetService->getObjectAmount('light_fighter'), 'Attacker has no light fighters after battle while it was expected some should have survived and returned.');
+        $this->assertLessThan(200, $this->planetService->getObjectAmount('light_fighter'), 'Attacker still has 200 light fighters after battle while it was expected they lost some.');
 
         // Assert that the defender has lost all units.
         $foreignPlanet->reloadPlanet();

--- a/tests/FleetDispatchTestCase.php
+++ b/tests/FleetDispatchTestCase.php
@@ -145,6 +145,22 @@ abstract class FleetDispatchTestCase extends MoonTestCase
     }
 
     /**
+     * Send a fleet to a new clean planet of another player.
+     *
+     * @param UnitCollection $units
+     * @param Resources $resources
+     * @param int $assertStatus
+     * @return PlanetService
+     */
+    protected function sendMissionToOtherPlayerCleanPlanet(UnitCollection $units, Resources $resources, int $assertStatus = 200): PlanetService
+    {
+        $nearbyForeignCleanPlanet = $this->getNearbyForeignCleanPlanet();
+
+        $this->dispatchFleet($nearbyForeignCleanPlanet->getPlanetCoordinates(), $units, $resources, PlanetType::Planet, $assertStatus);
+        return $nearbyForeignCleanPlanet;
+    }
+
+    /**
      * Send a fleet to a moon of another player.
      *
      * @param UnitCollection $units


### PR DESCRIPTION
This PR reverses the planet min/max temperature assignment so it works according to the official game.