### PR TITLE
Fix Expedition resource gain amount format bug

### DIFF
--- a/app/GameMessages/ExpeditionGainResources.php
+++ b/app/GameMessages/ExpeditionGainResources.php
@@ -4,7 +4,6 @@ namespace OGame\GameMessages;
 
 use OGame\Models\Enums\ResourceType;
 use OGame\GameMessages\Abstracts\ExpeditionGameMessage;
-use OGame\Facades\AppUtil;
 
 class ExpeditionGainResources extends ExpeditionGameMessage
 {
@@ -42,7 +41,7 @@ class ExpeditionGainResources extends ExpeditionGameMessage
         if (!empty($params['resource_type']) && !empty($params['resource_amount'])) {
             // Convert resource type to human readable string.
             $resourceTypeLabel = ResourceType::from($params['resource_type'])->getTranslation();
-            $translatedBody .= '<br /><br />' . __('t_messages.expedition_resources_captured', ['resource_type' => $resourceTypeLabel, 'resource_amount' => AppUtil::formatNumber((int)$params['resource_amount'])]);
+            $translatedBody .= '<br /><br />' . __('t_messages.expedition_resources_captured', ['resource_type' => $resourceTypeLabel, 'resource_amount' => $params['resource_amount']]);
         }
 
         return $translatedBody;


### PR DESCRIPTION
## Description
Expedition gain messages displayed only the number before the first comma (e.g., “Crystal 7 have been captured.”).

Root cause: `ExpeditionGainResources::getBody()` re-formatted an already formatted `resource_amount`. The string value (e.g., "7,880,000") was cast to (int) for `AppUtil::formatNumber()`, so PHP truncated it at the first comma to 7.

What this PR does: Removes the redundant cast and formatting call, using the already formatted `resource_amount` produced by `formatReservedParams()` in the base message class. `use OGame\Facades\AppUtil;` is deleted, as it is not used anymore.

### Type of Change:
- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #727 

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [X] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [X] **Static Analysis:** Code passes PHPStan static code analysis.
- [X] **Testing:** This change is backward compatible and old expedition messages are displayed properly.
- [ ] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [ ] **Documentation:** Documentation has been updated to reflect any changes made.

## Additional Information
<img width="629" height="419" alt="Screenshot 2025-10-23 at 17 08 23" src="https://github.com/user-attachments/assets/7756fc86-cf44-47ec-8f5a-8913ca9bec72" />