### PR TITLE
Resources Int to float

### DIFF
--- a/app/Models/BuildingQueue.php
+++ b/app/Models/BuildingQueue.php
@@ -14,9 +14,9 @@ use Illuminate\Database\Eloquent\Model;
  * @property int $time_duration
  * @property int $time_start
  * @property int $time_end
- * @property int $metal
- * @property int $crystal
- * @property int $deuterium
+ * @property float $metal
+ * @property float $crystal
+ * @property float $deuterium
  * @property int $building
  * @property int $processed
  * @property int $canceled

--- a/app/Models/Planet.php
+++ b/app/Models/Planet.php
@@ -24,13 +24,13 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property int $temp_max
  * @property float $metal
  * @property int $metal_production
- * @property int $metal_max
+ * @property float $metal_max
  * @property float $crystal
  * @property int $crystal_production
- * @property int $crystal_max
+ * @property float $crystal_max
  * @property float $deuterium
  * @property int $deuterium_production
- * @property int $deuterium_max
+ * @property float $deuterium_max
  * @property int $energy_used
  * @property int $energy_max
  * @property int $time_last_update

--- a/app/Models/ResearchQueue.php
+++ b/app/Models/ResearchQueue.php
@@ -15,9 +15,9 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property int $time_duration
  * @property int $time_start
  * @property int $time_end
- * @property int $metal
- * @property int $crystal
- * @property int $deuterium
+ * @property float $metal
+ * @property float $crystal
+ * @property float $deuterium
  * @property int $building
  * @property int $processed
  * @property int $canceled

--- a/app/Models/UnitQueue.php
+++ b/app/Models/UnitQueue.php
@@ -17,9 +17,9 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property int $time_end
  * @property int $time_progress
  * @property int $object_amount_progress
- * @property int $metal
- * @property int $crystal
- * @property int $deuterium
+ * @property float $metal
+ * @property float $crystal
+ * @property float $deuterium
  * @property int $processed
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at

--- a/app/Services/BuildingQueueService.php
+++ b/app/Services/BuildingQueueService.php
@@ -258,9 +258,9 @@ class BuildingQueueService
             $queue_item->time_start = $time_start;
             $queue_item->time_end = $queue_item->time_start + $queue_item->time_duration;
             $queue_item->building = 1;
-            $queue_item->metal = (int)$price->metal->get();
-            $queue_item->crystal = (int)$price->crystal->get();
-            $queue_item->deuterium = (int)$price->deuterium->get();
+            $queue_item->metal = $price->metal->get();
+            $queue_item->crystal = $price->crystal->get();
+            $queue_item->deuterium = $price->deuterium->get();
             $queue_item->save();
 
             // If the calculated end time is lower than the current time,

--- a/app/Services/PlanetService.php
+++ b/app/Services/PlanetService.php
@@ -1791,9 +1791,9 @@ class PlanetService
         }
 
         // Write values to planet
-        $this->planet->metal_max = (int)$storage_sum->metal->get();
-        $this->planet->crystal_max = (int)$storage_sum->crystal->get();
-        $this->planet->deuterium_max = (int)$storage_sum->deuterium->get();
+        $this->planet->metal_max = $storage_sum->metal->get();
+        $this->planet->crystal_max = $storage_sum->crystal->get();
+        $this->planet->deuterium_max = $storage_sum->deuterium->get();
         if ($save_planet) {
             $this->save();
         }

--- a/app/Services/ResearchQueueService.php
+++ b/app/Services/ResearchQueueService.php
@@ -312,9 +312,9 @@ class ResearchQueueService
             $queue_item->time_start = $time_start;
             $queue_item->time_end = $queue_item->time_start + $queue_item->time_duration;
             $queue_item->building = 1;
-            $queue_item->metal = (int)$price->metal->get();
-            $queue_item->crystal = (int)$price->crystal->get();
-            $queue_item->deuterium = (int)$price->deuterium->get();
+            $queue_item->metal = $price->metal->get();
+            $queue_item->crystal = $price->crystal->get();
+            $queue_item->deuterium = $price->deuterium->get();
             $queue_item->save();
 
             // If the calculated end time is lower than the current time,

--- a/app/Services/UnitQueueService.php
+++ b/app/Services/UnitQueueService.php
@@ -196,9 +196,9 @@ class UnitQueueService
         $queue->time_duration = $build_time_total;
         $queue->time_start = $time_start;
         $queue->time_end = $queue->time_start + $queue->time_duration;
-        $queue->metal = (int)$total_price->metal->get();
-        $queue->crystal = (int)$total_price->crystal->get();
-        $queue->deuterium = (int)$total_price->deuterium->get();
+        $queue->metal = $total_price->metal->get();
+        $queue->crystal = $total_price->crystal->get();
+        $queue->deuterium = $total_price->deuterium->get();
 
         // All OK, deduct resources.
         $planet->deductResources($total_price);

--- a/database/migrations/2025_01_21_233657_handle_various_resource_fields_from_int_to_float.php
+++ b/database/migrations/2025_01_21_233657_handle_various_resource_fields_from_int_to_float.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('building_queues', function (Blueprint $table) {
+            $table->float('metal')->default(0)->change();
+            $table->float('crystal')->default(0)->change();
+            $table->float('deuterium')->default(0)->change();
+        });
+        Schema::table('research_queues', function (Blueprint $table) {
+            $table->float('metal')->default(0)->change();
+            $table->float('crystal')->default(0)->change();
+            $table->float('deuterium')->default(0)->change();
+        });
+        Schema::table('unit_queues', function (Blueprint $table) {
+            $table->float('metal')->default(0)->change();
+            $table->float('crystal')->default(0)->change();
+            $table->float('deuterium')->default(0)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('building_queues', function (Blueprint $table) {
+            $table->integer('metal')->default(0)->change();
+            $table->integer('crystal')->default(0)->change();
+            $table->integer('deuterium')->default(0)->change();
+        });
+        Schema::table('research_queues', function (Blueprint $table) {
+            $table->integer('metal')->default(0)->change();
+            $table->integer('crystal')->default(0)->change();
+            $table->integer('deuterium')->default(0)->change();
+        });
+        Schema::table('unit_queues', function (Blueprint $table) {
+            $table->integer('metal')->default(0)->change();
+            $table->integer('crystal')->default(0)->change();
+            $table->integer('deuterium')->default(0)->change();
+        });
+    }
+};


### PR DESCRIPTION
## Description
Various resource fields were still ints, rather than floats, this makes it uniform, 
I also changed the planet _max values to floats as they're already done in the migrations. 

I wonder if some of the _production columns on the planet table may also need to be changed - it would be good to go through all the columns ideally,  (one for another PR)

### Type of Change:
- [x] Bug fix


## Related Issues

Link to any issues or discussions that this PR addresses:
Fixes https://github.com/lanedirt/OGameX/issues/543

- [x] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [x] **Static Analysis:** Code passes PHPStan static code analysis.
- [x] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.

- [x] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [x] **Documentation:** Documentation has been updated to reflect any changes made.

