### PR TITLE
Alter isBuildingObject

### DIFF
--- a/app/Http/Controllers/DefenseController.php
+++ b/app/Http/Controllers/DefenseController.php
@@ -51,7 +51,7 @@ class DefenseController extends AbstractUnitsController
 
         return view(view: 'ingame.defense.index')->with(
             array_merge(
-                ['shipyard_upgrading' => $player->isBuildingObject('shipyard')],
+                ['shipyard_upgrading' => $player->planets->current()->isBuildingObject('shipyard')],
                 parent::indexPage($request, $player)
             )
         );
@@ -68,7 +68,7 @@ class DefenseController extends AbstractUnitsController
     public function addBuildRequest(Request $request, PlayerService $player): JsonResponse
     {
         // If the shipyard isn't upgrading, we can continue to process the request.
-        if (!$player->isBuildingObject('shipyard')) {
+        if (!$player->planets->current()->isBuildingObject('shipyard')) {
             return parent::addBuildRequest($request, $player);
         } else {
             // Otherwise, it shouldn't be allowed.

--- a/app/Http/Controllers/ShipyardController.php
+++ b/app/Http/Controllers/ShipyardController.php
@@ -43,7 +43,7 @@ class ShipyardController extends AbstractUnitsController
 
         return view(view: 'ingame.shipyard.index')->with(
             array_merge(
-                ['shipyard_upgrading' => $player->isBuildingObject('shipyard')],
+                ['shipyard_upgrading' => $player->planets->current()->isBuildingObject('shipyard')],
                 parent::indexPage($request, $player)
             )
         );
@@ -71,7 +71,7 @@ class ShipyardController extends AbstractUnitsController
     public function addBuildRequest(Request $request, PlayerService $player): JsonResponse
     {
         // If the shipyard isn't upgrading, we can continue to process the request.
-        if (!$player->isBuildingObject('shipyard')) {
+        if (!$player->planets->current()->isBuildingObject('shipyard')) {
             return parent::addBuildRequest($request, $player);
         } else {
             // Otherwise, it shouldn't be allowed.

--- a/app/Http/Traits/ObjectAjaxTrait.php
+++ b/app/Http/Traits/ObjectAjaxTrait.php
@@ -71,13 +71,13 @@ trait ObjectAjaxTrait
                 $production_time = AppUtil::formatTimeDuration($planet->getUnitConstructionTime($object->machine_name));
                 $production_datetime = AppUtil::formatDateTimeDuration($planet->getUnitConstructionTime($object->machine_name));
 
-                $shipyard_upgrading = $player->isBuildingObject('shipyard');
+                $shipyard_upgrading = $player->planets->current()->isBuildingObject('shipyard');
                 break;
             case GameObjectType::Defense:
                 $production_time = AppUtil::formatTimeDuration($planet->getUnitConstructionTime($object->machine_name));
                 $production_datetime = AppUtil::formatDateTimeDuration($planet->getUnitConstructionTime($object->machine_name));
 
-                $shipyard_upgrading = $player->isBuildingObject('shipyard');
+                $shipyard_upgrading = $player->planets->current()->isBuildingObject('shipyard');
                 break;
             case GameObjectType::Research:
                 $production_time = AppUtil::formatTimeDuration($planet->getTechnologyResearchTime($object->machine_name));

--- a/app/Services/PlanetService.php
+++ b/app/Services/PlanetService.php
@@ -1759,8 +1759,8 @@ class PlanetService
     public function isBuildingObject(string $machine_name, int|null $level = null): bool
     {
         $object = ObjectService::getObjectByMachineName($machine_name);
-        
-        if($level === null) {
+
+        if ($level === null) {
             $level = $this->getObjectLevel($machine_name) + 1;
         }
 

--- a/app/Services/PlanetService.php
+++ b/app/Services/PlanetService.php
@@ -1756,9 +1756,13 @@ class PlanetService
      *
      * @return bool
      */
-    public function isBuildingObject(string $machine_name, int $level): bool
+    public function isBuildingObject(string $machine_name, int|null $level = null): bool
     {
         $object = ObjectService::getObjectByMachineName($machine_name);
+        
+        if($level === null) {
+            $level = $this->getObjectLevel($machine_name) + 1;
+        }
 
         // Check only building queue objects
         if ($object->type !== GameObjectType::Building && $object->type !== GameObjectType::Station) {

--- a/app/Services/PlayerService.php
+++ b/app/Services/PlayerService.php
@@ -638,8 +638,7 @@ class PlayerService
     public function isBuildingObject(string $machine_name): bool
     {
         foreach ($this->planets->all() as $planet) {
-            $object_level = $planet->getObjectLevel($machine_name);
-            if ($planet->isBuildingObject($machine_name, $object_level + 1)) {
+            if ($planet->isBuildingObject($machine_name)) {
                 return true;
             }
         }

--- a/app/Services/PlayerService.php
+++ b/app/Services/PlayerService.php
@@ -631,7 +631,7 @@ class PlayerService
     }
 
     /**
-     * Get is the player building the object or not
+     * Players current planet building the object?
      *
      * @return bool
      */

--- a/app/Services/PlayerService.php
+++ b/app/Services/PlayerService.php
@@ -631,7 +631,7 @@ class PlayerService
     }
 
     /**
-     * Players current planet building the object?
+     * Is the players current planet building the object
      *
      * @return bool
      */

--- a/app/Services/PlayerService.php
+++ b/app/Services/PlayerService.php
@@ -631,7 +631,7 @@ class PlayerService
     }
 
     /**
-     * Is the players current planet building the object
+     * Get is the player building the object or not
      *
      * @return bool
      */

--- a/app/Services/PlayerService.php
+++ b/app/Services/PlayerService.php
@@ -637,13 +637,9 @@ class PlayerService
      */
     public function isBuildingObject(string $machine_name): bool
     {
-        foreach ($this->planets->all() as $planet) {
-            $object_level = $planet->getObjectLevel($machine_name);
-            if ($planet->isBuildingObject($machine_name, $object_level + 1)) {
-                return true;
-            }
-        }
+        $planet = $this->planets->current();
+        $object_level = $planet->getObjectLevel($machine_name);
 
-        return false;
+        return $planet->isBuildingObject($machine_name, $object_level + 1);
     }
 }

--- a/app/Services/PlayerService.php
+++ b/app/Services/PlayerService.php
@@ -637,9 +637,13 @@ class PlayerService
      */
     public function isBuildingObject(string $machine_name): bool
     {
-        $planet = $this->planets->current();
-        $object_level = $planet->getObjectLevel($machine_name);
+        foreach ($this->planets->all() as $planet) {
+            $object_level = $planet->getObjectLevel($machine_name);
+            if ($planet->isBuildingObject($machine_name, $object_level + 1)) {
+                return true;
+            }
+        }
 
-        return $planet->isBuildingObject($machine_name, $object_level + 1);
+        return false;
     }
 }


### PR DESCRIPTION
## Description
Closes https://github.com/lanedirt/OGameX/issues/701

- Adjusts the shipyard logic building to take into account the current planet, rather than as the whole player.
- Alters the planet service `isBuildingObject` method level to accept null, which means we'll get the level if not provided

### Type of Change:
- [X] Bug fix


## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [X] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [X] **Static Analysis:** Code passes PHPStan static code analysis.
- PlayerService has no tests... so didnt add one. Could we perhaps make an issue for it to cover it more? dunno if its worth it unit test wise.. 

