### PR TITLE
Implement techtree for requirements in popup

### DIFF
--- a/app/GameObjects/Models/Abstracts/GameObject.php
+++ b/app/GameObjects/Models/Abstracts/GameObject.php
@@ -106,4 +106,14 @@ abstract class GameObject
         }
         throw new InvalidArgumentException("Calculation method '$calculationName->value' not found.");
     }
+
+    /**
+     * Check if the object has any requirements.
+     *
+     * @return bool
+     */
+    public function hasRequirements(): bool
+    {
+        return count($this->requirements) > 0;
+    }
 }

--- a/app/GameObjects/Models/Techtree/TechtreeRequiredBy.php
+++ b/app/GameObjects/Models/Techtree/TechtreeRequiredBy.php
@@ -7,7 +7,7 @@ use OGame\GameObjects\Models\Abstracts\GameObject;
 /**
  * Class TechtreeRequiredBy
  *
- * Represents a requirement for a GameObject.
+ * Represents a requirement for a GameObject. Use to render applications GUI.
  *
  * @package OGame\GameObjects\Models
  */

--- a/app/GameObjects/Models/Techtree/TechtreeRequiredBy.php
+++ b/app/GameObjects/Models/Techtree/TechtreeRequiredBy.php
@@ -7,7 +7,7 @@ use OGame\GameObjects\Models\Abstracts\GameObject;
 /**
  * Class TechtreeRequiredBy
  *
- * Represents a requirement for a GameObject. Use to render applications GUI.
+ * Represents a requirement for a GameObject. Used to render applications GUI.
  *
  * @package OGame\GameObjects\Models
  */

--- a/app/GameObjects/Models/Techtree/TechtreeRequirement.php
+++ b/app/GameObjects/Models/Techtree/TechtreeRequirement.php
@@ -24,6 +24,11 @@ class TechtreeRequirement
     public int $column;
 
     /**
+     * @var TechtreeRequirement The parent requirement that this requirement belongs to.
+     */
+    public TechtreeRequirement|null $parent;
+
+    /**
      * @var GameObject The GameObject that is required.
      */
     public GameObject $gameObject;
@@ -43,14 +48,16 @@ class TechtreeRequirement
      *
      * @param int $depth
      * @param int $column
+     * @param TechtreeRequirement|null $parent
      * @param GameObject $gameObject
      * @param int $levelRequired
      * @param int $levelCurrent
      */
-    public function __construct(int $depth, int $column, GameObject $gameObject, int $levelRequired, int $levelCurrent)
+    public function __construct(int $depth, int $column, TechtreeRequirement|null $parent, GameObject $gameObject, int $levelRequired, int $levelCurrent)
     {
         $this->depth = $depth;
         $this->column = $column;
+        $this->parent = $parent;
         $this->gameObject = $gameObject;
         $this->levelRequired = $levelRequired;
         $this->levelCurrent = $levelCurrent;

--- a/app/GameObjects/Models/Techtree/TechtreeRequirement.php
+++ b/app/GameObjects/Models/Techtree/TechtreeRequirement.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace OGame\GameObjects\Models\Techtree;
+
+use OGame\GameObjects\Models\Abstracts\GameObject;
+
+/**
+ * Class TechtreeRequirement
+ *
+ * Represents requirement that current object requires on. Used to render the tech tree graph.
+ *
+ * @package OGame\GameObjects\Models
+ */
+class TechtreeRequirement
+{
+    /**
+     * @var GameObject The GameObject that is required.
+     */
+    public GameObject $gameObject;
+
+    /**
+     * @var int The level that is required by the parent object.
+     */
+    public int $level_required;
+
+    /**
+     * @var int The level that this current object is at.
+     */
+    public int $level_current;
+
+    /**
+     * GameObjectRequirement constructor.
+     *
+     * @param GameObject $gameObject
+     * @param int $levelRequired
+     * @param int $levelCurrent
+     */
+    public function __construct(GameObject $gameObject, int $levelRequired, int $levelCurrent)
+    {
+        $this->gameObject = $gameObject;
+        $this->level_required = $levelRequired;
+        $this->level_current = $levelCurrent;
+    }
+}

--- a/app/GameObjects/Models/Techtree/TechtreeRequirement.php
+++ b/app/GameObjects/Models/Techtree/TechtreeRequirement.php
@@ -19,6 +19,11 @@ class TechtreeRequirement
     public int $depth;
 
     /**
+     * @var int The column of the requirement. All requirements that lead to the same parent should have the same column.
+     */
+    public int $column;
+
+    /**
      * @var GameObject The GameObject that is required.
      */
     public GameObject $gameObject;
@@ -36,13 +41,16 @@ class TechtreeRequirement
     /**
      * GameObjectRequirement constructor.
      *
+     * @param int $depth
+     * @param int $column
      * @param GameObject $gameObject
      * @param int $levelRequired
      * @param int $levelCurrent
      */
-    public function __construct(int $depth, GameObject $gameObject, int $levelRequired, int $levelCurrent)
+    public function __construct(int $depth, int $column, GameObject $gameObject, int $levelRequired, int $levelCurrent)
     {
         $this->depth = $depth;
+        $this->column = $column;
         $this->gameObject = $gameObject;
         $this->levelRequired = $levelRequired;
         $this->levelCurrent = $levelCurrent;

--- a/app/GameObjects/Models/Techtree/TechtreeRequirement.php
+++ b/app/GameObjects/Models/Techtree/TechtreeRequirement.php
@@ -14,6 +14,11 @@ use OGame\GameObjects\Models\Abstracts\GameObject;
 class TechtreeRequirement
 {
     /**
+     * @var int The depth of the requirement.
+     */
+    public int $depth;
+
+    /**
      * @var GameObject The GameObject that is required.
      */
     public GameObject $gameObject;
@@ -21,12 +26,12 @@ class TechtreeRequirement
     /**
      * @var int The level that is required by the parent object.
      */
-    public int $level_required;
+    public int $levelRequired;
 
     /**
      * @var int The level that this current object is at.
      */
-    public int $level_current;
+    public int $levelCurrent;
 
     /**
      * GameObjectRequirement constructor.
@@ -35,10 +40,11 @@ class TechtreeRequirement
      * @param int $levelRequired
      * @param int $levelCurrent
      */
-    public function __construct(GameObject $gameObject, int $levelRequired, int $levelCurrent)
+    public function __construct(int $depth, GameObject $gameObject, int $levelRequired, int $levelCurrent)
     {
+        $this->depth = $depth;
         $this->gameObject = $gameObject;
-        $this->level_required = $levelRequired;
-        $this->level_current = $levelCurrent;
+        $this->levelRequired = $levelRequired;
+        $this->levelCurrent = $levelCurrent;
     }
 }

--- a/app/GameObjects/StationObjects.php
+++ b/app/GameObjects/StationObjects.php
@@ -111,8 +111,8 @@ class StationObjects
         $naniteFactory->description = 'This is the ultimate in robotics technology. Each level cuts the construction time for buildings, ships, and defenses.';
         $naniteFactory->description_long = 'A nanomachine, also called a nanite, is a mechanical or electromechanical device whose dimensions are measured in nanometers (millionths of a millimeter, or units of 10^-9 meter). The microscopic size of nanomachines translates into higher operational speed. This factory produces nanomachines that are the ultimate evolution in robotics technology. Once constructed, each upgrade significantly decreases production time for buildings, ships, and defensive structures.';
         $naniteFactory->requirements = [
-            new GameObjectRequirement('robot_factory', 10),
             new GameObjectRequirement('computer_technology', 10),
+            new GameObjectRequirement('robot_factory', 10),
         ];
         $naniteFactory->price = new GameObjectPrice(1000000, 500000, 100000, 0, 2);
         $naniteFactory->valid_planet_types = [PlanetType::Planet];

--- a/app/Http/Controllers/Abstracts/AbstractBuildingsController.php
+++ b/app/Http/Controllers/Abstracts/AbstractBuildingsController.php
@@ -93,7 +93,7 @@ abstract class AbstractBuildingsController extends OGameController
                 $next_level = $current_level + 1;
 
                 // Check requirements of this building
-                $requirements_met = ObjectService::objectRequirementsMetWithQueue($object_machine_name, $next_level, $this->planet, $player);
+                $requirements_met = ObjectService::objectRequirementsMetWithQueue($object_machine_name, $next_level, $this->planet);
 
                 $valid_planet_type = ObjectService::objectValidPlanetType($object_machine_name, $this->planet);
 

--- a/app/Http/Controllers/Abstracts/AbstractUnitsController.php
+++ b/app/Http/Controllers/Abstracts/AbstractUnitsController.php
@@ -85,7 +85,7 @@ abstract class AbstractUnitsController extends OGameController
                 $amount = $planet->getObjectAmount($object->machine_name);
 
                 // Check requirements of this building
-                $requirements_met = ObjectService::objectRequirementsMet($object->machine_name, $planet, $player);
+                $requirements_met = ObjectService::objectRequirementsMet($object->machine_name, $planet);
 
                 // Check if the current planet has enough resources to build this building.
                 $enough_resources = $planet->hasResources(ObjectService::getObjectPrice($object->machine_name, $planet));

--- a/app/Http/Controllers/ResearchController.php
+++ b/app/Http/Controllers/ResearchController.php
@@ -85,7 +85,7 @@ class ResearchController extends OGameController
                 $next_level = $current_level + 1;
 
                 // Check requirements of this technology
-                $requirements_met = ObjectService::objectRequirementsMetWithQueue($object->machine_name, $next_level, $planet, $player);
+                $requirements_met = ObjectService::objectRequirementsMetWithQueue($object->machine_name, $next_level, $planet);
 
                 // Check if the current planet has enough resources to research this technology.
                 $enough_resources = $planet->hasResources(ObjectService::getObjectPrice($object->machine_name, $planet));

--- a/app/Http/Controllers/TechtreeController.php
+++ b/app/Http/Controllers/TechtreeController.php
@@ -402,7 +402,8 @@ class TechtreeController extends OGameController
      * @param PlanetService $planet
      * @return array<TechtreeRequirement>
      */
-    private function getRequirementGraph(GameObject $object, PlanetService $planet, int $depth = 1): array {
+    private function getRequirementGraph(GameObject $object, PlanetService $planet, int $depth = 1): array
+    {
         $requirement_array = [];
 
         // If we're at the beginning, add current object to requirement array as depth 0 (root) before
@@ -410,8 +411,7 @@ class TechtreeController extends OGameController
         if ($depth === 1) {
             if ($object->type === GameObjectType::Research) {
                 $object_level = $planet->getPlayer()->getResearchLevel($object->machine_name);
-            }
-            else {
+            } else {
                 $object_level = $planet->getObjectLevel($object->machine_name);
             }
             $requirement_array[] = new TechtreeRequirement(0, $object, 1, $object_level);
@@ -428,8 +428,7 @@ class TechtreeController extends OGameController
             // simplify for player/current planet combination.
             if ($object->type === GameObjectType::Research) {
                 $object_level = $planet->getPlayer()->getResearchLevel($object->machine_name);
-            }
-            else {
+            } else {
                 $object_level = $planet->getObjectLevel($object->machine_name);
             }
 

--- a/app/Http/Controllers/TechtreeController.php
+++ b/app/Http/Controllers/TechtreeController.php
@@ -438,9 +438,10 @@ class TechtreeController extends OGameController
      *
      * @param GameObject $object
      * @param PlanetService $planet
+     * @param TechtreeRequirement|null $parent
      * @return array<TechtreeRequirement>
      */
-    private function getRequirementGraph(GameObject $object, PlanetService $planet, int $depth = 1, int &$column = 0): array
+    private function getRequirementGraph(GameObject $object, PlanetService $planet, int $depth = 1, int &$column = 0, TechtreeRequirement|null $parent = null): array
     {
         $requirement_array = [];
 
@@ -451,7 +452,11 @@ class TechtreeController extends OGameController
             } else {
                 $object_level = $planet->getObjectLevel($object->machine_name);
             }
-            $requirement_array[] = new TechtreeRequirement(0, 0, $object, 1, $object_level);
+            $requirement = new TechtreeRequirement(0, 0, null, $object, 1, $object_level);
+            $requirement_array[] = $requirement;
+
+            // Set current object as parent for the loop below.
+            $parent = $requirement;
         }
 
         foreach ($object->requirements as $requirement) {
@@ -464,10 +469,11 @@ class TechtreeController extends OGameController
                 $object_level = $planet->getObjectLevel($object->machine_name);
             }
 
-            $requirement_array[] = new TechtreeRequirement($depth, $current_column, $object, $requirement->level, $object_level);
+            $requirement = new TechtreeRequirement($depth, $current_column, $parent, $object, $requirement->level, $object_level);
+            $requirement_array[] = $requirement;
 
             // Get requirements for this object recursively
-            $child_requirements = $this->getRequirementGraph($object, $planet, $depth + 1, $column);
+            $child_requirements = $this->getRequirementGraph($object, $planet, $depth + 1, $column, $requirement);
             $requirement_array = array_merge($requirement_array, $child_requirements);
         }
 

--- a/app/Http/Controllers/TechtreeController.php
+++ b/app/Http/Controllers/TechtreeController.php
@@ -27,8 +27,6 @@ class TechtreeController extends OGameController
     {
         $object_id = (int)$request->input('object_id');
         $tab = (int)$request->input('tab');
-        // TODO: is this planet still needed?
-        $planet = $player->planets->current();
 
         // Load object
         $object = ObjectService::getObjectById($object_id);
@@ -37,13 +35,11 @@ class TechtreeController extends OGameController
             return view('ingame.techtree.techtree')->with([
                 'object' => $object,
                 'object_id' => $object_id,
-                'planet' => $planet,
             ]);
         } elseif ($tab === 2) {
             return view('ingame.techtree.techinfo')->with([
                 'object' => $object,
                 'object_id' => $object_id,
-                'planet' => $planet,
                 'production_table' => $this->getProductionTable($object, $player),
                 'storage_table' => $this->getStorageTable($object, $player),
                 'rapidfire_table' => $this->getRapidfireTable($object),
@@ -55,14 +51,12 @@ class TechtreeController extends OGameController
             return view('ingame.techtree.technology')->with([
                 'object' => $object,
                 'object_id' => $object_id,
-                'planet' => $planet,
             ]);
         } elseif ($tab === 4) {
             return view('ingame.techtree.applications')->with([
                 'object' => $object,
                 'object_id' => $object_id,
-                'planet' => $planet,
-                'required_by' => $this->getRequiredBy($object, $player, $planet)
+                'required_by' => $this->getRequiredBy($object, $player->planets->current())
             ]);
         }
 
@@ -373,12 +367,14 @@ class TechtreeController extends OGameController
     }
 
     /**
+     * Returns the objects that require the given object including status if requirements have been met for current
+     * player and planet.
+     *
      * @param GameObject $object
-     * @param PlayerService $player
      * @param PlanetService $planet
      * @return array<TechtreeRequiredBy>
      */
-    private function getRequiredBy(GameObject $object, PlayerService $player, PlanetService $planet): array
+    private function getRequiredBy(GameObject $object, PlanetService $planet): array
     {
         $all_objects = ObjectService::getObjects();
         $required_by = [];
@@ -395,7 +391,7 @@ class TechtreeController extends OGameController
         });
 
         foreach ($require_objects as $r_object) {
-            $required_by[] = new TechtreeRequiredBy($r_object, ObjectService::objectRequirementsMet($r_object->machine_name, $planet, $player));
+            $required_by[] = new TechtreeRequiredBy($r_object, ObjectService::objectRequirementsMet($r_object->machine_name, $planet));
         }
 
         return $required_by;

--- a/app/Http/Controllers/TechtreeController.php
+++ b/app/Http/Controllers/TechtreeController.php
@@ -35,12 +35,12 @@ class TechtreeController extends OGameController
         if ($tab === 1) {
             $requirement_graph = $this->getRequirementGraph($object, $player->planets->current());
 
-            // Get the amount of columns in the requirement graph by getting the highest column number
+            // Get the amount of columns in the requirement graph by getting the highest column number.
             $columns = array_column($requirement_graph, 'column');
             $amount_of_columns = !empty($columns) ? max($columns) + 1 : 1;
 
-            // Restructure requirement graph into an array with all unique items for a specific depth as a sub-array.
-            // This makes it easier to render the tech tree in the frontend.
+            // Create requirement graph array with all unique items for a specific depth as a sub-array.
+            // This makes it easier to render the tech tree in the template.
             $requirement_graph_by_depth = [];
             $items_added = [];
             foreach ($requirement_graph as $requirement) {
@@ -51,7 +51,7 @@ class TechtreeController extends OGameController
                 }
             }
 
-            // Create new unique requirements array where every requirement with a specific level
+            // Create unique requirements array where every requirement with a specific level
             // only appears once.
             $requirement_graph_unique = [];
             foreach ($requirement_graph as $requirement) {
@@ -444,7 +444,7 @@ class TechtreeController extends OGameController
             } else {
                 $object_level = $planet->getObjectLevel($object->machine_name);
             }
-            $requirement = new TechtreeRequirement(0, 0, null, $object, 1, $object_level);
+            $requirement = new TechtreeRequirement(0, 0, null, $object, 0, $object_level);
             $requirement_array[] = $requirement;
 
             // Set current object as parent for the loop below.

--- a/app/Http/Controllers/TechtreeController.php
+++ b/app/Http/Controllers/TechtreeController.php
@@ -36,21 +36,13 @@ class TechtreeController extends OGameController
             $requirement_graph = $this->getRequirementGraph($object, $player->planets->current());
 
             // Get the amount of columns in the requirement graph by getting the highest column number
-            $max_column = 0;
-            foreach ($requirement_graph as $requirement) {
-                if ($requirement->column > $max_column) {
-                    $max_column = $requirement->column;
-                }
-            }
-
-            // +1 because columns are 0-based
-            $amount_of_columns = $max_column + 1;
+            $columns = array_column($requirement_graph, 'column');
+            $amount_of_columns = !empty($columns) ? max($columns) + 1 : 1;
 
             // Restructure requirement graph into an array with all unique items for a specific depth as a sub-array.
             // This makes it easier to render the tech tree in the frontend.
             $requirement_graph_by_depth = [];
             $items_added = [];
-
             foreach ($requirement_graph as $requirement) {
                 $key = 't' . $requirement->gameObject->id . 'l' . $requirement->levelRequired;
                 if (!isset($items_added[$key])) {
@@ -70,10 +62,10 @@ class TechtreeController extends OGameController
 
             return view('ingame.techtree.techtree')->with([
                 'object' => $object,
+                'amount_of_columns' => $amount_of_columns,
                 'requirement_graph' => $requirement_graph,
                 'requirement_graph_unique' => $requirement_graph_unique,
                 'requirement_graph_by_depth' => $requirement_graph_by_depth,
-                'amount_of_columns' => $amount_of_columns,
             ]);
         } elseif ($tab === 2) {
             return view('ingame.techtree.techinfo')->with([

--- a/app/Http/Traits/ObjectAjaxTrait.php
+++ b/app/Http/Traits/ObjectAjaxTrait.php
@@ -42,7 +42,7 @@ trait ObjectAjaxTrait
         $next_level = $current_level + 1;
 
         // Check requirements of this object
-        $requirements_met = ObjectService::objectRequirementsMetWithQueue($object->machine_name, $next_level, $planet, $player);
+        $requirements_met = ObjectService::objectRequirementsMetWithQueue($object->machine_name, $next_level, $planet);
 
         // Check if the current planet has the right type to build this object.
         $valid_planet_type = ObjectService::objectValidPlanetType($object->machine_name, $planet);

--- a/app/Http/Traits/ObjectAjaxTrait.php
+++ b/app/Http/Traits/ObjectAjaxTrait.php
@@ -148,7 +148,6 @@ trait ObjectAjaxTrait
         }
 
         $view_html = view('ingame.ajax.object')->with([
-            'id' => $object_id,
             'object' => $object,
             'object_type' => $object->type,
             'planet_id' => $planet->getPlanetId(),
@@ -163,6 +162,7 @@ trait ObjectAjaxTrait
             'production_next' => $production_next,
             'energy_difference' => $energy_difference,
             'enough_resources' => $enough_resources,
+            'has_requirements' => $object->hasRequirements(),
             'requirements_met' => $requirements_met,
             'valid_planet_type' => $valid_planet_type,
             'build_active' => $build_queue->count(),

--- a/app/Services/BuildingQueueService.php
+++ b/app/Services/BuildingQueueService.php
@@ -94,7 +94,7 @@ class BuildingQueueService
 
         // Check if user satisfies requirements to build this object.
         // TODO: refactor throw exception into a more user-friendly message.
-        $requirements_met = ObjectService::objectRequirementsMetWithQueue($building->machine_name, $next_level, $planet, $planet->getPlayer());
+        $requirements_met = ObjectService::objectRequirementsMetWithQueue($building->machine_name, $next_level, $planet);
         if (!$requirements_met) {
             throw new Exception('Requirements not met to build this object.');
         }
@@ -241,7 +241,7 @@ class BuildingQueueService
 
             // Sanity check: check if the building requirements are still met. If not,
             // then cancel build request.
-            if (!ObjectService::objectRequirementsWithLevelsMet($object->machine_name, $queue_item->object_level_target, $planet, $planet->getPlayer())) {
+            if (!ObjectService::objectRequirementsWithLevelsMet($object->machine_name, $queue_item->object_level_target, $planet)) {
                 $this->cancel($planet, $queue_item->id, $queue_item->object_id);
 
                 continue;
@@ -355,7 +355,7 @@ class BuildingQueueService
         foreach ($build_queue_items as $build_queue_item) {
             $object = ObjectService::getObjectById($build_queue_item->object_id);
 
-            if (!ObjectService::objectRequirementsMetWithQueue($object->machine_name, $build_queue_item->object_level_target, $planet, $planet->getPlayer())) {
+            if (!ObjectService::objectRequirementsMetWithQueue($object->machine_name, $build_queue_item->object_level_target, $planet)) {
                 $this->cancel($planet, $build_queue_item->id, $object->id);
                 break;
             }

--- a/app/Services/PlanetService.php
+++ b/app/Services/PlanetService.php
@@ -864,7 +864,7 @@ class PlanetService
             foreach ($this->getPlayer()->planets->allPlanets() as $planet) {
                 // Check if the object's requirements are met on the planet;
                 // otherwise, the planet's research lab cannot be included in the research network.
-                if (!ObjectService::objectRequirementsMet($machine_name, $planet, $this->getPlayer())) {
+                if (!ObjectService::objectRequirementsMet($machine_name, $planet)) {
                     continue;
                 }
 

--- a/app/Services/ResearchQueueService.php
+++ b/app/Services/ResearchQueueService.php
@@ -127,7 +127,7 @@ class ResearchQueueService
 
         // Check if user satisifes requirements to research this object.
         // TODO: refactor throw exception into a more user-friendly message.
-        $requirements_met = ObjectService::objectRequirementsMetWithQueue($object->machine_name, $next_level, $planet, $planet->getPlayer());
+        $requirements_met = ObjectService::objectRequirementsMetWithQueue($object->machine_name, $next_level, $planet);
         if (!$requirements_met) {
             throw new Exception('Requirements not met to build this object.');
         }
@@ -295,7 +295,7 @@ class ResearchQueueService
 
             // Sanity check: check if the researching requirements are still met. If not,
             // then cancel research request.
-            if (!ObjectService::objectRequirementsWithLevelsMet($object->machine_name, $queue_item->object_level_target, $planet, $player)) {
+            if (!ObjectService::objectRequirementsWithLevelsMet($object->machine_name, $queue_item->object_level_target, $planet)) {
                 $this->cancel($player, $queue_item->id, $queue_item->object_id);
 
                 continue;
@@ -440,7 +440,7 @@ class ResearchQueueService
         foreach ($research_queue_items as $research_queue_item) {
             $object = ObjectService::getObjectById($research_queue_item->object_id);
 
-            if (!ObjectService::objectRequirementsMetWithQueue($object->machine_name, $research_queue_item->object_level_target, $planet, $player)) {
+            if (!ObjectService::objectRequirementsMetWithQueue($object->machine_name, $research_queue_item->object_level_target, $planet)) {
                 $this->cancel($player, $research_queue_item->id, $object->id);
                 break;
             }

--- a/app/Services/UnitQueueService.php
+++ b/app/Services/UnitQueueService.php
@@ -166,7 +166,7 @@ class UnitQueueService
         $object = ObjectService::getUnitObjectById($object_id);
 
         // Check if user satisifes requirements to build this object.
-        $requirements_met = ObjectService::objectRequirementsMet($object->machine_name, $planet, $planet->getPlayer());
+        $requirements_met = ObjectService::objectRequirementsMet($object->machine_name, $planet);
 
         // Sanity check: check if the planet has enough resources to build
         // the amount requested. If not, then adjust the ordered amount.

--- a/public/js/ingame.js
+++ b/public/js/ingame.js
@@ -71599,9 +71599,17 @@ function drawArrows(id) {
   $.each(endpoints, function () {
     var $elem = $techtree.find(".tech" + this.toString());
     newTree.addEndpoint($elem);
-    var elemLeft = Math.floor($elem.find('a').offset().left);
-    var elemTop = Math.floor($elem.find('a').offset().top);
-    coordinates[this] = [elemLeft, elemTop];
+
+    // TODO OGAMEX: without this additional if check, the techtree throws errors.
+    var elemOffset = $elem.find('a').offset();
+    if (elemOffset) {
+      var elemLeft = Math.floor(elemOffset.left);
+      var elemTop = Math.floor(elemOffset.top);
+      coordinates[this] = [elemLeft, elemTop];
+    }
+    else {
+      coordinates[this] = [0, 0];
+    }
   });
   var changedSomething;
 
@@ -71613,13 +71621,24 @@ function drawArrows(id) {
       var $source = $techtree.find(".tech" + this.source + " a");
       var $target = $techtree.find(".tech" + this.target + " a");
 
-      if ($source.offset().top >= $target.offset().top - 10 && $source.offset().top <= $target.offset().top + 10) {
+      // TODO OGAMEX: without this additional if check, the techtree throws errors.
+      var sourceOffset = $source.offset();
+      var targetOffset = $target.offset();
+
+      if (sourceOffset == undefined || targetOffset == undefined) {
+        return;
+      }
+
+      if (sourceOffset.top >= targetOffset.top - 10 && sourceOffset.top <= targetOffset.top + 10) {
         $source.parent().css('margin-top', parseInt($source.parent().css('margin-top').replace(/px/, '')) + rowHeight); // we just moved a tech downwards... we have to adjust all corresponding coordinates
         // the surrounding div with class depth* is the second parent
 
         $source.parent().parent().find('a[data-tech-id]').each(function () {
-          coordinates[$(this).attr('data-tech-id')][1] += rowHeight; // 1 == top
-          //console.log("RESET "+$(this).attr('data-tech-id') + " "+(coordinates[$(this).attr('data-tech-id')][1]));
+          // TODO OGAMEX: without this additional if check, the techtree throws errors.
+          if (coordinates[$(this).attr('data-tech-id')]) {
+            coordinates[$(this).attr('data-tech-id')][1] += rowHeight; // 1 == top
+            //console.log("RESET "+$(this).attr('data-tech-id') + " "+(coordinates[$(this).attr('data-tech-id')][1]));
+          }
         });
         changedSomething = true;
       }
@@ -71740,24 +71759,30 @@ function drawArrows(id) {
 
     if (translated[this.target].left < translated[this.source].left) {
       // target is left of the source
-      if (!lineInCoordinatesBlocked(translated, translated[this.source].left, translated[this.source].top, translated[this.source].left, translated[this.target].top) && !positionInCoordinatesBlocked(translated, translated[this.source].left, translated[this.target].top) && !lineInCoordinatesBlocked(translated, translated[this.source].left, translated[this.target].top, translated[this.target].left, translated[this.target].top)) {
+      // TODO OGAMEX: uncommented this because it throws errors while drawing the techtree.
+      // Even with identical HTML to the original game, it still doesn't work for certain
+      // complicated tech trees.
+      /*if (!lineInCoordinatesBlocked(translated, translated[this.source].left, translated[this.source].top, translated[this.source].left, translated[this.target].top) && !positionInCoordinatesBlocked(translated, translated[this.source].left, translated[this.target].top) && !lineInCoordinatesBlocked(translated, translated[this.source].left, translated[this.target].top, translated[this.target].left, translated[this.target].top)) {
         // vertical, horizontal
         connectOptions.anchors = [chooseAnchor(this.source, 'top', topAnchors, alreadyUsedAnchors), chooseAnchor(this.target, 'right', rightAnchors, alreadyUsedAnchors)]; //console.log("chose top right");
       } else {
         // horizontal, vertical
         connectOptions.anchors = [chooseAnchor(this.source, 'left', leftAnchors, alreadyUsedAnchors), chooseAnchor(this.target, 'bottom', bottomAnchors, alreadyUsedAnchors)];
         connectOptions.overlays[1][1] = readableVersionOfLabel(connectOptions.overlays[1][1], alreadyUsedAnchors[this.target].bottom); //console.log("chose left bottom");
-      }
+      }*/
     } else if (translated[this.target].left > translated[this.source].left) {
       // target is right of the source
-      if (!lineInCoordinatesBlocked(translated, translated[this.source].left, translated[this.source].top, translated[this.source].left, translated[this.target].top) && !positionInCoordinatesBlocked(translated, translated[this.source].left, translated[this.target].top) && !lineInCoordinatesBlocked(translated, translated[this.source].left, translated[this.target].top, translated[this.target].left, translated[this.target].top)) {
+      // TODO OGAMEX: uncommented this because it throws errors while drawing the techtree.
+      // Even with identical HTML to the original game, it still doesn't work for certain
+      // complicated tech trees.
+      /*if (!lineInCoordinatesBlocked(translated, translated[this.source].left, translated[this.source].top, translated[this.source].left, translated[this.target].top) && !positionInCoordinatesBlocked(translated, translated[this.source].left, translated[this.target].top) && !lineInCoordinatesBlocked(translated, translated[this.source].left, translated[this.target].top, translated[this.target].left, translated[this.target].top)) {
         // vertical, horizontal
         connectOptions.anchors = [chooseAnchor(this.source, 'top', topAnchors, alreadyUsedAnchors), chooseAnchor(this.target, 'left', leftAnchors, alreadyUsedAnchors)]; //console.log("chose top left");
       } else {
         // horizontal, vertical
         connectOptions.anchors = [chooseAnchor(this.source, 'right', rightAnchors, alreadyUsedAnchors), chooseAnchor(this.target, 'bottom', bottomAnchors, alreadyUsedAnchors)];
         connectOptions.overlays[1][1] = readableVersionOfLabel(connectOptions.overlays[1][1], alreadyUsedAnchors[this.target].bottom); //console.log("chose right bottom");
-      }
+      }*/
     } else {
       // target is above the source
       if (translated[this.target].top < translated[this.source].top - 1 && lineInCoordinatesBlocked(translated, translated[this.source].left, translated[this.source].top, translated[this.target].left, translated[this.target].top)) {
@@ -71772,7 +71797,6 @@ function drawArrows(id) {
         connectOptions.overlays[1][1] = readableVersionOfLabel(connectOptions.overlays[1][1], alreadyUsedAnchors[this.target].bottom); //console.log("chose top bottom");
       }
     } // else: default.
-
 
     newTree.connect(connectOptions);
   });
@@ -78322,20 +78346,20 @@ function getActivityStar(data) {
   }
 
   if (data.showMinutes && data.showActivity === 60) {
-    return `<div class="activity showMinutes tooltip js_hideTipOnMobile hideTooltipOnMouseenter" 
+    return `<div class="activity showMinutes tooltip js_hideTipOnMobile hideTooltipOnMouseenter"
                 title="${loca.LOCA_ALL_ACTIVITY}">
                 ${data.idleTime}
             </div>`;
   }
 
-  return `<div class="activity minute${data.showActivity} tooltip js_hideTipOnMobile hideTooltipOnMouseenter" 
+  return `<div class="activity minute${data.showActivity} tooltip js_hideTipOnMobile hideTooltipOnMouseenter"
             title="${loca.LOCA_ALL_ACTIVITY}">
         </div>`;
 }
 
 function addFleetContainer(planetPosition, planetType) {
-  return `<div id="ownFleetStatus_${planetPosition}_${planetType}" 
-            class="fleetAction js_hideTipOnMobile hideTooltipOnMouseenter" 
+  return `<div id="ownFleetStatus_${planetPosition}_${planetType}"
+            class="fleetAction js_hideTipOnMobile hideTooltipOnMouseenter"
             title="">
         </div>`;
 }
@@ -78431,7 +78455,7 @@ function getPlanetOrMoonTooltipLinks(planet, galaxyContentObject, systemData) {
           let espionageMissionFunction = getEspionageMission(galaxyContentObject, planet, systemData);
 
           if (espionageMissionFunction) {
-            linkHTML += `<li><a href="#" 
+            linkHTML += `<li><a href="#"
                                 onClick="${espionageMissionFunction}">
                                 ${mission.name}
                             </a></li>`;
@@ -78450,7 +78474,7 @@ function getPlanetOrMoonTooltipLinks(planet, galaxyContentObject, systemData) {
       let holdMissionAvailable = planet.availableMissions.find(availMission => availMission.missionType === 5);
 
       if (systemData.showOutlawWarning && !systemData.isOutlaw && player.isStrong && !holdMissionAvailable) {
-        linkHTML += `<li><a href="#" 
+        linkHTML += `<li><a href="#"
                             onClick="outlawWarning(${constants.missleattack}, ${galaxy}, ${system}, ${position}, ${planet.planetType}, ${systemData.availableMissiles});return false;">
                             ${loca.LOCA_FLEET_MISSILEATTACK}
                         </a></li>`;
@@ -78510,7 +78534,7 @@ function getDebrisTooltip(planet, galaxyContentObject, systemData) {
       linkHTML += `<li><a href="${premiumLink}">${loca.LOCA_HEADER_GETADMIRAL}</a></li>`;
     }
   } else if (recyclersToSend && (position === 16 ? systemData.availablePathfinders : systemData.availableRecyclers) && planet.recyclePossible) {
-    linkHTML = `<li><a href="#" 
+    linkHTML = `<li><a href="#"
             onClick="sendShips(${8}, ${galaxyContentObject.galaxy}, ${galaxyContentObject.system}, ${galaxyContentObject.position}, ${planet.planetType}, ${recyclersToSend});return false;">
                 ${loca.LOCA_GALAXY_DEBRIS_REDUCE}
             </a></li>`;
@@ -78569,9 +78593,9 @@ function getPlayerTooltip(galaxyContentObject) {
     if (player.isAdmin) {
       buddyLink = `
                 <li>
-                    <a style="margin-top: 4px;" 
-                    href="${actions.buddies.link}" 
-                    target="_blank" title="${actions.buddies.title}" 
+                    <a style="margin-top: 4px;"
+                    href="${actions.buddies.link}"
+                    target="_blank" title="${actions.buddies.title}"
                     class="js_hideTipOnMobile no_decoration">
                         <span class="support_icon icon icon_mail" style="margin-top: 5px;"></span> &nbsp;
                         <div style="position:absolute; top: 32px;left:30px">${actions.buddies.title}</div>
@@ -78717,7 +78741,7 @@ function getEventPlanetTooltip(planet, galaxyContentObject, systemData) {
           let espionageMissionFunction = getEspionageMission(galaxyContentObject, planet, systemData);
 
           if (espionageMissionFunction) {
-            linkHTML += `<li><a href="#" 
+            linkHTML += `<li><a href="#"
                                 onClick="${espionageMissionFunction}">
                                 ${mission.name}
                             </a></li>`;
@@ -78850,8 +78874,8 @@ function getActions(galaxyContentObject, systemData) {
   } else {
     if (player.isAdmin) {
       messageLink = `
-                <a href="${actions.buddies.link}" 
-                    target="_blank" title="${actions.buddies.title}" 
+                <a href="${actions.buddies.link}"
+                    target="_blank" title="${actions.buddies.title}"
                     class="tooltip js_hideTipOnMobile icon">
                         <span class="support_icon icon icon_mail"></span>
                 </a>
@@ -78954,8 +78978,8 @@ function getEmptySlotActions(galaxyContentObject, systemData) {
                href="javascript: void(0);"
                onClick="movePlanet(
                        '${planetMove.moveLink}',
-                       {'position':${galaxyContentObject.position}, 
-                       'galaxy': ${galaxyContentObject.galaxy}, 
+                       {'position':${galaxyContentObject.position},
+                       'galaxy': ${galaxyContentObject.galaxy},
                        'system': ${galaxyContentObject.system}},
                        '${planetMove.galaxyLink}'
                        ); return false;"
@@ -78986,7 +79010,7 @@ function getDiscoveryLinkIcon(galaxyContentObject) {
     if (typeof discoverMission !== 'undefined') {
       if (discoverMission.canSend === true) {
         const titleText = galaxyLoca.discoverySend + " " + discoverMission.discoveryCount;
-        discoverLink = `<div class="planetDiscoverIcons planetDiscoverDefault icon"><a href="#" 
+        discoverLink = `<div class="planetDiscoverIcons planetDiscoverDefault icon"><a href="#"
                     class="tooltip js_hideTipOnMobile ipiHintable planetDiscover position${galaxyContentObject.position}"
                     data-ipi-hint="ipiDiscoverLifeform"
                     onClick="discoverPlanet(

--- a/public/js/ingame.min.js
+++ b/public/js/ingame.min.js
@@ -71599,9 +71599,17 @@ function drawArrows(id) {
   $.each(endpoints, function () {
     var $elem = $techtree.find(".tech" + this.toString());
     newTree.addEndpoint($elem);
-    var elemLeft = Math.floor($elem.find('a').offset().left);
-    var elemTop = Math.floor($elem.find('a').offset().top);
-    coordinates[this] = [elemLeft, elemTop];
+
+    // TODO OGAMEX: without this additional if check, the techtree throws errors.
+    var elemOffset = $elem.find('a').offset();
+    if (elemOffset) {
+      var elemLeft = Math.floor(elemOffset.left);
+      var elemTop = Math.floor(elemOffset.top);
+      coordinates[this] = [elemLeft, elemTop];
+    }
+    else {
+      coordinates[this] = [0, 0];
+    }
   });
   var changedSomething;
 
@@ -71613,13 +71621,24 @@ function drawArrows(id) {
       var $source = $techtree.find(".tech" + this.source + " a");
       var $target = $techtree.find(".tech" + this.target + " a");
 
-      if ($source.offset().top >= $target.offset().top - 10 && $source.offset().top <= $target.offset().top + 10) {
+      // TODO OGAMEX: without this additional if check, the techtree throws errors.
+      var sourceOffset = $source.offset();
+      var targetOffset = $target.offset();
+
+      if (sourceOffset == undefined || targetOffset == undefined) {
+        return;
+      }
+
+      if (sourceOffset.top >= targetOffset.top - 10 && sourceOffset.top <= targetOffset.top + 10) {
         $source.parent().css('margin-top', parseInt($source.parent().css('margin-top').replace(/px/, '')) + rowHeight); // we just moved a tech downwards... we have to adjust all corresponding coordinates
         // the surrounding div with class depth* is the second parent
 
         $source.parent().parent().find('a[data-tech-id]').each(function () {
-          coordinates[$(this).attr('data-tech-id')][1] += rowHeight; // 1 == top
-          //console.log("RESET "+$(this).attr('data-tech-id') + " "+(coordinates[$(this).attr('data-tech-id')][1]));
+          // TODO OGAMEX: without this additional if check, the techtree throws errors.
+          if (coordinates[$(this).attr('data-tech-id')]) {
+            coordinates[$(this).attr('data-tech-id')][1] += rowHeight; // 1 == top
+            //console.log("RESET "+$(this).attr('data-tech-id') + " "+(coordinates[$(this).attr('data-tech-id')][1]));
+          }
         });
         changedSomething = true;
       }
@@ -71740,24 +71759,30 @@ function drawArrows(id) {
 
     if (translated[this.target].left < translated[this.source].left) {
       // target is left of the source
-      if (!lineInCoordinatesBlocked(translated, translated[this.source].left, translated[this.source].top, translated[this.source].left, translated[this.target].top) && !positionInCoordinatesBlocked(translated, translated[this.source].left, translated[this.target].top) && !lineInCoordinatesBlocked(translated, translated[this.source].left, translated[this.target].top, translated[this.target].left, translated[this.target].top)) {
+      // TODO OGAMEX: uncommented this because it throws errors while drawing the techtree.
+      // Even with identical HTML to the original game, it still doesn't work for certain
+      // complicated tech trees.
+      /*if (!lineInCoordinatesBlocked(translated, translated[this.source].left, translated[this.source].top, translated[this.source].left, translated[this.target].top) && !positionInCoordinatesBlocked(translated, translated[this.source].left, translated[this.target].top) && !lineInCoordinatesBlocked(translated, translated[this.source].left, translated[this.target].top, translated[this.target].left, translated[this.target].top)) {
         // vertical, horizontal
         connectOptions.anchors = [chooseAnchor(this.source, 'top', topAnchors, alreadyUsedAnchors), chooseAnchor(this.target, 'right', rightAnchors, alreadyUsedAnchors)]; //console.log("chose top right");
       } else {
         // horizontal, vertical
         connectOptions.anchors = [chooseAnchor(this.source, 'left', leftAnchors, alreadyUsedAnchors), chooseAnchor(this.target, 'bottom', bottomAnchors, alreadyUsedAnchors)];
         connectOptions.overlays[1][1] = readableVersionOfLabel(connectOptions.overlays[1][1], alreadyUsedAnchors[this.target].bottom); //console.log("chose left bottom");
-      }
+      }*/
     } else if (translated[this.target].left > translated[this.source].left) {
       // target is right of the source
-      if (!lineInCoordinatesBlocked(translated, translated[this.source].left, translated[this.source].top, translated[this.source].left, translated[this.target].top) && !positionInCoordinatesBlocked(translated, translated[this.source].left, translated[this.target].top) && !lineInCoordinatesBlocked(translated, translated[this.source].left, translated[this.target].top, translated[this.target].left, translated[this.target].top)) {
+      // TODO OGAMEX: uncommented this because it throws errors while drawing the techtree.
+      // Even with identical HTML to the original game, it still doesn't work for certain
+      // complicated tech trees.
+      /*if (!lineInCoordinatesBlocked(translated, translated[this.source].left, translated[this.source].top, translated[this.source].left, translated[this.target].top) && !positionInCoordinatesBlocked(translated, translated[this.source].left, translated[this.target].top) && !lineInCoordinatesBlocked(translated, translated[this.source].left, translated[this.target].top, translated[this.target].left, translated[this.target].top)) {
         // vertical, horizontal
         connectOptions.anchors = [chooseAnchor(this.source, 'top', topAnchors, alreadyUsedAnchors), chooseAnchor(this.target, 'left', leftAnchors, alreadyUsedAnchors)]; //console.log("chose top left");
       } else {
         // horizontal, vertical
         connectOptions.anchors = [chooseAnchor(this.source, 'right', rightAnchors, alreadyUsedAnchors), chooseAnchor(this.target, 'bottom', bottomAnchors, alreadyUsedAnchors)];
         connectOptions.overlays[1][1] = readableVersionOfLabel(connectOptions.overlays[1][1], alreadyUsedAnchors[this.target].bottom); //console.log("chose right bottom");
-      }
+      }*/
     } else {
       // target is above the source
       if (translated[this.target].top < translated[this.source].top - 1 && lineInCoordinatesBlocked(translated, translated[this.source].left, translated[this.source].top, translated[this.target].left, translated[this.target].top)) {
@@ -71772,7 +71797,6 @@ function drawArrows(id) {
         connectOptions.overlays[1][1] = readableVersionOfLabel(connectOptions.overlays[1][1], alreadyUsedAnchors[this.target].bottom); //console.log("chose top bottom");
       }
     } // else: default.
-
 
     newTree.connect(connectOptions);
   });
@@ -78322,20 +78346,20 @@ function getActivityStar(data) {
   }
 
   if (data.showMinutes && data.showActivity === 60) {
-    return `<div class="activity showMinutes tooltip js_hideTipOnMobile hideTooltipOnMouseenter" 
+    return `<div class="activity showMinutes tooltip js_hideTipOnMobile hideTooltipOnMouseenter"
                 title="${loca.LOCA_ALL_ACTIVITY}">
                 ${data.idleTime}
             </div>`;
   }
 
-  return `<div class="activity minute${data.showActivity} tooltip js_hideTipOnMobile hideTooltipOnMouseenter" 
+  return `<div class="activity minute${data.showActivity} tooltip js_hideTipOnMobile hideTooltipOnMouseenter"
             title="${loca.LOCA_ALL_ACTIVITY}">
         </div>`;
 }
 
 function addFleetContainer(planetPosition, planetType) {
-  return `<div id="ownFleetStatus_${planetPosition}_${planetType}" 
-            class="fleetAction js_hideTipOnMobile hideTooltipOnMouseenter" 
+  return `<div id="ownFleetStatus_${planetPosition}_${planetType}"
+            class="fleetAction js_hideTipOnMobile hideTooltipOnMouseenter"
             title="">
         </div>`;
 }
@@ -78431,7 +78455,7 @@ function getPlanetOrMoonTooltipLinks(planet, galaxyContentObject, systemData) {
           let espionageMissionFunction = getEspionageMission(galaxyContentObject, planet, systemData);
 
           if (espionageMissionFunction) {
-            linkHTML += `<li><a href="#" 
+            linkHTML += `<li><a href="#"
                                 onClick="${espionageMissionFunction}">
                                 ${mission.name}
                             </a></li>`;
@@ -78450,7 +78474,7 @@ function getPlanetOrMoonTooltipLinks(planet, galaxyContentObject, systemData) {
       let holdMissionAvailable = planet.availableMissions.find(availMission => availMission.missionType === 5);
 
       if (systemData.showOutlawWarning && !systemData.isOutlaw && player.isStrong && !holdMissionAvailable) {
-        linkHTML += `<li><a href="#" 
+        linkHTML += `<li><a href="#"
                             onClick="outlawWarning(${constants.missleattack}, ${galaxy}, ${system}, ${position}, ${planet.planetType}, ${systemData.availableMissiles});return false;">
                             ${loca.LOCA_FLEET_MISSILEATTACK}
                         </a></li>`;
@@ -78510,7 +78534,7 @@ function getDebrisTooltip(planet, galaxyContentObject, systemData) {
       linkHTML += `<li><a href="${premiumLink}">${loca.LOCA_HEADER_GETADMIRAL}</a></li>`;
     }
   } else if (recyclersToSend && (position === 16 ? systemData.availablePathfinders : systemData.availableRecyclers) && planet.recyclePossible) {
-    linkHTML = `<li><a href="#" 
+    linkHTML = `<li><a href="#"
             onClick="sendShips(${8}, ${galaxyContentObject.galaxy}, ${galaxyContentObject.system}, ${galaxyContentObject.position}, ${planet.planetType}, ${recyclersToSend});return false;">
                 ${loca.LOCA_GALAXY_DEBRIS_REDUCE}
             </a></li>`;
@@ -78569,9 +78593,9 @@ function getPlayerTooltip(galaxyContentObject) {
     if (player.isAdmin) {
       buddyLink = `
                 <li>
-                    <a style="margin-top: 4px;" 
-                    href="${actions.buddies.link}" 
-                    target="_blank" title="${actions.buddies.title}" 
+                    <a style="margin-top: 4px;"
+                    href="${actions.buddies.link}"
+                    target="_blank" title="${actions.buddies.title}"
                     class="js_hideTipOnMobile no_decoration">
                         <span class="support_icon icon icon_mail" style="margin-top: 5px;"></span> &nbsp;
                         <div style="position:absolute; top: 32px;left:30px">${actions.buddies.title}</div>
@@ -78717,7 +78741,7 @@ function getEventPlanetTooltip(planet, galaxyContentObject, systemData) {
           let espionageMissionFunction = getEspionageMission(galaxyContentObject, planet, systemData);
 
           if (espionageMissionFunction) {
-            linkHTML += `<li><a href="#" 
+            linkHTML += `<li><a href="#"
                                 onClick="${espionageMissionFunction}">
                                 ${mission.name}
                             </a></li>`;
@@ -78850,8 +78874,8 @@ function getActions(galaxyContentObject, systemData) {
   } else {
     if (player.isAdmin) {
       messageLink = `
-                <a href="${actions.buddies.link}" 
-                    target="_blank" title="${actions.buddies.title}" 
+                <a href="${actions.buddies.link}"
+                    target="_blank" title="${actions.buddies.title}"
                     class="tooltip js_hideTipOnMobile icon">
                         <span class="support_icon icon icon_mail"></span>
                 </a>
@@ -78954,8 +78978,8 @@ function getEmptySlotActions(galaxyContentObject, systemData) {
                href="javascript: void(0);"
                onClick="movePlanet(
                        '${planetMove.moveLink}',
-                       {'position':${galaxyContentObject.position}, 
-                       'galaxy': ${galaxyContentObject.galaxy}, 
+                       {'position':${galaxyContentObject.position},
+                       'galaxy': ${galaxyContentObject.galaxy},
                        'system': ${galaxyContentObject.system}},
                        '${planetMove.galaxyLink}'
                        ); return false;"
@@ -78986,7 +79010,7 @@ function getDiscoveryLinkIcon(galaxyContentObject) {
     if (typeof discoverMission !== 'undefined') {
       if (discoverMission.canSend === true) {
         const titleText = galaxyLoca.discoverySend + " " + discoverMission.discoveryCount;
-        discoverLink = `<div class="planetDiscoverIcons planetDiscoverDefault icon"><a href="#" 
+        discoverLink = `<div class="planetDiscoverIcons planetDiscoverDefault icon"><a href="#"
                     class="tooltip js_hideTipOnMobile ipiHintable planetDiscover position${galaxyContentObject.position}"
                     data-ipi-hint="ipiDiscoverLifeform"
                     onClick="discoverPlanet(

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,8 +1,8 @@
 {
     "/css/ingame.css": "/css/ingame.css?id=187eb3c9a997d0496baa94d59cca9f72",
     "/css/outgame.css": "/css/outgame.css?id=0edfd34484fc3ec74eca0604a470461f",
-    "/js/ingame.js": "/js/ingame.js?id=7b486089ea4717611bbc6a457c331f3c",
-    "/js/ingame.min.js": "/js/ingame.min.js?id=7b486089ea4717611bbc6a457c331f3c",
+    "/js/ingame.js": "/js/ingame.js?id=ba05e4104188e0887a9eaeee60fde652",
+    "/js/ingame.min.js": "/js/ingame.min.js?id=ba05e4104188e0887a9eaeee60fde652",
     "/js/outgame.js": "/js/outgame.js?id=5fa6ee5cdc34001db0bdccd06a7f676c",
     "/js/outgame.min.js": "/js/outgame.min.js?id=5fa6ee5cdc34001db0bdccd06a7f676c"
 }

--- a/resources/js/ingame/e7c74974620fa35b197315ebdbb8c2.js
+++ b/resources/js/ingame/e7c74974620fa35b197315ebdbb8c2.js
@@ -41758,9 +41758,17 @@ function drawArrows(id) {
   $.each(endpoints, function () {
     var $elem = $techtree.find(".tech" + this.toString());
     newTree.addEndpoint($elem);
-    var elemLeft = Math.floor($elem.find('a').offset().left);
-    var elemTop = Math.floor($elem.find('a').offset().top);
-    coordinates[this] = [elemLeft, elemTop];
+
+    // TODO OGAMEX: without this additional if check, the techtree throws errors.
+    var elemOffset = $elem.find('a').offset();
+    if (elemOffset) {
+      var elemLeft = Math.floor(elemOffset.left);
+      var elemTop = Math.floor(elemOffset.top);
+      coordinates[this] = [elemLeft, elemTop];
+    }
+    else {
+      coordinates[this] = [0, 0];
+    }
   });
   var changedSomething;
 
@@ -41772,13 +41780,24 @@ function drawArrows(id) {
       var $source = $techtree.find(".tech" + this.source + " a");
       var $target = $techtree.find(".tech" + this.target + " a");
 
-      if ($source.offset().top >= $target.offset().top - 10 && $source.offset().top <= $target.offset().top + 10) {
+      // TODO OGAMEX: without this additional if check, the techtree throws errors.
+      var sourceOffset = $source.offset();
+      var targetOffset = $target.offset();
+
+      if (sourceOffset == undefined || targetOffset == undefined) {
+        return;
+      }
+
+      if (sourceOffset.top >= targetOffset.top - 10 && sourceOffset.top <= targetOffset.top + 10) {
         $source.parent().css('margin-top', parseInt($source.parent().css('margin-top').replace(/px/, '')) + rowHeight); // we just moved a tech downwards... we have to adjust all corresponding coordinates
         // the surrounding div with class depth* is the second parent
 
         $source.parent().parent().find('a[data-tech-id]').each(function () {
-          coordinates[$(this).attr('data-tech-id')][1] += rowHeight; // 1 == top
-          //console.log("RESET "+$(this).attr('data-tech-id') + " "+(coordinates[$(this).attr('data-tech-id')][1]));
+          // TODO OGAMEX: without this additional if check, the techtree throws errors.
+          if (coordinates[$(this).attr('data-tech-id')]) {
+            coordinates[$(this).attr('data-tech-id')][1] += rowHeight; // 1 == top
+            //console.log("RESET "+$(this).attr('data-tech-id') + " "+(coordinates[$(this).attr('data-tech-id')][1]));
+          }
         });
         changedSomething = true;
       }
@@ -41899,24 +41918,30 @@ function drawArrows(id) {
 
     if (translated[this.target].left < translated[this.source].left) {
       // target is left of the source
-      if (!lineInCoordinatesBlocked(translated, translated[this.source].left, translated[this.source].top, translated[this.source].left, translated[this.target].top) && !positionInCoordinatesBlocked(translated, translated[this.source].left, translated[this.target].top) && !lineInCoordinatesBlocked(translated, translated[this.source].left, translated[this.target].top, translated[this.target].left, translated[this.target].top)) {
+      // TODO OGAMEX: uncommented this because it throws errors while drawing the techtree.
+      // Even with identical HTML to the original game, it still doesn't work for certain
+      // complicated tech trees.
+      /*if (!lineInCoordinatesBlocked(translated, translated[this.source].left, translated[this.source].top, translated[this.source].left, translated[this.target].top) && !positionInCoordinatesBlocked(translated, translated[this.source].left, translated[this.target].top) && !lineInCoordinatesBlocked(translated, translated[this.source].left, translated[this.target].top, translated[this.target].left, translated[this.target].top)) {
         // vertical, horizontal
         connectOptions.anchors = [chooseAnchor(this.source, 'top', topAnchors, alreadyUsedAnchors), chooseAnchor(this.target, 'right', rightAnchors, alreadyUsedAnchors)]; //console.log("chose top right");
       } else {
         // horizontal, vertical
         connectOptions.anchors = [chooseAnchor(this.source, 'left', leftAnchors, alreadyUsedAnchors), chooseAnchor(this.target, 'bottom', bottomAnchors, alreadyUsedAnchors)];
         connectOptions.overlays[1][1] = readableVersionOfLabel(connectOptions.overlays[1][1], alreadyUsedAnchors[this.target].bottom); //console.log("chose left bottom");
-      }
+      }*/
     } else if (translated[this.target].left > translated[this.source].left) {
       // target is right of the source
-      if (!lineInCoordinatesBlocked(translated, translated[this.source].left, translated[this.source].top, translated[this.source].left, translated[this.target].top) && !positionInCoordinatesBlocked(translated, translated[this.source].left, translated[this.target].top) && !lineInCoordinatesBlocked(translated, translated[this.source].left, translated[this.target].top, translated[this.target].left, translated[this.target].top)) {
+      // TODO OGAMEX: uncommented this because it throws errors while drawing the techtree.
+      // Even with identical HTML to the original game, it still doesn't work for certain
+      // complicated tech trees.
+      /*if (!lineInCoordinatesBlocked(translated, translated[this.source].left, translated[this.source].top, translated[this.source].left, translated[this.target].top) && !positionInCoordinatesBlocked(translated, translated[this.source].left, translated[this.target].top) && !lineInCoordinatesBlocked(translated, translated[this.source].left, translated[this.target].top, translated[this.target].left, translated[this.target].top)) {
         // vertical, horizontal
         connectOptions.anchors = [chooseAnchor(this.source, 'top', topAnchors, alreadyUsedAnchors), chooseAnchor(this.target, 'left', leftAnchors, alreadyUsedAnchors)]; //console.log("chose top left");
       } else {
         // horizontal, vertical
         connectOptions.anchors = [chooseAnchor(this.source, 'right', rightAnchors, alreadyUsedAnchors), chooseAnchor(this.target, 'bottom', bottomAnchors, alreadyUsedAnchors)];
         connectOptions.overlays[1][1] = readableVersionOfLabel(connectOptions.overlays[1][1], alreadyUsedAnchors[this.target].bottom); //console.log("chose right bottom");
-      }
+      }*/
     } else {
       // target is above the source
       if (translated[this.target].top < translated[this.source].top - 1 && lineInCoordinatesBlocked(translated, translated[this.source].left, translated[this.source].top, translated[this.target].left, translated[this.target].top)) {
@@ -41931,7 +41956,6 @@ function drawArrows(id) {
         connectOptions.overlays[1][1] = readableVersionOfLabel(connectOptions.overlays[1][1], alreadyUsedAnchors[this.target].bottom); //console.log("chose top bottom");
       }
     } // else: default.
-
 
     newTree.connect(connectOptions);
   });
@@ -48481,20 +48505,20 @@ function getActivityStar(data) {
   }
 
   if (data.showMinutes && data.showActivity === 60) {
-    return `<div class="activity showMinutes tooltip js_hideTipOnMobile hideTooltipOnMouseenter" 
+    return `<div class="activity showMinutes tooltip js_hideTipOnMobile hideTooltipOnMouseenter"
                 title="${loca.LOCA_ALL_ACTIVITY}">
                 ${data.idleTime}
             </div>`;
   }
 
-  return `<div class="activity minute${data.showActivity} tooltip js_hideTipOnMobile hideTooltipOnMouseenter" 
+  return `<div class="activity minute${data.showActivity} tooltip js_hideTipOnMobile hideTooltipOnMouseenter"
             title="${loca.LOCA_ALL_ACTIVITY}">
         </div>`;
 }
 
 function addFleetContainer(planetPosition, planetType) {
-  return `<div id="ownFleetStatus_${planetPosition}_${planetType}" 
-            class="fleetAction js_hideTipOnMobile hideTooltipOnMouseenter" 
+  return `<div id="ownFleetStatus_${planetPosition}_${planetType}"
+            class="fleetAction js_hideTipOnMobile hideTooltipOnMouseenter"
             title="">
         </div>`;
 }
@@ -48590,7 +48614,7 @@ function getPlanetOrMoonTooltipLinks(planet, galaxyContentObject, systemData) {
           let espionageMissionFunction = getEspionageMission(galaxyContentObject, planet, systemData);
 
           if (espionageMissionFunction) {
-            linkHTML += `<li><a href="#" 
+            linkHTML += `<li><a href="#"
                                 onClick="${espionageMissionFunction}">
                                 ${mission.name}
                             </a></li>`;
@@ -48609,7 +48633,7 @@ function getPlanetOrMoonTooltipLinks(planet, galaxyContentObject, systemData) {
       let holdMissionAvailable = planet.availableMissions.find(availMission => availMission.missionType === 5);
 
       if (systemData.showOutlawWarning && !systemData.isOutlaw && player.isStrong && !holdMissionAvailable) {
-        linkHTML += `<li><a href="#" 
+        linkHTML += `<li><a href="#"
                             onClick="outlawWarning(${constants.missleattack}, ${galaxy}, ${system}, ${position}, ${planet.planetType}, ${systemData.availableMissiles});return false;">
                             ${loca.LOCA_FLEET_MISSILEATTACK}
                         </a></li>`;
@@ -48669,7 +48693,7 @@ function getDebrisTooltip(planet, galaxyContentObject, systemData) {
       linkHTML += `<li><a href="${premiumLink}">${loca.LOCA_HEADER_GETADMIRAL}</a></li>`;
     }
   } else if (recyclersToSend && (position === 16 ? systemData.availablePathfinders : systemData.availableRecyclers) && planet.recyclePossible) {
-    linkHTML = `<li><a href="#" 
+    linkHTML = `<li><a href="#"
             onClick="sendShips(${8}, ${galaxyContentObject.galaxy}, ${galaxyContentObject.system}, ${galaxyContentObject.position}, ${planet.planetType}, ${recyclersToSend});return false;">
                 ${loca.LOCA_GALAXY_DEBRIS_REDUCE}
             </a></li>`;
@@ -48728,9 +48752,9 @@ function getPlayerTooltip(galaxyContentObject) {
     if (player.isAdmin) {
       buddyLink = `
                 <li>
-                    <a style="margin-top: 4px;" 
-                    href="${actions.buddies.link}" 
-                    target="_blank" title="${actions.buddies.title}" 
+                    <a style="margin-top: 4px;"
+                    href="${actions.buddies.link}"
+                    target="_blank" title="${actions.buddies.title}"
                     class="js_hideTipOnMobile no_decoration">
                         <span class="support_icon icon icon_mail" style="margin-top: 5px;"></span> &nbsp;
                         <div style="position:absolute; top: 32px;left:30px">${actions.buddies.title}</div>
@@ -48876,7 +48900,7 @@ function getEventPlanetTooltip(planet, galaxyContentObject, systemData) {
           let espionageMissionFunction = getEspionageMission(galaxyContentObject, planet, systemData);
 
           if (espionageMissionFunction) {
-            linkHTML += `<li><a href="#" 
+            linkHTML += `<li><a href="#"
                                 onClick="${espionageMissionFunction}">
                                 ${mission.name}
                             </a></li>`;
@@ -49009,8 +49033,8 @@ function getActions(galaxyContentObject, systemData) {
   } else {
     if (player.isAdmin) {
       messageLink = `
-                <a href="${actions.buddies.link}" 
-                    target="_blank" title="${actions.buddies.title}" 
+                <a href="${actions.buddies.link}"
+                    target="_blank" title="${actions.buddies.title}"
                     class="tooltip js_hideTipOnMobile icon">
                         <span class="support_icon icon icon_mail"></span>
                 </a>
@@ -49113,8 +49137,8 @@ function getEmptySlotActions(galaxyContentObject, systemData) {
                href="javascript: void(0);"
                onClick="movePlanet(
                        '${planetMove.moveLink}',
-                       {'position':${galaxyContentObject.position}, 
-                       'galaxy': ${galaxyContentObject.galaxy}, 
+                       {'position':${galaxyContentObject.position},
+                       'galaxy': ${galaxyContentObject.galaxy},
                        'system': ${galaxyContentObject.system}},
                        '${planetMove.galaxyLink}'
                        ); return false;"
@@ -49145,7 +49169,7 @@ function getDiscoveryLinkIcon(galaxyContentObject) {
     if (typeof discoverMission !== 'undefined') {
       if (discoverMission.canSend === true) {
         const titleText = galaxyLoca.discoverySend + " " + discoverMission.discoveryCount;
-        discoverLink = `<div class="planetDiscoverIcons planetDiscoverDefault icon"><a href="#" 
+        discoverLink = `<div class="planetDiscoverIcons planetDiscoverDefault icon"><a href="#"
                     class="tooltip js_hideTipOnMobile ipiHintable planetDiscover position${galaxyContentObject.position}"
                     data-ipi-hint="ipiDiscoverLifeform"
                     onClick="discoverPlanet(

--- a/resources/views/ingame/ajax/object.blade.php
+++ b/resources/views/ingame/ajax/object.blade.php
@@ -4,7 +4,7 @@
     <div class="sprite sprite_large building {{ $object->class_name }}">
         @if ($has_requirements)
             <button class="technology_tree  tooltip js_hideTipOnMobile overlay ipiHintable"
-                    aria-label="Open techtree"
+                    aria-label="@lang('Open techtree')"
                     data-target="{{ route('techtree.ajax', ['tab' => 1, 'object_id' => $object->id]) }}"
                     data-ipi-hint="ipiTechnologyTreefusionPlant"
                     data-tooltip-title="Open techtree">
@@ -12,9 +12,9 @@
             </button>
         @else
             <button class="technology_tree no_prerequisites tooltip js_hideTipOnMobile overlay ipiHintable"
-                    aria-label="Open techtree" title="No requirements available"
+                    aria-label="@lang('Open techtree')" title="@lang('No requirements available')"
                     data-target="{{ route('techtree.ajax', ['tab' => 1, 'object_id' => $object->id]) }}"
-                    data-ipi-hint="ipiTechnologyTreedeuteriumSynthesizer"> Techtree
+                    data-ipi-hint="ipiTechnologyTreedeuteriumSynthesizer"> @lang('Techtree')
             </button>
         @endif
 
@@ -32,7 +32,7 @@
         <div class="information">
             <span class="level"
                   data-value="{{ $next_level }}">
-                Level {!! $current_level !!}
+                @lang('Level') {!! $current_level !!}
             </span>
             <ul class="narrow">
 

--- a/resources/views/ingame/ajax/object.blade.php
+++ b/resources/views/ingame/ajax/object.blade.php
@@ -2,11 +2,22 @@
 
 <div id="technologydetails" data-technology-id="3">
     <div class="sprite sprite_large building {{ $object->class_name }}">
-        <button class="technology_tree no_prerequisites tooltip js_hideTipOnMobile overlay ipiHintable"
-                aria-label="open techtree" title="No requirements available"
-                data-target="{{ route('techtree.ajax', ['tab' => 4, 'object_id' => $id]) }}"
-                data-ipi-hint="ipiTechnologyTreedeuteriumSynthesizer"> techtree
-        </button>
+        @if ($has_requirements)
+            <button class="technology_tree  tooltip js_hideTipOnMobile overlay ipiHintable"
+                    aria-label="Open techtree"
+                    data-target="{{ route('techtree.ajax', ['tab' => 1, 'object_id' => $object->id]) }}"
+                    data-ipi-hint="ipiTechnologyTreefusionPlant"
+                    data-tooltip-title="Open techtree">
+                Techtree
+            </button>
+        @else
+            <button class="technology_tree no_prerequisites tooltip js_hideTipOnMobile overlay ipiHintable"
+                    aria-label="Open techtree" title="No requirements available"
+                    data-target="{{ route('techtree.ajax', ['tab' => 1, 'object_id' => $object->id]) }}"
+                    data-ipi-hint="ipiTechnologyTreedeuteriumSynthesizer"> Techtree
+            </button>
+        @endif
+
         @if ($object_type == \OGame\GameObjects\Models\Enums\GameObjectType::Building || $object_type == \OGame\GameObjects\Models\Enums\GameObjectType::Station || $object_type == \OGame\GameObjects\Models\Enums\GameObjectType::Research)
             @if (!empty($build_active_current) && $build_active_current->object->id == $object->id)
                 <a role="button" href="javascript:void(0);" class="tooltip abort_link js_hideTipOnMobile" title="" onclick="cancelbuilding({{ $object->id }},{{ $build_active_current->id }},'Cancel expansion of {{ $object->title }} to level {{ $build_active_current->level_target }}?'); return false;"></a>
@@ -188,7 +199,7 @@
                                 $disabled_shipyard_upgrading = ($object->type == \OGame\GameObjects\Models\Enums\GameObjectType::Ship || $object->type == \OGame\GameObjects\Models\Enums\GameObjectType::Defense) && $shipyard_upgrading;
                                 $ships_being_built = $object->machine_name == 'shipyard' && $ship_or_defense_in_progress;
                             @endphp
-                                    
+
                             @if (!$enough_resources || !$requirements_met || !$valid_planet_type || $build_queue_max || !$max_build_amount || $research_lab_upgrading || ($object->machine_name === 'research_lab' && $research_in_progress || $disabled_shipyard_upgrading || $ships_being_built))
                                 disabled
                             @else
@@ -238,7 +249,7 @@
         @endif
         <div class="txt_box">
             <button class="details tooltip js_hideTipOnMobile overlay" aria-label="@lang('More details')" title="@lang('More details')"
-                    data-target="{{ route('techtree.ajax', ['tab' => 2, 'object_id' => $id]) }}"
+                    data-target="{{ route('techtree.ajax', ['tab' => 2, 'object_id' => $object->id]) }}"
                     data-overlay-title="{{ $title }}"> ?
             </button>
             <span class="text">

--- a/resources/views/ingame/techtree/applications.blade.php
+++ b/resources/views/ingame/techtree/applications.blade.php
@@ -2,7 +2,7 @@
     @include('ingame.techtree.partials.nav', ['currentAction' => 'applications', 'objectId' => $object->id])
 
     <div class="content applications">
-        <p class="hint">{{$object->title}} is a requirement for:</p>
+        <p class="hint">{{$object->title}} @lang('is a requirement for'):</p>
         <ul class="applications">
             @php /** @var OGame\GameObjects\Models\Techtree\TechtreeRequiredBy $required */ @endphp
             @foreach ($required_by as $required)
@@ -13,8 +13,6 @@
             @endforeach
         </ul>
     </div>
-    <script>
-    </script>
 </div>
 
 <script type="text/javascript">

--- a/resources/views/ingame/techtree/applications.blade.php
+++ b/resources/views/ingame/techtree/applications.blade.php
@@ -1,29 +1,5 @@
-
 <div id="technologytree" data-title="@lang('Technology') - {{ $object->title }}">
-    <nav data-current-action="applications">
-        <ul>
-            <li>
-                <a class="overlay" data-action="technologytree" data-overlay-same="true" href="{{ route('techtree.ajax', ['tab' => 1, 'object_id' => $object->id]) }}">
-                    @lang('Techtree')
-                </a>
-            </li>
-            <li>
-                <a class="overlay" data-action="applications" data-overlay-same="true" href="{{ route('techtree.ajax', ['tab' => 4, 'object_id' => $object->id]) }}">
-                    @lang('Applications')
-                </a>
-            </li>
-            <li>
-                <a class="overlay" data-action="technologyinformation" data-overlay-same="true" href="{{ route('techtree.ajax', ['tab' => 2, 'object_id' => $object->id]) }}">
-                    @lang('Techinfo')
-                </a>
-            </li>
-            <li>
-                <a class="overlay" data-action="technologies" data-overlay-same="true" href="{{ route('techtree.ajax', ['tab' => 3, 'object_id' => $object->id]) }}">
-                    @lang('Technology')
-                </a>
-            </li>
-        </ul>
-    </nav>
+    @include('ingame.techtree.partials.nav', ['currentAction' => 'applications', 'objectId' => $object->id])
 
     <div class="content applications">
         <p class="hint">{{$object->title}} is a requirement for:</p>

--- a/resources/views/ingame/techtree/partials/nav.blade.php
+++ b/resources/views/ingame/techtree/partials/nav.blade.php
@@ -1,0 +1,25 @@
+{{-- Techtree Navigation Component --}}
+<nav data-current-action="{{ $currentAction }}">
+    <ul>
+        <li>
+            <a class="overlay" data-action="technologytree" data-overlay-same="true" href="{{ route('techtree.ajax', ['tab' => 1, 'object_id' => $objectId]) }}">
+                @lang('Techtree')
+            </a>
+        </li>
+        <li>
+            <a class="overlay" data-action="applications" data-overlay-same="true" href="{{ route('techtree.ajax', ['tab' => 4, 'object_id' => $objectId]) }}">
+                @lang('Applications')
+            </a>
+        </li>
+        <li>
+            <a class="overlay" data-action="technologyinformation" data-overlay-same="true" href="{{ route('techtree.ajax', ['tab' => 2, 'object_id' => $objectId]) }}">
+                @lang('Techinfo')
+            </a>
+        </li>
+        <li>
+            <a class="overlay" data-action="technologies" data-overlay-same="true" href="{{ route('techtree.ajax', ['tab' => 3, 'object_id' => $objectId]) }}">
+                @lang('Technology')
+            </a>
+        </li>
+    </ul>
+</nav>

--- a/resources/views/ingame/techtree/partials/techtree_node.blade.php
+++ b/resources/views/ingame/techtree/partials/techtree_node.blade.php
@@ -5,7 +5,7 @@
 
 {{-- Techtree node component --}}
 <div class="techtreeNode">
-    <div class="techImage js_hideTipOnMobile tooltipHTML tech{{ $object->id }} techt{{ $object->id }}l{{ $required_level }} built" title="{{ $object->title }} @lang('Level') ({{ $required_level }})|{{ $object->description }}">
+    <div class="techImage js_hideTipOnMobile tooltipHTML tech{{ $object->id }} techt{{ $object->id }}l{{ $required_level }} {{ $current_level >= $required_level ? 'built' : 'notBuilt' }}" title="{{ $object->title }} @lang('Level') ({{ $required_level }})|{{ $object->description }}">
         <a href="{{ route('techtree.ajax', ['tab' => 1, 'object_id' => $object->id]) }}"
            class="sprite sprite_small small overlay {{ $object->class_name }} hasRequirements"
            data-overlay-same="true"

--- a/resources/views/ingame/techtree/partials/techtree_node.blade.php
+++ b/resources/views/ingame/techtree/partials/techtree_node.blade.php
@@ -5,7 +5,7 @@
 
 {{-- Techtree node component --}}
 <div class="techtreeNode">
-    <div class="techImage js_hideTipOnMobile tooltipHTML tech{{ $object->id }} techt{{ $object->id }}l1 built" title="{{ $object->title }} @lang('Level') ({{ $required_level }})|{{ $object->description }}">
+    <div class="techImage js_hideTipOnMobile tooltipHTML tech{{ $object->id }} techt{{ $object->id }}l{{ $required_level }} built" title="{{ $object->title }} @lang('Level') ({{ $required_level }})|{{ $object->description }}">
         <a href="{{ route('techtree.ajax', ['tab' => 1, 'object_id' => $object->id]) }}"
            class="sprite sprite_small small overlay {{ $object->class_name }} hasRequirements"
            data-overlay-same="true"

--- a/resources/views/ingame/techtree/partials/techtree_node.blade.php
+++ b/resources/views/ingame/techtree/partials/techtree_node.blade.php
@@ -1,0 +1,17 @@
+@php
+    use OGame\GameObjects\Models\Enums\GameObjectType;
+    /** @var OGame\GameObjects\Models\Abstracts\GameObject $object */
+@endphp
+
+{{-- Techtree node component --}}
+<div class="techtreeNode">
+    <div class="techImage js_hideTipOnMobile tooltipHTML tech{{ $object->id }} techt{{ $object->id }}l1 built" title="{{ $object->title }} @lang('Level') ({{ $required_level }})|{{ $object->description }}">
+        <a href="{{ route('techtree.ajax', ['tab' => 1, 'object_id' => $object->id]) }}"
+           class="sprite sprite_small small overlay {{ $object->class_name }} hasRequirements"
+           data-overlay-same="true"
+           data-tech-id="{{ $object->id }}"
+           data-tech-name="{{ $object->title }}"
+           data-tech-type="{{ $object->type === GameObjectType::Research ? 'Type Research' : 'Type Buildings' }}">
+           </a>
+    </div>
+</div>

--- a/resources/views/ingame/techtree/partials/techtree_node.blade.php
+++ b/resources/views/ingame/techtree/partials/techtree_node.blade.php
@@ -7,7 +7,7 @@
 <div class="techtreeNode">
     <div class="techImage js_hideTipOnMobile tooltipHTML tech{{ $object->id }} techt{{ $object->id }}l{{ $required_level }} {{ $current_level >= $required_level ? 'built' : 'notBuilt' }}" title="{{ $object->title }} @lang('Level') ({{ $required_level }})|{{ $object->description }}">
         <a href="{{ route('techtree.ajax', ['tab' => 1, 'object_id' => $object->id]) }}"
-           class="sprite sprite_small small overlay {{ $object->class_name }} hasRequirements"
+           class="sprite sprite_small small overlay {{ $object->class_name }}"
            data-overlay-same="true"
            data-tech-id="{{ $object->id }}"
            data-tech-name="{{ $object->title }}"

--- a/resources/views/ingame/techtree/techinfo.blade.php
+++ b/resources/views/ingame/techtree/techinfo.blade.php
@@ -1,29 +1,5 @@
-
 <div id="technologytree" data-title="@lang('Technology') - {{ $object->title }}">
-    <nav data-current-action="technologyinformation">
-        <ul>
-            <li>
-                <a class="overlay" data-action="technologytree" data-overlay-same="true" href="{{ route('techtree.ajax', ['tab' => 1, 'object_id' => $object->id]) }}">
-                    @lang('Techtree')
-                </a>
-            </li>
-            <li>
-                <a class="overlay" data-action="applications" data-overlay-same="true" href="{{ route('techtree.ajax', ['tab' => 4, 'object_id' => $object->id]) }}">
-                    @lang('Applications')
-                </a>
-            </li>
-            <li>
-                <a class="overlay" data-action="technologyinformation" data-overlay-same="true" href="{{ route('techtree.ajax', ['tab' => 2, 'object_id' => $object->id]) }}">
-                    @lang('Techinfo')
-                </a>
-            </li>
-            <li>
-                <a class="overlay" data-action="technologies" data-overlay-same="true" href="{{ route('techtree.ajax', ['tab' => 3, 'object_id' => $object->id]) }}">
-                    @lang('Technology')
-                </a>
-            </li>
-        </ul>
-    </nav>
+    @include('ingame.techtree.partials.nav', ['currentAction' => 'technologyinformation', 'objectId' => $object->id])
 
     <div class="content technologyinformation sprite_before sprite_large {{ $object->class_name }}">
         <div class="information">

--- a/resources/views/ingame/techtree/technology.blade.php
+++ b/resources/views/ingame/techtree/technology.blade.php
@@ -1,41 +1,17 @@
+<div id="technologytree" data-title="@lang('Technology') - {{ $object->title }}">
+    @include('ingame.techtree.partials.nav', ['currentAction' => 'technologies', 'objectId' => $object->id])
 
-<ul class="subsection_tabs">
-    <li>
-        <a class="overlay reiter"
-           data-overlay-same="true"
-           href="{{ route('techtree.ajax', ['tab' => 1, 'object_id' => $object->object->id]) }}">
-            <span>
-                Techtree            </span>
-        </a>
-    </li>
-    <li>
-        <a class="overlay reiter"
-           data-overlay-same="true"
-           href="{{ route('techtree.ajax', ['tab' => 4, 'object_id' => $object->object->id]) }}">
-            <span>
-                Applications            </span>
-        </a>
-    </li>
-    <li>
-        <a class="overlay reiter"
-           data-overlay-same="true"
-           href="{{ route('techtree.ajax', ['tab' => 2, 'object_id' => $object->object->id]) }}">
-            <span>
-                Techinfo            </span>
-        </a>
-    </li>
-    <li>
-        <a class="overlay reiter active"
-           data-overlay-same="true"
-           href="{{ route('techtree.ajax', ['tab' => 3, 'object_id' => $object->object->id]) }}">
-            <span>
-                Technology            </span>
-        </a>
-    </li>
-</ul>
+    <div class="techtree" data-id="5752c611e29741257f3cf67e060afb27" data-title="Applications - {{ $object->title }}">
+        <div class="advice">{{ $object->title }} is a prerequisite of:</div>
+        There are no such technologies.
+    </div>
 
-<div class="techtree" data-id="5752c611e29741257f3cf67e060afb27" data-title="Applications - {{ $object->object->title }}">
-    <div class="advice">{{ $object->object->title }} is a prerequisite of:</div>
-    There are no such technologies.        </div>
+</div>
+
 <script type="text/javascript">
-    $(document).ready(function(){initOverlayName();});</script>
+    $(
+        function(){
+            initOverlayName();
+        }
+    );
+</script>

--- a/resources/views/ingame/techtree/technology.blade.php
+++ b/resources/views/ingame/techtree/technology.blade.php
@@ -3,7 +3,7 @@
 
     <div class="content technology">
         <p class="hint">
-            No requirements available
+            @lang('No requirements available')
         </p>
     </div>
 </div>

--- a/resources/views/ingame/techtree/technology.blade.php
+++ b/resources/views/ingame/techtree/technology.blade.php
@@ -1,11 +1,11 @@
 <div id="technologytree" data-title="@lang('Technology') - {{ $object->title }}">
     @include('ingame.techtree.partials.nav', ['currentAction' => 'technologies', 'objectId' => $object->id])
 
-    <div class="techtree" data-id="5752c611e29741257f3cf67e060afb27" data-title="Applications - {{ $object->title }}">
-        <div class="advice">{{ $object->title }} is a prerequisite of:</div>
-        There are no such technologies.
+    <div class="content technology">
+        <p class="hint">
+            No requirements available
+        </p>
     </div>
-
 </div>
 
 <script type="text/javascript">

--- a/resources/views/ingame/techtree/techtree.blade.php
+++ b/resources/views/ingame/techtree/techtree.blade.php
@@ -11,34 +11,18 @@
 
     <div class="content technologytree">
         @if ($object->hasRequirements())
-            <div class="graph columns_1" data-id="67d6cebc93399">
-                @php
-                    $depth = 0;
-                    $nextDepthFound = true;
-                @endphp
-                @while ($nextDepthFound)
-                    @php
-                        // Keep track if we have found a new depth with this iteration.
-                        $nextDepthFound = false;
-                    @endphp
-                    {{-- Print all objects per depth together, so loop through all objects and print expected depth until there is no next depth found --}}
-                    @foreach ($requirement_graph as $requirement)
-                        @if ($requirement->depth === $depth)
-                            <div class="techWrapper depth{{ $requirement->depth }} clearfix">
-                                @include('ingame.techtree.partials.techtree_node', ['object' => $requirement->gameObject, 'required_level' => $requirement->levelRequired])
-                            </div>
-                        @elseif ($requirement->depth > $depth)
-                            @php
-                                // If we have found a new depth, we need to mark it so loop will continue for next interation.
-                                $nextDepthFound = true;
-                            @endphp
+        <div class="graph columns_{{ $amount_of_columns }}" data-id="67d6cebc93399">
+            @foreach ($requirement_graph_by_depth as $depth => $depth_items)
+                <div class="techWrapper depth{{ $depth }} clearfix">
+                    @for ($column = 0; $column < $amount_of_columns; $column++)
+                        @if (isset($depth_items[$column]))
+                            @include('ingame.techtree.partials.techtree_node', ['object' => $depth_items[$column]->gameObject, 'required_level' => $depth_items[$column]->levelRequired, 'current_level' => $depth_items[$column]->levelCurrent])
+                        @else
+                            <div class="techtreeNode empty">&nbsp;</div>
                         @endif
-                    @endforeach
-                    @php
-                        $depth++;
-                    @endphp
-                @endwhile
-            </div>
+                    @endfor
+                </div>
+            @endforeach
         @else
             <p class="hint">
                 No requirements available
@@ -59,7 +43,11 @@
                     @php
                         $object_dependency = ObjectService::getObjectByMachineName($requirement_dependency->object_machine_name);
                     @endphp
-                    {"source":"t{{ $object_dependency->id }}l{{ $requirement_dependency->level }}","target":"t{{ $requirement->gameObject->id }}l{{ $requirement->levelRequired }}","label":"{{ $requirement_dependency->level }}","paintStyle":"hasRequirements"},
+                    @if ($requirement_dependency->level >= $requirement->levelRequired)
+                        {"source":"t{{ $object_dependency->id }}l{{ $requirement_dependency->level }}","target":"t{{ $requirement->gameObject->id }}l{{ $requirement->levelRequired }}","label":"{{ $requirement_dependency->level }}","paintStyle":"hasRequirements"},
+                    @else
+                        {"source":"t{{ $object_dependency->id }}l{{ $requirement_dependency->level }}","target":"t{{ $requirement->gameObject->id }}l{{ $requirement->levelRequired }}","label":"{{ $requirement_dependency->level }}/{{ $requirement->levelRequired }}","paintStyle":"hasNotRequirements"},
+                    @endif
                 @endforeach
             @endforeach
         ];

--- a/resources/views/ingame/techtree/techtree.blade.php
+++ b/resources/views/ingame/techtree/techtree.blade.php
@@ -1,7 +1,6 @@
 @php
     use OGame\GameObjects\Models\Abstracts\GameObject;
     use OGame\GameObjects\Models\Techtree\TechtreeRequirement;
-    use OGame\Services\ObjectService;
     /** @var GameObject $object */
     /** @var array<TechtreeRequirement> $requirement_graph */
 @endphp
@@ -38,17 +37,11 @@
         ];
         var connections = [
             @foreach ($requirement_graph as $requirement)
-                {{-- Create connections from child to parent --}}
-                @foreach ($requirement->gameObject->requirements as $requirement_dependency)
-                    @php
-                        $object_dependency = ObjectService::getObjectByMachineName($requirement_dependency->object_machine_name);
-                    @endphp
-                    @if ($requirement_dependency->level >= $requirement->levelRequired)
-                        {"source":"t{{ $object_dependency->id }}l{{ $requirement_dependency->level }}","target":"t{{ $requirement->gameObject->id }}l{{ $requirement->levelRequired }}","label":"{{ $requirement_dependency->level }}","paintStyle":"hasRequirements"},
-                    @else
-                        {"source":"t{{ $object_dependency->id }}l{{ $requirement_dependency->level }}","target":"t{{ $requirement->gameObject->id }}l{{ $requirement->levelRequired }}","label":"{{ $requirement_dependency->level }}/{{ $requirement->levelRequired }}","paintStyle":"hasNotRequirements"},
-                    @endif
-                @endforeach
+                @if ($requirement->parent !== null && $requirement->levelCurrent >= $requirement->levelRequired)
+                    {"source":"t{{ $requirement->gameObject->id }}l{{ $requirement->levelRequired }}","target":"t{{ $requirement->parent->gameObject->id }}l{{ $requirement->parent->levelRequired }}","label":"{{ $requirement->levelRequired }}","paintStyle":"hasRequirements"},
+                @elseif ($requirement->parent !== null)
+                    {"source":"t{{ $requirement->gameObject->id }}l{{ $requirement->levelRequired }}","target":"t{{ $requirement->parent->gameObject->id }}l{{ $requirement->parent->levelRequired }}","label":"{{ $requirement->levelCurrent }}/{{ $requirement->levelRequired }}","paintStyle":"hasNotRequirements"},
+                @endif
             @endforeach
         ];
         (function($){

--- a/resources/views/ingame/techtree/techtree.blade.php
+++ b/resources/views/ingame/techtree/techtree.blade.php
@@ -1,10 +1,47 @@
+@php
+    use OGame\GameObjects\Models\Abstracts\GameObject;
+    /** @var GameObject $object */
+@endphp
+
 <div id="technologytree" data-title="@lang('Technology') - {{ $object->title }}">
     @include('ingame.techtree.partials.nav', ['currentAction' => 'technologytree', 'objectId' => $object->id])
 
-    <div class="techtree" data-id="5752c611e29741257f3cf67e060afb27" data-title="@lang('Applications') - {{ $object->title }}">
-        <div class="advice">{{ $object->title }} is a prerequisite of:</div>
-        There are no such technologies.
+    <div class="content technologytree">
+        @if ($object->hasRequirements())
+            <div class="graph columns_1" data-id="67d6cebc93399">
+                <div class="techWrapper depth0 clearfix">
+                    {{-- The depth0 represents the current object which is always displayed on the first row --}}
+                    <div class="techtreeNode">
+                        @include('ingame.techtree.partials.techtree_node', ['object' => $object, 'required_level' => 1])
+                    </div>
+                </div>
+                <div class="techWrapper depth1 clearfix">
+                  <div class="techtreeNode">
+                    <div class="techImage js_hideTipOnMobile tooltipHTML tech14 techt14l2 built" title="Robotics Factory Level (2)|Robotic factories provide construction robots to aid in the construction of buildings. Each level increases the speed of the upgrade of buildings.">
+                        <a href="https://s256-en.ogame.gameforge.com/game/index.php?page=ajax&amp;component=technologytree&amp;technologyId=14&amp;ajax=1"
+                        class="sprite sprite_small small overlay roboticsFactory hasRequirements"
+                        data-overlay-same="true"
+                        data-tech-id="14"
+                        data-tech-name="Robotics Factory"
+                        data-tech-type="Type Buildings">
+                        </a>
+                    </div>
+                </div>
+                </div>
+            </div>
+        @else
+            <p class="hint">
+                No requirements available
+            </p>
+        @endif
     </div>
+    <script>
+        var endpoints = ["t21l1","t14l2"];
+        var connections = [{"source":"t14l2","target":"t21l1","label":"2","paintStyle":"hasRequirements"}];
+        (function($){
+          initTechtree("67d6cebc93399")
+        })(jQuery);
+    </script>
 </div>
 
 <script type="text/javascript">

--- a/resources/views/ingame/techtree/techtree.blade.php
+++ b/resources/views/ingame/techtree/techtree.blade.php
@@ -1,41 +1,16 @@
+<div id="technologytree" data-title="@lang('Technology') - {{ $object->title }}">
+    @include('ingame.techtree.partials.nav', ['currentAction' => 'technologytree', 'objectId' => $object->id])
 
-<ul class="subsection_tabs">
-    <li>
-        <a class="overlay reiter active"
-           data-overlay-same="true"
-           href="{{ route('techtree.ajax', ['tab' => 1, 'object_id' => $object->object->id]) }}">
-            <span>
-                Techtree            </span>
-        </a>
-    </li>
-    <li>
-        <a class="overlay reiter"
-           data-overlay-same="true"
-           href="{{ route('techtree.ajax', ['tab' => 4, 'object_id' => $object->object->id]) }}">
-            <span>
-                Applications            </span>
-        </a>
-    </li>
-    <li>
-        <a class="overlay reiter"
-           data-overlay-same="true"
-           href="{{ route('techtree.ajax', ['tab' => 2, 'object_id' => $object->object->id]) }}">
-            <span>
-                Techinfo            </span>
-        </a>
-    </li>
-    <li>
-        <a class="overlay reiter"
-           data-overlay-same="true"
-           href="{{ route('techtree.ajax', ['tab' => 3, 'object_id' => $object->object->id]) }}">
-            <span>
-                Technology            </span>
-        </a>
-    </li>
-</ul>
+    <div class="techtree" data-id="5752c611e29741257f3cf67e060afb27" data-title="@lang('Applications') - {{ $object->title }}">
+        <div class="advice">{{ $object->title }} is a prerequisite of:</div>
+        There are no such technologies.
+    </div>
+</div>
 
-<div class="techtree" data-id="5752c611e29741257f3cf67e060afb27" data-title="Applications - {{ $object->object->title }}">
-    <div class="advice">{{ $object->object->title }} is a prerequisite of:</div>
-    There are no such technologies.        </div>
 <script type="text/javascript">
-    $(document).ready(function(){initOverlayName();});</script>
+    $(
+        function(){
+            initOverlayName();
+        }
+    );
+</script>

--- a/resources/views/ingame/techtree/techtree.blade.php
+++ b/resources/views/ingame/techtree/techtree.blade.php
@@ -9,7 +9,6 @@
 
 <div id="technologytree" data-title="@lang('Technology') - {{ $object->title }}">
     @include('ingame.techtree.partials.nav', ['currentAction' => 'technologytree', 'objectId' => $object->id])
-
     <div class="content technologytree">
         @if ($object->hasRequirements())
         <div class="graph columns_{{ $amount_of_columns }}" data-id="67d6cebc93399">
@@ -24,9 +23,10 @@
                     @endfor
                 </div>
             @endforeach
+        </div>
         @else
             <p class="hint">
-                No requirements available
+                @lang('No requirements available')
             </p>
         @endif
     </div>

--- a/resources/views/ingame/techtree/techtree.blade.php
+++ b/resources/views/ingame/techtree/techtree.blade.php
@@ -2,7 +2,9 @@
     use OGame\GameObjects\Models\Abstracts\GameObject;
     use OGame\GameObjects\Models\Techtree\TechtreeRequirement;
     /** @var GameObject $object */
-    /** @var array<TechtreeRequirement> $requirement_graph */
+    /** @var array<TechtreeRequirement> $techtree */
+    /** @var array<TechtreeRequirement> $techtree_unique */
+    /** @var array<int, array<int, TechtreeRequirement>> $techtree_by_depth */
 @endphp
 
 <div id="technologytree" data-title="@lang('Technology') - {{ $object->title }}">
@@ -11,7 +13,7 @@
     <div class="content technologytree">
         @if ($object->hasRequirements())
         <div class="graph columns_{{ $amount_of_columns }}" data-id="67d6cebc93399">
-            @foreach ($requirement_graph_by_depth as $depth => $depth_items)
+            @foreach ($techtree_by_depth as $depth => $depth_items)
                 <div class="techWrapper depth{{ $depth }} clearfix">
                     @for ($column = 0; $column < $amount_of_columns; $column++)
                         @if (isset($depth_items[$column]))
@@ -31,12 +33,12 @@
     <script>
         var endpoints = [
             {{-- Create list of all requirements with level required --}}
-            @foreach ($requirement_graph_unique as $requirement)
+            @foreach ($techtree_unique as $requirement)
                 "t{{ $requirement->gameObject->id }}l{{ $requirement->levelRequired }}",
             @endforeach
         ];
         var connections = [
-            @foreach ($requirement_graph as $requirement)
+            @foreach ($techtree as $requirement)
                 @if ($requirement->parent !== null && $requirement->levelCurrent >= $requirement->levelRequired)
                     {"source":"t{{ $requirement->gameObject->id }}l{{ $requirement->levelRequired }}","target":"t{{ $requirement->parent->gameObject->id }}l{{ $requirement->parent->levelRequired }}","label":"{{ $requirement->levelRequired }}","paintStyle":"hasRequirements"},
                 @elseif ($requirement->parent !== null)

--- a/resources/views/ingame/techtree/techtree.blade.php
+++ b/resources/views/ingame/techtree/techtree.blade.php
@@ -32,7 +32,7 @@
     <script>
         var endpoints = [
             {{-- Create list of all requirements with level required --}}
-            @foreach ($requirement_graph as $requirement)
+            @foreach ($requirement_graph_unique as $requirement)
                 "t{{ $requirement->gameObject->id }}l{{ $requirement->levelRequired }}",
             @endforeach
         ];

--- a/tests/Feature/Http200Test.php
+++ b/tests/Feature/Http200Test.php
@@ -144,4 +144,76 @@ class Http200Test extends AccountTestCase
             }
         }
     }
+
+    /**
+     * Verify that all AJAX techtree pages return HTTP 200.
+     */
+    public function testAjaxTechtree(): void
+    {
+        foreach (ObjectService::getObjects() as $object) {
+            $response = $this->get('ajax/techtree?tab=1&object_id=' . $object->id);
+
+            try {
+                $response->assertStatus(200);
+            } catch (\PHPUnit\Framework\AssertionFailedError $e) {
+                $customMessage = 'AJAX techtree popup for "' . $object->title . '" does not return HTTP 200.';
+                // Optionally, include original message: $customMessage .= "\nOriginal assertion failure: " . $e->getMessage();
+                $this->fail($customMessage);
+            }
+        }
+    }
+
+    /**
+     * Verify that all AJAX applications pages return HTTP 200.
+     */
+    public function testAjaxApplications(): void
+    {
+        foreach (ObjectService::getObjects() as $object) {
+            $response = $this->get('ajax/techtree?tab=2&object_id=' . $object->id);
+
+            try {
+                $response->assertStatus(200);
+            } catch (\PHPUnit\Framework\AssertionFailedError $e) {
+                $customMessage = 'AJAX techtree popup applications tab for "' . $object->title . '" does not return HTTP 200.';
+                // Optionally, include original message: $customMessage .= "\nOriginal assertion failure: " . $e->getMessage();
+                $this->fail($customMessage);
+            }
+        }
+    }
+
+    /**
+     * Verify that all AJAX techinfo pages return HTTP 200.
+     */
+    public function testAjaxTechinfo(): void
+    {
+        foreach (ObjectService::getObjects() as $object) {
+            $response = $this->get('ajax/techtree?tab=3&object_id=' . $object->id);
+
+            try {
+                $response->assertStatus(200);
+            } catch (\PHPUnit\Framework\AssertionFailedError $e) {
+                $customMessage = 'AJAX techtree popup techinfo tab for "' . $object->title . '" does not return HTTP 200.';
+                // Optionally, include original message: $customMessage .= "\nOriginal assertion failure: " . $e->getMessage();
+                $this->fail($customMessage);
+            }
+        }
+    }
+
+    /**
+     * Verify that all AJAX technology pages return HTTP 200.
+     */
+    public function testAjaxTechnology(): void
+    {
+        foreach (ObjectService::getObjects() as $object) {
+            $response = $this->get('ajax/techtree?tab=4&object_id=' . $object->id);
+
+            try {
+                $response->assertStatus(200);
+            } catch (\PHPUnit\Framework\AssertionFailedError $e) {
+                $customMessage = 'AJAX techtree popup technology tab for "' . $object->title . '" does not return HTTP 200.';
+                // Optionally, include original message: $customMessage .= "\nOriginal assertion failure: " . $e->getMessage();
+                $this->fail($customMessage);
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Description
This PR makes the techtree popup work and contains some additional refactoring to simplify methods.

### Note on known bugs/limitations:
With the changes in this PR the techtree popup technically works, however functionally there are some differences compared to the original game. The original game uses `jsplumb` (https://jsplumbtoolkit.com) for rendering the techtree. There is quite a lot of custom JS code in the `resources/js/ingame/e7c74974620fa35b197315ebdbb8c2.js` file that takes the raw techtree data provided by the blade template, processes it, and then calls the jsplumb methods. However during development, this custom JS code threw a lot of exceptions. Even when I tried to use the exact same frontend code in OGameX as a test, this custom JS still threw errors. Unfortunately I'm not sure what causes this. Maybe the frontend JS code on the original game has changed since we copied the base JS code to OGameX. But there were no obvious differences when I glanced over it.

After a few hours of troubleshooting I decided not to debug this further as it would cost a lot of time. Instead I decided to comment out the parts that gave trouble. I marked these blocks of the JS code with comments like this:

```
TODO OGAMEX: [...]
```

If you re-enable this JS logic, the errors will come back again. As a result of the removal of this code, the techtree still works however it can look a little bit different when comparing it to the official game. The differences are caused because the removed custom code was used to tweak the way the paths from point A to point B were made to prevent overlapping lines. Below some examples of the differences. This can be tweaked later to make it more like the original, but it will probably take quite a bit of reverse engineering effort.

#### Example 1: simple one-column techtree (shipyard) works the same in both versions:
<img width="557" alt="Screenshot 2025-03-23 at 12 10 18" src="https://github.com/user-attachments/assets/a32ef47f-7a75-4238-87fb-c2e6b7e78829" />

#### Example 2: two-column techtree (nanite factory) is positioned differently, but more or less the same:
Original:
<img width="723" alt="Screenshot 2025-03-23 at 12 11 01" src="https://github.com/user-attachments/assets/231adb9d-bc61-4c92-8a26-1e667ee2a565" />
OGameX:
<img width="749" alt="Screenshot 2025-03-23 at 12 11 08" src="https://github.com/user-attachments/assets/efe80308-488f-41cd-a6d1-90cadd71fb00" />

#### Example 3: multi-column techtree (death star) with a lot of dependencies becomes quite messy:
Original:
<img width="804" alt="Screenshot 2025-03-23 at 12 11 35" src="https://github.com/user-attachments/assets/30ab6b4b-89d5-47df-bd68-da0483fc2c9a" />
OGameX:
<img width="807" alt="Screenshot 2025-03-23 at 12 11 23" src="https://github.com/user-attachments/assets/c02ad1df-a971-4ecd-b270-63fd76792fe1" />

## Remaining todos:
- [x] Add basic techtree UI and scaffolding.
- [x] Fix popup tab navigation for all tabs even if they have not been implemented yet.
- [x] Make `techtree.blade.php` structure work for simple one level deep requirements, e.g. `Shipyard`.
- [x] Make techtree work for two level deep requirements, e.g. `Missile Silo`.
- [x] There is an issue that has been pinpointed to the `drawArrows()` ingame.min.js method. This method prepares the arrows/connectors that are then passed into jsplumb. In the OGameX version with identical HTML, it throws errors that the official game does not have. Needs further investigating. --> Comment out all parts that give issues.
- [x] Fix rendering where the same level building is rendered multiple times. E.g. `Ion Canon`. --> Everything seems to render now, except `Bomber` and `Cruiser`.
- [x] Fix bug where popup is not centered correctly (caused by JS init errors, check examples)
- [x] Make techtree work for simple ships with building and tech requirements, e.g. `Light Fighter`.
- [x] Make techtree work for complicated ships with building and tech requirements, e.g. `Death Star`. Although note: the official game tech tree contains bugs as e.g. the `Research Lab` appears more than once. See if we can fix this bug in our version.
- [x] Make techtree work for multi column layout, e.g. `Nanite factory`.
- [x] Verify logic for arrows and parent object when it's not able to be built, able to be built but not yet (level 0), or built. The states should be reflected in the tech tree with different colors and labels. Check the official game for examples.
- [x] Verify that all `techtree_node.blade.php` dynamic classes are correct when compared to the official game. `hasRequirements vs `hasNotRequirements` on tech tree node? is it used for anything? --> now removed
- [x] Refactor the techtree rendering methods for readability
- [x] Add feature test that ensure that techtree popups successfully load without errors for all game objects.

### Type of Change:
- [x] Feature enhancement

## Related Issues
Fixes #139

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [x] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [x] **Static Analysis:** Code passes PHPStan static code analysis.
- [x] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [x] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [x] **Documentation:** Documentation has been updated to reflect any changes made.