### PR TITLE
Queued buildings/research/units with end date greater than 2038 throws error

### DIFF
--- a/database/migrations/2025_01_23_094711_support_higher_building_levels.php
+++ b/database/migrations/2025_01_23_094711_support_higher_building_levels.php
@@ -1,0 +1,100 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('building_queues', function (Blueprint $table) {
+            $table->bigInteger('time_duration')->default(0)->change();
+            $table->bigInteger('time_start')->default(0)->change();
+            $table->bigInteger('time_end')->default(0)->change();
+        });
+
+        Schema::table('research_queues', function (Blueprint $table) {
+            $table->bigInteger('time_duration')->default(0)->change();
+            $table->bigInteger('time_start')->default(0)->change();
+            $table->bigInteger('time_end')->default(0)->change();
+        });
+
+        Schema::table('unit_queues', function (Blueprint $table) {
+            $table->bigInteger('time_duration')->default(0)->change();
+            $table->bigInteger('time_start')->default(0)->change();
+            $table->bigInteger('time_end')->default(0)->change();
+            $table->bigInteger('time_progress')->default(0)->change();
+        });
+
+        Schema::table('fleet_missions', function (Blueprint $table) {
+            $table->bigInteger('time_departure')->default(0)->change();
+            $table->bigInteger('time_arrival')->default(0)->change();
+        });
+
+        Schema::table('planets', function (Blueprint $table) {
+            $table->bigInteger('time_last_update')->default(0)->change();
+        });
+
+        Schema::table('sessions', function (Blueprint $table) {
+            $table->bigInteger('last_activity')->change();
+        });
+
+        Schema::table('cache', function (Blueprint $table) {
+            $table->bigInteger('expiration')->change();
+        });
+
+        Schema::table('cache_locks', function (Blueprint $table) {
+            $table->bigInteger('expiration')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('building_queues', function (Blueprint $table) {
+            $table->integer('time_duration')->default(0)->change();
+            $table->integer('time_start')->default(0)->change();
+            $table->integer('time_end')->default(0)->change();
+        });
+
+        Schema::table('research_queues', function (Blueprint $table) {
+            $table->integer('time_duration')->default(0)->change();
+            $table->integer('time_start')->default(0)->change();
+            $table->integer('time_end')->default(0)->change();
+        });
+
+        Schema::table('unit_queues', function (Blueprint $table) {
+            $table->integer('time_duration')->default(0)->change();
+            $table->integer('time_start')->default(0)->change();
+            $table->integer('time_end')->default(0)->change();
+            $table->integer('time_progress')->default(0)->change();
+        });
+
+        Schema::table('fleet_missions', function (Blueprint $table) {
+            $table->integer('time_departure')->default(0)->change();
+            $table->integer('time_arrival')->default(0)->change();
+        });
+
+        Schema::table('planets', function (Blueprint $table) {
+            $table->integer('time_last_update')->default(0)->change();
+        });
+
+        Schema::table('sessions', function (Blueprint $table) {
+            $table->integer('last_activity')->change();
+        });
+
+        Schema::table('cache', function (Blueprint $table) {
+            $table->integer('expiration')->change();
+        });
+
+        Schema::table('cache_locks', function (Blueprint $table) {
+            $table->integer('expiration')->change();
+        });
+    }
+};

--- a/database/migrations/2025_01_23_102757_convert_laravel_timestamp_to_date_time.php
+++ b/database/migrations/2025_01_23_102757_convert_laravel_timestamp_to_date_time.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * List of tables that use Laravel's default timestamps
+     *
+     * @var array<string>
+     */
+    private array $tables = [
+        'battle_reports',
+        'building_queues',
+        'debris_fields',
+        'espionage_reports',
+        'fleet_missions',
+        'highscores',
+        'messages',
+        'notes',
+        'planets',
+        'research_queues',
+        'settings',
+        'users',
+        'users_tech',
+        'unit_queues',
+    ];
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        foreach ($this->tables as $table) {
+            Schema::table($table, function (Blueprint $table) {
+                $table->datetime('created_at')->nullable()->change();
+                $table->datetime('updated_at')->nullable()->change();
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        foreach ($this->tables as $table) {
+            Schema::table($table, function (Blueprint $table) {
+                $table->timestamp('created_at')->nullable()->change();
+                $table->timestamp('updated_at')->nullable()->change();
+            });
+        }
+    }
+};

--- a/tests/Feature/FleetDispatch/FleetDispatchAttackTest.php
+++ b/tests/Feature/FleetDispatch/FleetDispatchAttackTest.php
@@ -940,4 +940,38 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
         // Output the number of attempts it took to create the moon
         dump("Moon was created after amount of attempts: " . $attempts);
     }
+
+    /**
+     * Assert that a debris field can contain large numbers (billions) of resources.
+     */
+    public function testLargeDebrisFieldCreation(): void
+    {
+        // Create coordinates for debris field.
+        $coordinates = $this->planetService->getPlanetCoordinates();
+
+        // Create large resource amounts (10 billion each).
+        $metal = 10000000000;
+        $crystal = 10000000000;
+        $deuterium = 10000000000;
+
+        // Create debris field with large numbers.
+        $debrisFieldService = resolve(DebrisFieldService::class);
+
+        // Load or create debris field.
+        $debrisFieldService->loadOrCreateForCoordinates($coordinates);
+
+        // Add resources to debris field.
+        $debrisFieldService->appendResources(new Resources($metal, $crystal, $deuterium, 0));
+        $debrisFieldService->save();
+
+        // Try to load the debris field again.
+        $exists = $debrisFieldService->loadForCoordinates($coordinates);
+        $this->assertTrue($exists, 'Large debris field was not created successfully.');
+
+        // Verify that debris field contains at least the amount of resources we added.
+        $resources = $debrisFieldService->getResources();
+        $this->assertGreaterThanOrEqual($metal, $resources->metal->get(), 'Debris field metal amount does not match expected large value.');
+        $this->assertGreaterThanOrEqual($crystal, $resources->crystal->get(), 'Debris field crystal amount does not match expected large value.');
+        $this->assertGreaterThanOrEqual($deuterium, $resources->deuterium->get(), 'Debris field deuterium amount does not match expected large value.');
+    }
 }


### PR DESCRIPTION
## Description
Change all database field types so it supports dates greater than 2038-01-01.

### Type of Change:
- [x] Bug fix

## Related Issues

Link to any issues or discussions that this PR addresses:
Fixes #545

## Checklist

Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [x] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [x] **Static Analysis:** Code passes PHPStan static code analysis.
- [x] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.

- [x] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [x] **Documentation:** Documentation has been updated to reflect any changes made.
