### PR TITLE
feat: add cancel functionality for unit queue (ships and defense)

### DIFF
--- a/app/Http/Controllers/Abstracts/AbstractUnitsController.php
+++ b/app/Http/Controllers/Abstracts/AbstractUnitsController.php
@@ -155,4 +155,38 @@ abstract class AbstractUnitsController extends OGameController
             'message' => 'Added to build order.',
         ]);
     }
+
+    /**
+     * Handles an incoming cancel buildrequest.
+     *
+     * @param Request $request
+     * @param PlayerService $player
+     * @return \Illuminate\Http\RedirectResponse
+     * @throws Exception
+     */
+    public function cancelBuildRequest(Request $request, PlayerService $player)
+    {
+        // Explicitly verify CSRF token
+        if (!hash_equals($request->session()->token(), $request->input('_token'))) {
+            return redirect()->route($this->route_view_index)
+                ->with('error', 'Invalid token.');
+        }
+
+        $unit_id = $request->input('technologyId');
+        $unit_queue_id = $request->input('listId');
+
+        if (!$unit_id || !$unit_queue_id) {
+            return redirect()->route($this->route_view_index)
+                ->with('error', 'Missing required parameters.');
+        }
+
+        try {
+            $this->queue->cancel($player->planets->current(), $unit_queue_id, $unit_id);
+
+            return redirect()->route($this->route_view_index);
+        } catch (Exception $e) {
+            return redirect()->route($this->route_view_index)
+                ->with('error', 'Failed to cancel: ' . $e->getMessage());
+        }
+    }
 }

--- a/resources/views/ingame/defense/index.blade.php
+++ b/resources/views/ingame/defense/index.blade.php
@@ -44,8 +44,19 @@
                     </div>
                     <script type="text/javascript">
                         var scheduleBuildListEntryUrl = '{{ route('shipyard.addbuildrequest') }}';
+                        var cancelBuildListEntryUrl = '{{ route('defense.cancelbuildrequest') }}';
                         var LOCA_ERROR_INQUIRY_NOT_WORKED_TRYAGAIN = 'Your last action could not be processed. Please try again.';
                         redirectPremiumLink = '#TODO_index.php?page=premium&showDarkMatter=1'
+
+                        function cancelbuilding(id, listId, question) {
+                            errorBoxDecision('Caution', "" + question + "", 'yes', 'No', function () {
+                                buildListActionCancel(id, listId)
+                            });
+                        }
+
+                        function buildListActionCancel(id, listId) {
+                            $('<form id="cancelProductionStart" action="' + cancelBuildListEntryUrl + '" method="POST" style="display: none;">{{ csrf_field() }}<input type="hidden" name="technologyId" value="' + id + '" /> <input type="hidden" name="listId" value="' + listId + '" /></form>').appendTo('body').submit();
+                        }
                     </script>
                 </div>
             </div>

--- a/resources/views/ingame/shared/buildqueue/unit-active.blade.php
+++ b/resources/views/ingame/shared/buildqueue/unit-active.blade.php
@@ -8,7 +8,10 @@
         <tr class="data">
             <td class="first" rowspan="5">
                 <div>
-                    <a href="{{ route('shipyard.index', ['openTech' => $build_active->object->id]) }}">
+                    <a href="javascript:void(0);" class="tooltip js_hideTipOnMobile tpd-hideOnClickOutside"
+                       style="display: block;"
+                       onclick="cancelbuilding({!! $build_active->object->id !!},{!! $build_active->id !!},'Cancel production of {!! $build_active->object_amount_remaining !!}x {!! $build_active->object->title !!}?'); return false;"
+                       title="">
                         <img class="queuePic" width="40" height="40"
                              src="{!! asset('img/objects/units/' . $build_active->object->assets->imgSmall) !!}"
                              alt="{{ $build_active->object->title }}">

--- a/resources/views/ingame/shared/buildqueue/unit-queue.blade.php
+++ b/resources/views/ingame/shared/buildqueue/unit-queue.blade.php
@@ -5,11 +5,14 @@
         <tr>
             @foreach ($build_queue as $item)
                 <td>
+                    <a href="javascript:void(0);" class="queue_link tooltip js_hideTipOnMobile dark_highlight_tablet"
+                       onclick="cancelbuilding({!! $item->object->id !!},{!! $item->id !!},&quot;Cancel production of {!! $item->object_amount !!}x {!! $item->object->title !!}?&quot;); return false;"
+                       title="">
                         <img class="queuePic"
                              src="{!! asset('img/objects/units/' . $item->object->assets->imgSmall) !!}" height="28"
                              width="28" alt="{!! $item->object->title !!}">
-                    <br />
-                    {!! $item->object_amount !!}
+                        <span>{!! $item->object_amount !!}</span>
+                    </a>
                 </td>
             @endforeach
         </tr>

--- a/resources/views/ingame/shipyard/index.blade.php
+++ b/resources/views/ingame/shipyard/index.blade.php
@@ -55,8 +55,19 @@
                     </div>
                     <script type="text/javascript">
                         var scheduleBuildListEntryUrl = '{{ route('shipyard.addbuildrequest') }}';
+                        var cancelBuildListEntryUrl = '{{ route('shipyard.cancelbuildrequest') }}';
                         var LOCA_ERROR_INQUIRY_NOT_WORKED_TRYAGAIN = 'Your last action could not be processed. Please try again.';
                         redirectPremiumLink = '#TODO_index.php?page=premium&showDarkMatter=1'
+
+                        function cancelbuilding(id, listId, question) {
+                            errorBoxDecision('Caution', "" + question + "", 'yes', 'No', function () {
+                                buildListActionCancel(id, listId)
+                            });
+                        }
+
+                        function buildListActionCancel(id, listId) {
+                            $('<form id="cancelProductionStart" action="' + cancelBuildListEntryUrl + '" method="POST" style="display: none;">{{ csrf_field() }}<input type="hidden" name="technologyId" value="' + id + '" /> <input type="hidden" name="listId" value="' + listId + '" /></form>').appendTo('body').submit();
+                        }
                     </script>
                 </div>
             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -76,11 +76,13 @@ Route::middleware(['auth', 'globalgame', 'locale'])->group(function () {
     Route::get('/shipyard', [ShipyardController::class, 'index'])->name('shipyard.index');
     Route::get('/ajax/shipyard', [ShipyardController::class, 'ajax'])->name('shipyard.ajax');
     Route::post('/shipyard/add-buildrequest', [ShipyardController::class, 'addBuildRequest'])->name('shipyard.addbuildrequest');
+    Route::post('/shipyard/cancel-buildrequest', [ShipyardController::class, 'cancelBuildRequest'])->name('shipyard.cancelbuildrequest');
 
     // Defense
     Route::get('/defense', [DefenseController::class, 'index'])->name('defense.index');
     Route::get('/ajax/defense', [DefenseController::class, 'ajax'])->name('defense.ajax');
     Route::post('/defense/add-buildrequest', [DefenseController::class, 'addBuildRequest'])->name('defense.addbuildrequest');
+    Route::post('/defense/cancel-buildrequest', [DefenseController::class, 'cancelBuildRequest'])->name('defense.cancelbuildrequest');
 
     // Techtree
     Route::get('/ajax/techtree', [TechtreeController::class, 'ajax'])->name('techtree.ajax');


### PR DESCRIPTION
## Description

Adds cancel functionality for unit production queues (ships and defense), matching building and research queues. Users can cancel queued or in-progress units and receive a refund for remaining units.

### Type of Change:

- [x] Feature enhancement

## Related Issues

N/A

## Checklist

Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [x] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [x] **Static Analysis:** Code passes PHPStan static code analysis. (Some pre-existing warnings unrelated to this PR)
- [x] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [x] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files. (No build changes required)
- [ ] **Documentation:** Documentation has been updated to reflect any changes made.

## Additional Information

**Changes:**
- Added `cancel()` method to `UnitQueueService` with proportional refund calculation
- Added `cancelBuildRequest()` controller method with CSRF protection
- Updated UI: click unit images to cancel
- Added routes for shipyard and defense cancellation

**Refund Logic:**
- Refunds resources based on remaining units: `refund = stored_resource * remaining_amount / object_amount`
- Handles partial builds correctly (e.g., if 30/100 units are built, refunds for 70 units)

**UI/UX:**
- Consistent with existing building/research queue cancellation
- Page reload confirms success