### PR TITLE
Fix: Grammar, punctuation, and consistency in English localization strings

### DIFF
--- a/resources/lang/en/t_messages.php
+++ b/resources/lang/en/t_messages.php
@@ -9,7 +9,7 @@ return [
 
 Congratulations on starting your illustrious career. I will be here to guide you through your first steps.
 
-On the left, you can see the menu which, allows you to supervise and govern your galactic empire.
+On the left, you can see the menu, which allows you to supervise and govern your galactic empire.
 
 You’ve already seen the Overview. Resources and Facilities allow you to construct buildings to help you expand your empire. Start by building a Solar Plant to harvest energy for your mines.
 
@@ -71,7 +71,7 @@ Deuterium: :deuterium',
     'transport_arrived' => [
         'from' => 'Fleet Command',
         'subject' => 'Reaching a planet',
-        'body' => 'Your fleet from :from reaches :to and delivers its goods:
+        'body' => 'Your fleet from :from has reached :to and delivers its goods:
 Metal: :metal Crystal: :crystal Deuterium: :deuterium',
         ],
 
@@ -87,14 +87,14 @@ Metal: :metal Crystal: :crystal Deuterium: :deuterium',
     'colony_established' => [
         'from' => 'Fleet Command',
         'subject' => 'Settlement Report',
-        'body' => 'The fleet has arrived at the assigned coordinates :coordinates, found a new planet there and are beginning to develop upon it immediately.',
+        'body' => 'The fleet has arrived at the assigned coordinates :coordinates, found a new planet there and are beginning to develop it immediately.',
     ],
 
     // ------------------------
     'colony_establish_fail_astrophysics' => [
         'from' => 'Settlers',
         'subject' => 'Settlement Report',
-        'body' => 'The fleet has arrived at assigned coordinates :coordinates and ascertains that the planet is viable for colonisation. Shortly after starting to develop the planet, the colonists realise that their knowledge of astrophysics is not sufficient to complete the colonisation of a new planet.',
+        'body' => 'The fleet has arrived at the assigned coordinates :coordinates and ascertains that the planet is viable for colonisation. Shortly after starting to develop the planet, the colonists realise that their knowledge of astrophysics is not sufficient to complete the colonisation of a new planet.',
     ],
 
     // ------------------------
@@ -131,17 +131,17 @@ Metal: :metal Crystal: :crystal Deuterium: :deuterium',
         'body' => [
             '1' => 'Due to a failure in the central computers of the flagship, the expedition mission had to be aborted. Unfortunately as a result of the computer malfunction, the fleet returns home empty handed.',
             '2' => 'Your expedition nearly ran into a neutron stars gravitation field and needed some time to free itself. Because of that a lot of Deuterium was consumed and the expedition fleet had to come back without any results.',
-            '3' => 'For unknown reasons the expeditions jump went totally wrong. It nearly landed in the heart of a sun. Fortunately it landed in a known system, but the jump back is going to take longer than thought.',
+            '3' => "For unknown reasons the expedition's jump went totally wrong. It nearly landed in the heart of a sun. Fortunately it landed in a known system, but the jump back is going to take longer than thought.",
             '4' => "A failure in the flagship's reactor core nearly destroys the entire expedition fleet. Fortunately the technicians were more than competent and could avoid the worst. The repairs took quite some time and forced the expedition to return without having accomplished its goal.",
-            '5' => 'A living being made out of pure energy came aboard and induced all the expedition members into some strange trance, causing them to only gazed at the hypnotizing patterns on the computer screens. When most of them finally snapped out of the hypnotic-like state, the expedition mission needed to be aborted as they had way too little Deuterium.',
-            '6' => "The new navigation module is still buggy. The expeditions jump not only lead them in the wrong direction, but it used all the Deuterium fuel. Fortunately the fleets jump got them close to the departure planet's moon. A bit disappointed the expedition now returns without impulse power. The return trip will take longer than expected.",
+            '5' => 'A living being made out of pure energy came aboard and induced all the expedition members into some strange trance, causing them to only gaze at the hypnotizing patterns on the computer screens. When most of them finally snapped out of the hypnotic-like state, the expedition mission needed to be aborted as they had way too little Deuterium.',
+            '6' => "The new navigation module is still buggy. The expedition's jump not only lead them in the wrong direction, but it used all the Deuterium fuel. Fortunately the fleets jump got them close to the departure planet's moon. A bit disappointed the expedition now returns without impulse power. The return trip will take longer than expected.",
             '7' => 'Your expedition has learnt about the extensive emptiness of space. There was not even one small asteroid or radiation or particle that could have made this expedition interesting.',
             '8' => "Well, now we know that those red, class 5 anomalies do not only have chaotic effects on the ships navigation systems but also generate massive hallucination on the crew. The expedition didn't bring anything back.",
             '9' => 'Your expedition fleet made contact with a friendly alien race. They announced that they would send a representative with goods to trade to your worlds.',
             '10' => "Your expedition took gorgeous pictures of a super nova. Nothing new could be obtained from the expedition, but at least there is good chance to win that 'Best Picture Of The Universe' competition in next month's issue of OGame magazine.",
             '11' => "Your expedition fleet followed odd signals for some time. At the end they noticed that those signals where being sent from an old probe which was sent out generations ago to greet foreign species. The probe was saved and some museums of your home planet already voiced their interest.",
             '12' => "Despite the first, very promising scans of this sector, we unfortunately returned empty handed.",
-            '13' => "Besides some quaint, small pets from a unknown marsh planet, this expedition brings nothing thrilling back from the trip.",
+            '13' => "Besides some quaint, small pets from an unknown marsh planet, this expedition brings nothing thrilling back from the trip.",
             '14' => "The expedition's flagship collided with a foreign ship when it jumped into the fleet without any warning. The foreign ship exploded and the damage to the flagship was substantial. The expedition cannot continue in these conditions, and so the fleet will begin to make its way back once the needed repairs have been carried out.",
             '15' => 'Our expedition team came across a strange colony that had been abandoned eons ago. After landing, our crew started to suffer from a high fever caused by an alien virus. It has been learned that this virus wiped out the entire civilization on the planet. Our expedition team is heading home to treat the sickened crew members. Unfortunately we had to abort the mission and we come home empty handed.',
             '16' => "A strange computer virus attacked the navigation system shortly after departing our home system. This caused the expedition fleet to fly in circles. Needless to say that the expedition wasn't really successful.",
@@ -174,7 +174,7 @@ Metal: :metal Crystal: :crystal Deuterium: :deuterium',
             '3' => 'We met an odd alien on the shelf of a small ship who gave us a case with Dark Matter in exchange for some simple mathematical calculations.',
             '4' => 'We found the remains of an alien ship. We found a little container with some Dark Matter on a shelf in the cargo hold!',
             '5' => 'Our expedition made first contact with a special race. It looks as though a creature made of pure energy, who named himself Legorian, flew through the expedition ships and then decided to help our underdeveloped species. A case containing Dark Matter materialized at the bridge of the ship!',
-            '6' => "Our expedition took over a ghost ship which was transporting a small amount of Dark Matter. We didn't find any hints of what happened to the original crew of the ship, but our technicians where able to rescue the Dark Matter.",
+            '6' => "Our expedition took over a ghost ship which was transporting a small amount of Dark Matter. We didn't find any hints of what happened to the original crew of the ship, but our technicians were able to rescue the Dark Matter.",
             '7' => 'Our expedition accomplished a unique experiment. They were able to harvest Dark Matter from a dying star.',
             '8' => 'Our expedition located a rusty space station, which seemed to have been floating uncontrolled through outer space for a long time. The station itself was totally useless, however, it was discovered that some Dark Matter is stored in the reactor. Our technicians are trying to save as much as they can.',
         ],


### PR DESCRIPTION
## Description
While looking at my failed expeditions this morning I noticed backticks  being used in many places where an apostrophe (') should be in its stead. I took a look at the `t_messages.php` and attempted to sort all the mistakes I could find. This PR corrects minor grammatical issues, missing articles, possessive forms, and punctuation errors in `resources/lang/en/t_messages.php.`

### Type of Change:
- [X] Other (please describe):

Changes include:
- Fixed missing and incorrect articles (e.g., a unknown → an unknown).
- Corrected possessive forms (expeditions → expedition’s).
- Adjusted verb tenses and agreement.
- Standardized phrasing and punctuation for readability and consistency.
- Ensured no semantic or variable placeholder changes.