### PR TITLE
General improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,25 +27,31 @@ The easiest way to check if your contributed code adheres to the conventions is 
 $ ./vendor/bin/pint --test
 ```
 
-Tip: it's possible to let Laravel Pint attempt to fix the code for you by running it without the --test flag:
+Tip: it's possible to let Laravel Pint attempt to fix the code for you by running the following composer script:
 
 ```
-$ ./vendor/bin/pint
+$ composer run cs
 ```
 
 ### 2. PHPStan static code analysis
-Make sure that your code passes the PHPStan static code analysis. You can run PHPStan locally using the following command:
+Make sure that your code passes the PHPStan static code analysis. You can run PHPStan locally using the following composer script:
 
 ```
-$ ./vendor/bin/phpstan analyse --memory-limit=384M
+$ composer run stan
 ```
 
 ### 3. Laravel unit and feature tests
-Your PR should include feature or unittests where possible to cover the changes you made. OGameX uses the default Laravel testing framework which covers feature and unittests by default.
+Your PR should include feature or unit tests where possible to cover the changes you made. OGameX uses the default Laravel testing framework which covers feature and unit tests by default.
 To run the tests locally, you can use the following command:
 
 ```
 $ php artisan test
+```
+
+You are also able to apply the `--filter` parameter to run a specific class or method such as :
+
+```
+$ php artisan test --filter PlanetServiceTest
 ```
 
 ### 4. Custom race condition tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,21 +27,21 @@ The easiest way to check if your contributed code adheres to the conventions is 
 $ ./vendor/bin/pint --test
 ```
 
-- Tip: it's possible to let Laravel Pint attempt to fix the code for you by running the following composer script:
+Tip: it's possible to let Laravel Pint attempt to fix the code for you by running the following composer script:
 
 ```
 $ composer run cs
 ```
 
 ### 2. PHPStan static code analysis
-- Make sure that your code passes the PHPStan static code analysis. You can run PHPStan locally using the following composer script:
+Make sure that your code passes the PHPStan static code analysis. You can run PHPStan locally using the following composer script:
 
 ```
 $ composer run stan
 ```
 
 ### 3. Laravel unit and feature tests
-- Your PR should include feature or unit tests where possible to cover the changes you made. OGameX uses the default Laravel testing framework which covers feature and unit tests by default.
+Your PR should include feature or unit tests where possible to cover the changes you made. OGameX uses the default Laravel testing framework which covers feature and unit tests by default.
 To run the tests locally, you can use the following command:
 
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,21 +27,21 @@ The easiest way to check if your contributed code adheres to the conventions is 
 $ ./vendor/bin/pint --test
 ```
 
-Tip: it's possible to let Laravel Pint attempt to fix the code for you by running the following composer script:
+- Tip: it's possible to let Laravel Pint attempt to fix the code for you by running the following composer script:
 
 ```
 $ composer run cs
 ```
 
 ### 2. PHPStan static code analysis
-Make sure that your code passes the PHPStan static code analysis. You can run PHPStan locally using the following composer script:
+- Make sure that your code passes the PHPStan static code analysis. You can run PHPStan locally using the following composer script:
 
 ```
 $ composer run stan
 ```
 
 ### 3. Laravel unit and feature tests
-Your PR should include feature or unit tests where possible to cover the changes you made. OGameX uses the default Laravel testing framework which covers feature and unit tests by default.
+- Your PR should include feature or unit tests where possible to cover the changes you made. OGameX uses the default Laravel testing framework which covers feature and unit tests by default.
 To run the tests locally, you can use the following command:
 
 ```

--- a/app/Http/Controllers/OverviewController.php
+++ b/app/Http/Controllers/OverviewController.php
@@ -69,7 +69,7 @@ class OverviewController extends OGameController
 
         $highscoreService = resolve(HighscoreService::class);
 
-        $user_rank = Cache::remember(sprintf('player-rank-%d',$player->getId()), now()->addMinutes(5), function () use ($highscoreService, $player) {
+        $user_rank = Cache::remember(sprintf('player-rank-%d', $player->getId()), now()->addMinutes(5), function () use ($highscoreService, $player) {
             return $highscoreService->getHighscorePlayerRank($player);
         });
 
@@ -77,7 +77,7 @@ class OverviewController extends OGameController
             return Highscore::query()->validRanks()->count();
         });
 
-        $user_score =  Cache::remember(sprintf('player-score-%d',$player->getId()), now()->addMinutes(5), function () use ($player) {
+        $user_score =  Cache::remember(sprintf('player-score-%d', $player->getId()), now()->addMinutes(5), function () use ($player) {
             return AppUtil::formatNumber(Highscore::where('player_id', $player->getId())->first()->general ?? 0);
         });
 

--- a/app/Http/Controllers/OverviewController.php
+++ b/app/Http/Controllers/OverviewController.php
@@ -69,7 +69,7 @@ class OverviewController extends OGameController
 
         $highscoreService = resolve(HighscoreService::class);
 
-        $user_rank = Cache::remember('player-rank-'.$player->getId(), now()->addMinutes(5), function () use ($highscoreService, $player) {
+        $user_rank = Cache::remember(sprintf('player-rank-%d',$player->getId()), now()->addMinutes(5), function () use ($highscoreService, $player) {
             return $highscoreService->getHighscorePlayerRank($player);
         });
 
@@ -77,7 +77,7 @@ class OverviewController extends OGameController
             return Highscore::query()->validRanks()->count();
         });
 
-        $user_score =  Cache::remember('player-score-'.$player->getId(), now()->addMinutes(5), function () use ($player) {
+        $user_score =  Cache::remember(sprintf('player-score-%d',$player->getId()), now()->addMinutes(5), function () use ($player) {
             return AppUtil::formatNumber(Highscore::where('player_id', $player->getId())->first()->general ?? 0);
         });
 

--- a/app/Observers/UserTechObserver.php
+++ b/app/Observers/UserTechObserver.php
@@ -32,7 +32,7 @@ class UserTechObserver
         foreach (HighscoreTypeEnum::cases() as $type) {
             $pages = floor(Highscore::count() / 100) + 1;
             for ($page = 1; $page <= $pages; $page++) {
-                Cache::forget('highscores'.'-'.$type->name.'-'.$page);
+                Cache::forget(sprintf('highscores-%s-%d', $type->name, $page));
             }
         }
     }

--- a/app/Services/HighscoreService.php
+++ b/app/Services/HighscoreService.php
@@ -131,7 +131,7 @@ class HighscoreService
     public function getHighscorePlayers(int $perPage = 100, int $pageOn = 1): array
     {
         // Get all player highscores
-        return Cache::remember(sprintf('highscores-%s-%d',$this->highscoreType->name,$pageOn), now()->addMinutes(5), function () use ($perPage, $pageOn) {
+        return Cache::remember(sprintf('highscores-%s-%d', $this->highscoreType->name, $pageOn), now()->addMinutes(5), function () use ($perPage, $pageOn) {
             $parsedHighscores = [];
 
             $highscores = Highscore::query()

--- a/app/Services/HighscoreService.php
+++ b/app/Services/HighscoreService.php
@@ -131,7 +131,7 @@ class HighscoreService
     public function getHighscorePlayers(int $perPage = 100, int $pageOn = 1): array
     {
         // Get all player highscores
-        return Cache::remember('highscores'.'-'.$this->highscoreType->name.'-'.$pageOn, now()->addMinutes(5), function () use ($perPage, $pageOn) {
+        return Cache::remember(sprintf('highscores-%s-%d',$this->highscoreType->name,$pageOn), now()->addMinutes(5), function () use ($perPage, $pageOn) {
             $parsedHighscores = [];
 
             $highscores = Highscore::query()

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
             "@php artisan migrate --graceful --ansi"
         ],
         "cs": [
-            "./vendor/bin/pint --dirty"
+            "./vendor/bin/pint --preset psr12"
         ],
         "stan": [
             "./vendor/bin/phpstan analyse --memory-limit=384M"

--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,12 @@
             "@php artisan key:generate --ansi",
             "@php -r \"file_exists('database/database.sqlite') || touch('database/database.sqlite');\"",
             "@php artisan migrate --graceful --ansi"
+        ],
+        "cs": [
+            "./vendor/bin/pint --dirty"
+        ],
+        "stan": [
+            "./vendor/bin/phpstan analyse --memory-limit=384M"
         ]
     },
     "extra": {


### PR DESCRIPTION
## Description

- Changes cache keys to use `sprintf` over concats with `.` 
- Changes UserTechObserver to only clear the pages it needs to, rather than all.
- Adds composer scripts so we can easily call `composer run cs` to apply pint styling etc without needing to remember >:)
