### PR TITLE
Fix ship building completion redirecting to /false

### DIFF
--- a/resources/views/ingame/shared/buildqueue/unit-active.blade.php
+++ b/resources/views/ingame/shared/buildqueue/unit-active.blade.php
@@ -61,7 +61,7 @@
         var pricebuilding = 750;
         var referrerPage = $.deparam.querystring().page;
         new CountdownTimer('unitCountdown', {{ $build_active->time_countdown }}, '{{ url()->current() }}', null, true, 3)
-        new CountdownTimerUnit('shipyardCountdownUnit', {{ $build_active->time_countdown_object_next }}, {{ $build_active->object_amount_remaining }}, {{ $build_active->object->id }}, {{ $build_active->time_countdown_per_object }}, false, 3)
+        new CountdownTimerUnit('shipyardCountdownUnit', {{ $build_active->time_countdown_object_next }}, {{ $build_active->object_amount_remaining }}, {{ $build_active->object->id }}, {{ $build_active->time_countdown_per_object }}, null, 3)
     </script>
 @else
     <table cellspacing="0" cellpadding="0" class="construction active">


### PR DESCRIPTION
## Description

Fixes bug where ship building completion redirects to `/false` (404 error).

**What happens:**
Sometimes when a ship finishes building, the page unexpectedly redirects to `/false` (404 error) instead of staying on the planet page.

**Root cause:**
There are two countdown timers running simultaneously:
1. `CountdownTimer` (total queue time) - has a valid URL, reloads page when done
2. `CountdownTimerUnit` (per-unit time) - receives `false` as reloadPage parameter

The bug occurs when timer 2 completes before timer 1 (race condition). The JavaScript checks `reloadPage != null`, and since `false != null` is true, it calls `reload_page(false)` which redirects to `/false`.

Usually, timer 1 reloads the page first, masking the bug. But in certain timing scenarios, timer 2 triggers first, causing the redirect to `/false`.

**Fix:**
Changed `false` to `null` in `CountdownTimerUnit`. Now `null != null` is false, so no redirect occurs when the per-unit timer completes.

### Type of Change:

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues

Fixes #714

## Checklist

- [x] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [x] **Static Analysis:** Code passes PHPStan static code analysis.
- [x] **Testing:** Tests successfully run locally.
- [ ] **CSS & JS Build:** N/A - no JS/CSS changes
- [ ] **Documentation:** N/A - simple bug fix

## Additional Information

No breaking changes.
