### PR TITLE
Adjust docker compose script to sort Windows

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,8 @@ RUN apt-get update && apt-get install -y \
     libzip-dev \
     unzip \
     git \
-    curl
+    curl \
+    dos2unix \
 
 # Install PHP FFI development files required to interface with Rust for BattleEngine
 RUN apt-get update && apt-get install -y \
@@ -71,6 +72,10 @@ USER root
 
 # Copy entry point and set permissions for www user
 COPY docker/entrypoint.sh /usr/local/bin/entrypoint
+
+# Convert line endings from CRLF to LF
+RUN dos2unix /usr/local/bin/entrypoint
+
 RUN chmod +x /usr/local/bin/entrypoint && \
     chown www:www /usr/local/bin/entrypoint
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y \
     unzip \
     git \
     curl \
-    dos2unix \
+    dos2unix
 
 # Install PHP FFI development files required to interface with Rust for BattleEngine
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
## Description

This PR adds dos2unix to the Dockerfile. The reason for this addition is to ensure that the entrypoint script works correctly in a Unix-based environment, especially when the Docker image is built on a Windows system.

Why: When developing on Windows, line endings in files are different from those in Unix-based systems (Windows uses CRLF, while Unix-based systems use LF). This difference can cause issues when running scripts in a Unix environment, as the presence of CRLF line endings can result in errors or unexpected behaviour.

The dos2unix command is being added to convert the entrypoint script to the proper Unix line endings (LF), ensuring that the script runs as intended on Unix-based systems.

Impact: This change will resolve potential issues related to incorrect line endings when running the entrypoint script, improving cross-platform compatibility and stability of the container.


### Type of Change:
- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues

Fixes https://github.com/lanedirt/OGameX/issues/552

## Checklist

Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [x] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [x] **Static Analysis:** Code passes PHPStan static code analysis.
- [x] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.

- [x] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [x] **Documentation:** Documentation has been updated to reflect any changes made.

## Additional Information

Will add some screens here of a fresh fresh install shortly 
