### PR TITLE
728 fix expedition delay multipliers

### DIFF
--- a/app/GameMissions/ExpeditionMission.php
+++ b/app/GameMissions/ExpeditionMission.php
@@ -207,15 +207,9 @@ class ExpeditionMission extends GameMission
         $totalWeight = array_sum($delayFactors);
         $rand = mt_rand(1, $totalWeight);
 
-        // Pick a random delay multiplier
-        $selectedMultiplier = $delayMultipliers[array_rand($delayMultipliers)];
-
-        // Calculate total weight and generate random number
-        $totalWeight = array_sum($delayFactors);
-        $rand = mt_rand(1, $totalWeight);
-
         // Select multiplier based on cumulative weight
         $cumulativeWeight = 0;
+        $selectedMultiplier = 2; // fallback default
 
         foreach ($delayFactors as $factor => $weight) {
             $cumulativeWeight += $weight;
@@ -231,7 +225,7 @@ class ExpeditionMission extends GameMission
 
         // Apply universe fleet speed modifier
         // Formula: Actual Delay = Base Delay / Fleet Speed
-        $fleetSpeed = $this->settingsService->fleetSpeed();
+        $fleetSpeed = $this->settings->fleetSpeed();
         $additionalReturnTripTime = intval($baseAdditionalReturnTripTime / $fleetSpeed);
 
         // Send a message to the player with the failure and delay outcome


### PR DESCRIPTION
## Description
add weighted factor of 2,3 and 5 for the delay calculation


### Type of Change:
- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #728 

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [x] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [x] **Static Analysis:** Code passes PHPStan static code analysis.
- [ ] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [ ] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [ ] **Documentation:** Documentation has been updated to reflect any changes made.


