### PR TITLE
Fix Weap Tech Cost

### DIFF
--- a/app/GameObjects/ResearchObjects.php
+++ b/app/GameObjects/ResearchObjects.php
@@ -301,7 +301,7 @@ With each level of the Combustion Drive developed, the speed of small and large 
         $weaponTechnology->requirements = [
             new GameObjectRequirement('research_lab', 4),
         ];
-        $weaponTechnology->price = new GameObjectPrice(800, 200, 000, 0, 2);
+        $weaponTechnology->price = new GameObjectPrice(800, 200, 0, 0, 2);
         $weaponTechnology->assets = new GameObjectAssets();
         $weaponTechnology->assets->imgMicro = 'weapons_technology_micro.jpg';
         $weaponTechnology->assets->imgSmall = 'weapons_technology_small.jpg';

--- a/app/GameObjects/ResearchObjects.php
+++ b/app/GameObjects/ResearchObjects.php
@@ -301,7 +301,7 @@ With each level of the Combustion Drive developed, the speed of small and large 
         $weaponTechnology->requirements = [
             new GameObjectRequirement('research_lab', 4),
         ];
-        $weaponTechnology->price = new GameObjectPrice(0, 800, 200, 0, 2);
+        $weaponTechnology->price = new GameObjectPrice(800, 200, 000, 0, 2);
         $weaponTechnology->assets = new GameObjectAssets();
         $weaponTechnology->assets->imgMicro = 'weapons_technology_micro.jpg';
         $weaponTechnology->assets->imgSmall = 'weapons_technology_small.jpg';


### PR DESCRIPTION


## Description
It should cost M/C, not C/D. This simply shifts the values to reflect the ogame default of 800 metal 200 crystal.

### Type of Change:
- [x] "Bug" fix

## Related Issues
N/A

## Checklist
N/A

## Additional Information
N/A
