### PR TITLE
Fix planet_id_from being incorrectly set for moons

### DIFF
--- a/app/Services/PhalanxService.php
+++ b/app/Services/PhalanxService.php
@@ -129,16 +129,6 @@ class PhalanxService
         $scan_results = [];
 
         foreach ($fleet_missions as $mission) {
-            // Debug: Log mission details
-            \Log::debug('Phalanx scanning mission', [
-                'mission_id' => $mission->id,
-                'parent_id' => $mission->parent_id,
-                'mission_type' => $mission->mission_type,
-                'planet_id_from' => $mission->planet_id_from,
-                'planet_id_to' => $mission->planet_id_to,
-                'target_planet_id' => $target_planet_id,
-            ]);
-
             // Determine if this is incoming to the scanned planet
             $is_incoming = $mission->planet_id_to === $target_planet_id;
 
@@ -162,7 +152,6 @@ class PhalanxService
                         $mission_type_name = $this->getMissionTypeName($mission->mission_type);
                         $fleet_direction = $this->getFleetDirectionLabel($mission->user_id, $scanner_player_id, $mission->mission_type);
 
-                        \Log::debug('Phalanx adding PREDICTED return trip', ['mission_id' => $mission->id]);
                         $scan_results[] = [
                             'mission_id' => $mission->id + 999999,
                             'mission_type' => $mission->mission_type,
@@ -230,10 +219,6 @@ class PhalanxService
             $fleet_icon = $is_return_trip ? '014a5d88b102d4b47ab5146d4807c6.gif' : 'f9cb590cdf265f499b0e2e5d91fc75.gif'; // Left for return, right for incoming
 
             // Add the incoming mission to results
-            \Log::debug('Phalanx adding INCOMING mission', [
-                'mission_id' => $mission->id,
-                'is_return_trip' => $is_return_trip
-            ]);
             $scan_results[] = [
                 'mission_id' => $mission->id,
                 'mission_type' => $mission->mission_type,

--- a/tests/Feature/PhalanxTest.php
+++ b/tests/Feature/PhalanxTest.php
@@ -310,11 +310,6 @@ class PhalanxTest extends FleetDispatchTestCase
         ]);
 
         $response->assertStatus(200);
-        // Debug: dump the fleet count if it's not 1
-        if ($response->json('fleet_count') !== 1) {
-            dump('Fleet count:', $response->json('fleet_count'));
-            dump('Response:', $response->json());
-        }
         $this->assertEquals(1, $response->json('fleet_count'));
 
         // Check that it shows "Your fleet"


### PR DESCRIPTION
## Description
When sending a fleet to a moon and then recalling it, the return mission DB record did not set `planet_id_from` properly. This caused the moon icon to display without the moon's name in the fleet movement UI.

This fix also revealed a sligh issue with `PhalanxService.php`: The code predicted return trips for EVERY outgoing mission, even if that mission was already a return trip. 

When testing this fix, return missions were now properly recorded with their origin planet. So phalanx started finding them and incorrectly predicting they would have their own return trips. This created duplicate/phantom entries (2 fleets instead of 1).

### Type of Change:
- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #715 

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [X] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [X] **Static Analysis:** Code passes PHPStan static code analysis.
- [X] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [ ] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [X] **Documentation:** Documentation has been updated to reflect any changes made.

## Additional Information
Add any additional context, screenshots, or explanations to help reviewers understand your PR. If this change introduces any breaking changes or significant impacts, please detail them here.
