### PR TITLE
Highscore ranks are not sorted correctly

### DIFF
--- a/app/Console/Commands/GenerateHighscoreRanks.php
+++ b/app/Console/Commands/GenerateHighscoreRanks.php
@@ -35,7 +35,7 @@ class GenerateHighscoreRanks extends Command
     private function updateTypeRank(HighscoreTypeEnum $type): void
     {
         $rank = 1;
-        $this->info("Updating highscore ranks for $type->name...");
+        $this->info("\nUpdating highscore ranks for $type->name...");
 
         // Order by the highscore value in descending order, and by the player creation date in ascending order.
         // This ensures that:
@@ -43,10 +43,9 @@ class GenerateHighscoreRanks extends Command
         // - If two players have the same highscore value, the player who joined the game first will be ranked higher.
         $query = Highscore::query()
             ->join('users', 'highscores.player_id', '=', 'users.id')
-            ->whereHas('player.tech')
-            ->where($type->name, '!=', null);
-        $query->orderBy($type->name, 'DESC')
-              ->orderBy('users.created_at', 'ASC');
+            ->select('highscores.*')
+            ->orderByDesc($type->name)
+            ->orderBy('users.created_at');
 
         $bar = $this->output->createProgressBar();
         $bar->start($query->count());
@@ -60,6 +59,6 @@ class GenerateHighscoreRanks extends Command
                 $rank++;
             }
         });
-        $this->info("All highscores for type $type->name completed!");
+        $this->info("\nAll highscores for type $type->name completed!\n");
     }
 }


### PR DESCRIPTION
## Description
Fixes issue where highscore ranks were calculated incorrectly because it used `users.id` as the `highscore.id` leading to the wrong highscore entry being updated.

### Type of Change:
- [x] Bug fix

## Related Issues
Fixes #641

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [x] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [x] **Static Analysis:** Code passes PHPStan static code analysis.
- [x] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [x] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [x] **Documentation:** Documentation has been updated to reflect any changes made.
