### PR TITLE
fix : Ensure galaxy,  system, position and type available

### DIFF
--- a/public/js/ingame.js
+++ b/public/js/ingame.js
@@ -76903,6 +76903,12 @@ FleetDispatcher.prototype.fetchTargetPlayerData = function () {
     params.recycler = 1;
   }
 
+    // Ensure all our params are existent, otherwise no point posting the data.
+    if (!params.galaxy || !params.system || !params.position || !params.type) {
+        this.stopLoading();
+        return;
+    }
+
   $.post(this.checkTargetUrl, params, function (data) {
     let status = data.status || 'failure';
     $("#additionalFleetSpeedInfo").html(data.additionalFlightSpeedinfo);

--- a/public/js/ingame.min.js
+++ b/public/js/ingame.min.js
@@ -76903,6 +76903,12 @@ FleetDispatcher.prototype.fetchTargetPlayerData = function () {
     params.recycler = 1;
   }
 
+    // Ensure all our params are existent, otherwise no point posting the data.
+    if (!params.galaxy || !params.system || !params.position || !params.type) {
+        this.stopLoading();
+        return;
+    }
+
   $.post(this.checkTargetUrl, params, function (data) {
     let status = data.status || 'failure';
     $("#additionalFleetSpeedInfo").html(data.additionalFlightSpeedinfo);

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,8 +1,8 @@
 {
     "/css/ingame.css": "/css/ingame.css?id=187eb3c9a997d0496baa94d59cca9f72",
     "/css/outgame.css": "/css/outgame.css?id=0edfd34484fc3ec74eca0604a470461f",
-    "/js/ingame.js": "/js/ingame.js?id=f7ca8c70d70904454426ad83cb49783f",
-    "/js/ingame.min.js": "/js/ingame.min.js?id=f7ca8c70d70904454426ad83cb49783f",
+    "/js/ingame.js": "/js/ingame.js?id=7b486089ea4717611bbc6a457c331f3c",
+    "/js/ingame.min.js": "/js/ingame.min.js?id=7b486089ea4717611bbc6a457c331f3c",
     "/js/outgame.js": "/js/outgame.js?id=5fa6ee5cdc34001db0bdccd06a7f676c",
     "/js/outgame.min.js": "/js/outgame.min.js?id=5fa6ee5cdc34001db0bdccd06a7f676c"
 }

--- a/resources/js/ingame/e7c74974620fa35b197315ebdbb8c2.js
+++ b/resources/js/ingame/e7c74974620fa35b197315ebdbb8c2.js
@@ -47062,6 +47062,12 @@ FleetDispatcher.prototype.fetchTargetPlayerData = function () {
     params.recycler = 1;
   }
 
+    // Ensure all our params are existent, otherwise no point posting the data.
+    if (!params.galaxy || !params.system || !params.position || !params.type) {
+        this.stopLoading();
+        return;
+    }
+
   $.post(this.checkTargetUrl, params, function (data) {
     let status = data.status || 'failure';
     $("#additionalFleetSpeedInfo").html(data.additionalFlightSpeedinfo);


### PR DESCRIPTION
## Description
When using the fleet system and emptying the galaxy box for instance, if you switch from say planet to moon, it will cause an exception and forever load.  

Found this while looking into exceptions via webhook. 

This basically ensures all the params are there, otherwise it'll stop loading - this seems to make the most sense here as it's where the params are being prepared to post.


### Type of Change:
- [X] Bug fix


## Related Issues
Fixes https://github.com/lanedirt/OGameX/issues/609

## Checklist
- [X] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.