### PR TITLE
fix: add required parameters to createMoonForPlanet method call

### DIFF
--- a/tests/Feature/JumpGateTest.php
+++ b/tests/Feature/JumpGateTest.php
@@ -38,7 +38,7 @@ class JumpGateTest extends MoonTestCase
 
         // Create second moon for the second planet
         $planetServiceFactory = resolve(PlanetServiceFactory::class);
-        $this->secondMoonService = $planetServiceFactory->createMoonForPlanet($this->secondPlanetService);
+        $this->secondMoonService = $planetServiceFactory->createMoonForPlanet($this->secondPlanetService, 100000, 20);
 
         // Set up Jump Gate on second moon
         $this->secondMoonService->setObjectLevel($jumpGateObject->id, 1, true);


### PR DESCRIPTION
## Description

Fixed failing JumpGateTest by adding required parameters to the `createMoonForPlanet()` method call. The method signature requires three parameters (`$planet`, `$debrisAmount`, `$moonChance`), but the test was only passing one parameter, causing fail.

### Type of Change:

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues

Fixes GitHub workflow test failures

## Checklist

Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [x] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [x] **Static Analysis:** Code passes PHPStan static code analysis.
- [x] **Testing:**
  - Relevant unit and feature tests are included or updated.
  - Tests successfully run locally.
- [x] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [x] **Documentation:** Documentation has been updated to reflect any changes made.

## Additional Information

Nope
