### PR TITLE
Fleet missions are able to be targeted towards itself and non existent moon causing crash

### DIFF
--- a/app/GameMissions/Abstracts/GameMission.php
+++ b/app/GameMissions/Abstracts/GameMission.php
@@ -126,6 +126,7 @@ abstract class GameMission
         if (!$planet->hasResources($resources)) {
             throw new Exception('Not enough resources on the planet to send the fleet.');
         }
+
         if (!$planet->hasUnits($units)) {
             $unitNames = [];
             foreach ($units->units as $unit) {
@@ -162,6 +163,7 @@ abstract class GameMission
      * @param PlanetType $targetType
      * @param UnitCollection $units
      * @param Resources $resources
+     * @param float $speed_percent
      * @param int $parent_id
      * @return FleetMission
      * @throws Exception

--- a/app/GameMissions/AttackMission.php
+++ b/app/GameMissions/AttackMission.php
@@ -45,6 +45,11 @@ class AttackMission extends GameMission
             return new MissionPossibleStatus(false);
         }
 
+        // If mission from and to coordinates and types are the same, the mission is not possible.
+        if ($planet->getPlanetCoordinates()->equals($targetCoordinate) && $planet->getPlanetType() === $targetType) {
+            return new MissionPossibleStatus(false);
+        }
+
         // If all checks pass, the mission is possible.
         return new MissionPossibleStatus(true);
     }

--- a/app/GameMissions/AttackMission.php
+++ b/app/GameMissions/AttackMission.php
@@ -33,9 +33,8 @@ class AttackMission extends GameMission
             return new MissionPossibleStatus(false);
         }
 
-        $targetPlanet = $this->planetServiceFactory->makeForCoordinate($targetCoordinate);
-
-        // If planet does not exist, the mission is not possible.
+        // If target planet does not exist, the mission is not possible.
+        $targetPlanet = $this->planetServiceFactory->makeForCoordinate($targetCoordinate, true, $targetType);
         if ($targetPlanet === null) {
             return new MissionPossibleStatus(false);
         }

--- a/app/GameMissions/ColonisationMission.php
+++ b/app/GameMissions/ColonisationMission.php
@@ -42,6 +42,11 @@ class ColonisationMission extends GameMission
             return new MissionPossibleStatus(false, __('You need a colony ship to colonize a planet.'));
         }
 
+        // If mission from and to coordinates and types are the same, the mission is not possible.
+        if ($planet->getPlanetCoordinates()->equals($targetCoordinate) && $planet->getPlanetType() === $targetType) {
+            return new MissionPossibleStatus(false);
+        }
+
         // If all checks pass, the mission is possible.
         return new MissionPossibleStatus(true);
     }

--- a/app/GameMissions/ColonisationMission.php
+++ b/app/GameMissions/ColonisationMission.php
@@ -30,9 +30,8 @@ class ColonisationMission extends GameMission
             return new MissionPossibleStatus(false);
         }
 
-        $targetPlanet = $this->planetServiceFactory->makeForCoordinate($targetCoordinate);
-
-        // If planet already exists, the mission is not possible.
+        // If target planet already exists, the mission is not possible.
+        $targetPlanet = $this->planetServiceFactory->makeForCoordinate($targetCoordinate, true, $targetType);
         if ($targetPlanet !== null) {
             return new MissionPossibleStatus(false);
         }

--- a/app/GameMissions/DeploymentMission.php
+++ b/app/GameMissions/DeploymentMission.php
@@ -28,9 +28,8 @@ class DeploymentMission extends GameMission
             return new MissionPossibleStatus(false);
         }
 
-        $targetPlanet = $this->planetServiceFactory->makeForCoordinate($targetCoordinate);
-
         // If target planet does not exist, the mission is not possible.
+        $targetPlanet = $this->planetServiceFactory->makeForCoordinate($targetCoordinate, true, $targetType);
         if ($targetPlanet === null) {
             return new MissionPossibleStatus(false);
         }

--- a/app/GameMissions/DeploymentMission.php
+++ b/app/GameMissions/DeploymentMission.php
@@ -40,6 +40,11 @@ class DeploymentMission extends GameMission
             return new MissionPossibleStatus(false);
         }
 
+        // If mission from and to coordinates and types are the same, the mission is not possible.
+        if ($planet->getPlanetCoordinates()->equals($targetCoordinate) && $planet->getPlanetType() === $targetType) {
+            return new MissionPossibleStatus(false);
+        }
+
         // If all checks pass, the mission is possible.
         return new MissionPossibleStatus(true);
     }

--- a/app/GameMissions/EspionageMission.php
+++ b/app/GameMissions/EspionageMission.php
@@ -29,9 +29,8 @@ class EspionageMission extends GameMission
             return new MissionPossibleStatus(false);
         }
 
-        $targetPlanet = $this->planetServiceFactory->makeForCoordinate($targetCoordinate);
-
-        // If planet does not exist, the mission is not possible.
+        // If target planet does not exist, the mission is not possible.
+        $targetPlanet = $this->planetServiceFactory->makeForCoordinate($targetCoordinate, true, $targetType);
         if ($targetPlanet === null) {
             return new MissionPossibleStatus(false);
         }

--- a/app/GameMissions/EspionageMission.php
+++ b/app/GameMissions/EspionageMission.php
@@ -46,6 +46,11 @@ class EspionageMission extends GameMission
             return new MissionPossibleStatus(false);
         }
 
+        // If mission from and to coordinates and types are the same, the mission is not possible.
+        if ($planet->getPlanetCoordinates()->equals($targetCoordinate) && $planet->getPlanetType() === $targetType) {
+            return new MissionPossibleStatus(false);
+        }
+
         // If all checks pass, the mission is possible.
         return new MissionPossibleStatus(true);
     }

--- a/app/GameMissions/RecycleMission.php
+++ b/app/GameMissions/RecycleMission.php
@@ -31,6 +31,11 @@ class RecycleMission extends GameMission
             return new MissionPossibleStatus(false);
         }
 
+        // The recycle mission has to contain at least one recycler.
+        if ($units->getAmountByMachineName('recycler') === 0) {
+            return new MissionPossibleStatus(false);
+        }
+
         // Check if debris field exists on the target coordinate.
         $debrisField = app(DebrisFieldService::class);
         $debrisFieldExists = $debrisField->loadForCoordinates($targetCoordinate);

--- a/app/GameMissions/TransportMission.php
+++ b/app/GameMissions/TransportMission.php
@@ -36,6 +36,11 @@ class TransportMission extends GameMission
             return new MissionPossibleStatus(false);
         }
 
+        // If mission from and to coordinates and types are the same, the mission is not possible.
+        if ($planet->getPlanetCoordinates()->equals($targetCoordinate) && $planet->getPlanetType() === $targetType) {
+            return new MissionPossibleStatus(false);
+        }
+
         // If all checks pass, the mission is possible.
         return new MissionPossibleStatus(true);
     }

--- a/app/GameMissions/TransportMission.php
+++ b/app/GameMissions/TransportMission.php
@@ -29,9 +29,8 @@ class TransportMission extends GameMission
             return new MissionPossibleStatus(false);
         }
 
-        $targetPlanet = $this->planetServiceFactory->makeForCoordinate($targetCoordinate);
-
         // If target planet does not exist, the mission is not possible.
+        $targetPlanet = $this->planetServiceFactory->makeForCoordinate($targetCoordinate, true, $targetType);
         if ($targetPlanet === null) {
             return new MissionPossibleStatus(false);
         }

--- a/app/Models/Planet/Coordinate.php
+++ b/app/Models/Planet/Coordinate.php
@@ -27,4 +27,15 @@ class Coordinate
     {
         return $this->galaxy . ':' . $this->system . ':' . $this->position;
     }
+
+    /**
+     * Returns true if the coordinate is equal to another coordinate.
+     *
+     * @param Coordinate $coordinate
+     * @return bool
+     */
+    public function equals(Coordinate $coordinate): bool
+    {
+        return $this->galaxy === $coordinate->galaxy && $this->system === $coordinate->system && $this->position === $coordinate->position;
+    }
 }

--- a/resources/views/ingame/fleet/index.blade.php
+++ b/resources/views/ingame/fleet/index.blade.php
@@ -223,7 +223,7 @@
                 "galaxy": {{ $planet->getPlanetCoordinates()->galaxy }},
                 "system": {{ $planet->getPlanetCoordinates()->system }},
                 "position": {{ $planet->getPlanetCoordinates()->position }},
-                "type": 1,
+                "type": {{ $planet->getPlanetType() }},
                 "name": "{{ $planet->getPlanetName() }}"
             };
             var targetPlanet = {
@@ -231,7 +231,7 @@
                 "system": {{ $system ?? $planet->getPlanetCoordinates()->system }},
                 "position": {{ $position ?? $planet->getPlanetCoordinates()->position }},
                 "type": {{ $type ?? 1 }},
-                "name": "{{ $planet->getPlanetName() }}"
+                "name": "Target"
             };
             var shipsOnPlanet = [@foreach ($units as $unitGroup)@foreach ($unitGroup as $unit)@if($unit->amount > 0){
                 "id": {{ $unit->object->id }},
@@ -243,7 +243,7 @@
                 "galaxy": {{ $planet->getPlanetCoordinates()->galaxy }},
                 "system": {{ $planet->getPlanetCoordinates()->system }},
                 "position": {{ $planet->getPlanetCoordinates()->position }},
-                "type": 1,
+                "type": {{ $planet->getPlanetType() }},
                 "name": "{{ $planet->getPlanetName() }}"
             }];
             var standardFleets = [];

--- a/tests/FleetDispatchTestCase.php
+++ b/tests/FleetDispatchTestCase.php
@@ -115,6 +115,20 @@ abstract class FleetDispatchTestCase extends MoonTestCase
     }
 
     /**
+     * Send a fleet to the first planet debris field of the test user.
+     *
+     * @param UnitCollection $units
+     * @param Resources $resources
+     * @param int $assertStatus
+     * @return void
+     */
+    protected function sendMissionToFirstPlanetDebrisField(UnitCollection $units, Resources $resources, int $assertStatus = 200): void
+    {
+        $coordinates = $this->planetService->getPlanetCoordinates();
+        $this->dispatchFleet($coordinates, $units, $resources, PlanetType::DebrisField, $assertStatus);
+    }
+
+    /**
      * Send a fleet to the second planet debris field of the test user.
      *
      * @param UnitCollection $units


### PR DESCRIPTION
## Description
Fixes issues:
- Fleet mission could be sent to current planet itself. This did not throw an error but it should not be possible.
- Fleet mission could be sent towards a non-existent moon. Issue was caused by the fleet mission planet exists check that did not include optional param `planet type`.

### Type of Change:
- [x] Bug fix

## Related Issues
Fixes #599

## Checklist

Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [x] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [x] **Static Analysis:** Code passes PHPStan static code analysis.
- [x] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.

- [x] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [x] **Documentation:** Documentation has been updated to reflect any changes made.
