### PR TITLE
Fix #806: Allow sending recyclers to invisible debris fields

### DIFF
--- a/app/Console/Commands/ResetDebrisFields.php
+++ b/app/Console/Commands/ResetDebrisFields.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace OGame\Console\Commands;
+
+use Illuminate\Console\Command;
+use OGame\Models\DebrisField;
+
+class ResetDebrisFields extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'ogamex:reset-debris-fields';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Resets (deletes) empty debris fields. In OGame, this happens weekly on Monday at 1:00 AM.';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): void
+    {
+        $this->info('Resetting empty debris fields...');
+
+        // Delete all debris fields that have no resources
+        $deletedCount = DebrisField::where('metal', 0)
+            ->where('crystal', 0)
+            ->where('deuterium', 0)
+            ->delete();
+
+        $this->info("Deleted {$deletedCount} empty debris field(s).");
+    }
+}

--- a/app/GameMissions/RecycleMission.php
+++ b/app/GameMissions/RecycleMission.php
@@ -38,8 +38,18 @@ class RecycleMission extends GameMission
             return new MissionPossibleStatus(false);
         }
 
-        // Allow sending recyclers to any debris field coordinate, even if empty or non-existent.
-        // This enables harvesting "invisible" debris fields (≤300 resources) that don't show in Galaxy View.
+        // Check if debris field exists (including "ghost" fields with 0 resources).
+        // In OGame, debris fields persist as invisible "ghost" fields after being fully harvested
+        // until the weekly reset (Monday 1:00 AM). This allows players to send recyclers to
+        // coordinates where a debris field existed, even if it currently has no resources.
+        $debrisField = app(DebrisFieldService::class);
+        $debrisFieldExists = $debrisField->loadForCoordinates($targetCoordinate);
+
+        if (!$debrisFieldExists) {
+            return new MissionPossibleStatus(false);
+        }
+
+        // If all checks pass, the mission is possible.
         return new MissionPossibleStatus(true);
     }
 

--- a/routes/console.php
+++ b/routes/console.php
@@ -2,6 +2,7 @@
 
 use OGame\Console\Commands\GenerateHighscores;
 use OGame\Console\Commands\GenerateHighscoreRanks;
+use OGame\Console\Commands\ResetDebrisFields;
 
 /*
 |--------------------------------------------------------------------------
@@ -16,3 +17,6 @@ use OGame\Console\Commands\GenerateHighscoreRanks;
 
 Schedule::command(GenerateHighscores::class)->everyFiveMinutes();
 Schedule::command(GenerateHighscoreRanks::class)->everyFiveMinutes();
+
+// Reset empty debris fields weekly on Monday at 1:00 AM
+Schedule::command(ResetDebrisFields::class)->weeklyOn(1, '1:00');


### PR DESCRIPTION
## Description

Fixes bug where players couldn't send recyclers to completely harvested debris fields. Implements proper "ghost debris field" mechanics matching official OGame behavior.

### Type of Change:

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues

Fixes #806

## Checklist

- [x] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [x] **Static Analysis:** Code passes PHPStan static code analysis.
- [x] **Testing:** All 11 recycle mission tests pass locally.
- [x] **CSS & JS Build:** No CSS/JS changes.
- [x] **Documentation:** No documentation changes needed.

## Additional Information

### Behavior

- Can send recyclers to debris fields with resources (visible in Galaxy View)
- Can send recyclers to ghost debris fields with 0 resources (invisible)
- Cannot send recyclers to coordinates that never had debris fields
- Ghost fields are automatically cleaned up every Monday at 1:00 AM
