### PR TITLE
fix: tooltip on ship units

### DIFF
--- a/resources/views/ingame/ajax/object.blade.php
+++ b/resources/views/ingame/ajax/object.blade.php
@@ -185,7 +185,7 @@
                 <div class="ipiHintable" data-ipi-hint="ipiTechnologyUpgradedeuteriumSynthesizer">
                     <button class="upgrade"
                             @php
-                                $disabled_shipyard_upgrading = $object->type == \OGame\GameObjects\Models\Enums\GameObjectType::Ship || $object->type == \OGame\GameObjects\Models\Enums\GameObjectType::Defense  && $shipyard_upgrading;
+                                $disabled_shipyard_upgrading = ($object->type == \OGame\GameObjects\Models\Enums\GameObjectType::Ship || $object->type == \OGame\GameObjects\Models\Enums\GameObjectType::Defense) && $shipyard_upgrading;
                                 $ships_being_built = $object->machine_name == 'shipyard' && $ship_or_defense_in_progress;
                             @endphp
                                     


### PR DESCRIPTION
## Description
![image](https://github.com/user-attachments/assets/7227d9c4-687c-4d00-9f9e-d17ca7932952)
I noticed without building a shipyard, I would get the above tooltip only on ship units

### Type of Change:
- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

Introduced via https://github.com/lanedirt/OGameX/pull/606, minor but wanted to resolve.