### PR TITLE
Fix research queue using wrong planet's lab level for time calculation

### DIFF
--- a/app/Services/ResearchQueueService.php
+++ b/app/Services/ResearchQueueService.php
@@ -253,7 +253,7 @@ class ResearchQueueService
 
             // See if the planet has enough resources for this research attempt.
             $price = ObjectService::getObjectPrice($object->machine_name, $planet);
-            $research_time = $player->planets->current()->getTechnologyResearchTime($object->machine_name);
+            $research_time = $planet->getTechnologyResearchTime($object->machine_name);
 
             // Only start the queue item if there are no other queue items researching
             // for this planet.


### PR DESCRIPTION
Use the planet where research was queued instead of currently viewed planet for calculating research time. Fixes incorrect research duration when viewing a different planet with lower lab level.

## Description
This PR fixes a bug in the research queue system where starting a new research item from the queue would use the currently viewed planet’s research lab level instead of the originating planet’s research lab level to calculate research time.

### Type of Change:
- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #781 

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [X] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [X] **Static Analysis:** Code passes PHPStan static code analysis.
- [X] **Testing:** Tests successfully run locally.
- [ ] **CSS & JS Build:** No changes.
- [ ] **Documentation:** No changes.

## Additional Information
This is a minimal one-line fix that addresses the root cause of the issue. The variable  `$planet`  was already being correctly loaded from the queue item’s  `planet_id`, but was not being used for the research time calculation. This fix ensures consistency throughout the queue processing logic.
