### PR TITLE
Fix Techtree typo

### DIFF
--- a/resources/views/ingame/techtree/partials/nav.blade.php
+++ b/resources/views/ingame/techtree/partials/nav.blade.php
@@ -3,7 +3,7 @@
     <ul>
         <li>
             <a class="overlay" data-action="technologytree" data-overlay-same="true" href="{{ route('techtree.ajax', ['tab' => 1, 'object_id' => $objectId]) }}">
-                @lang('Techtree')
+                @lang('techtree')
             </a>
         </li>
         <li>


### PR DESCRIPTION
Turn capitalized Techtree into lowercase techtree

## Description
This PR fixes a minor mistake. `Techtree` in `@lang('Techtree')` should be lowercase and not capitalized as per the original game.

### Type of Change:
- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #[issue-number]

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [ ] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [ ] **Static Analysis:** Code passes PHPStan static code analysis.
- [ ] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [ ] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [ ] **Documentation:** Documentation has been updated to reflect any changes made.

## Additional Information
Original: 
<img width="205" height="75" alt="image" src="https://github.com/user-attachments/assets/e9bdd0f1-0e0d-4640-b34d-128169ad1e40" />

