### PR TITLE
Fix Techtree Properties Tooltip

### DIFF
--- a/app/Http/Controllers/TechtreeController.php
+++ b/app/Http/Controllers/TechtreeController.php
@@ -294,13 +294,13 @@ class TechtreeController extends OGameController
 
         $tooltips_array = [];
         $tooltips_array['structural_integrity'] = $this->getPropertyTooltip($properties->structural_integrity->name, $structural_integrity->breakdown, $structural_integrity->totalValue);
-        $tooltips_array['shield'] = $this->getPropertyTooltip($properties->shield->name, $shield->breakdown, $structural_integrity->totalValue);
-        $tooltips_array['attack'] = $this->getPropertyTooltip($properties->attack->name, $attack->breakdown, $structural_integrity->totalValue);
+        $tooltips_array['shield'] = $this->getPropertyTooltip($properties->shield->name, $shield->breakdown, $shield->totalValue);
+        $tooltips_array['attack'] = $this->getPropertyTooltip($properties->attack->name, $attack->breakdown, $attack->totalValue);
 
         if ($object->type !== GameObjectType::Defense) {
-            $tooltips_array['speed'] = $this->getPropertyTooltip($properties->speed->name, $speed->breakdown, $structural_integrity->totalValue);
-            $tooltips_array['capacity'] = $this->getPropertyTooltip($properties->capacity->name, $capacity->breakdown, $structural_integrity->totalValue);
-            $tooltips_array['fuel'] = $this->getPropertyTooltip($properties->fuel->name, $fuel->breakdown, $structural_integrity->totalValue);
+            $tooltips_array['speed'] = $this->getPropertyTooltip($properties->speed->name, $speed->breakdown, $speed->totalValue);
+            $tooltips_array['capacity'] = $this->getPropertyTooltip($properties->capacity->name, $capacity->breakdown, $capacity->totalValue);
+            $tooltips_array['fuel'] = $this->getPropertyTooltip($properties->fuel->name, $fuel->breakdown, $fuel->totalValue);
         }
 
         return view('ingame.techtree.info.properties')->with([


### PR DESCRIPTION
## Description
All property tooltips were incorrectly using `$structural_integrity->totalValue` for the sum calculation, instead of their own respective values.

### Type of Change:
- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #711 

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [X] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [X] **Static Analysis:** Code passes PHPStan static code analysis.
- [X] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [ ] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [ ] **Documentation:** Documentation has been updated to reflect any changes made.

## Additional Information
Current: 
<img width="807" height="431" alt="image" src="https://github.com/user-attachments/assets/6d706005-a0c6-4809-81ce-1602381d3959" />
With this PR:
<img width="807" height="431" alt="image" src="https://github.com/user-attachments/assets/7e99c772-f89a-40b3-b389-5d581f32e2fd" />

