### PR TITLE
fix: Space Dock no longer counts towards planet fields (#713)

### DIFF
--- a/app/GameObjects/Models/Abstracts/GameObject.php
+++ b/app/GameObjects/Models/Abstracts/GameObject.php
@@ -69,6 +69,14 @@ abstract class GameObject
     public GameObjectAssets $assets;
 
     /**
+     * Whether this object consumes a planet field when built. Most buildings consume a field,
+     * but some (like Space Dock which floats in orbit) do not.
+     *
+     * @var bool
+     */
+    public bool $consumesPlanetField = true;
+
+    /**
      * Custom calculation formulas for this object. These formulas can be used to calculate custom values for the object.
      * E.g. a formula to determine max amount of planets that can be colonized with astrophysics technology.
      *

--- a/app/GameObjects/StationObjects.php
+++ b/app/GameObjects/StationObjects.php
@@ -166,6 +166,7 @@ Since the Space Dock floats in orbit, it does not require a planet field.';
             new GameObjectRequirement('shipyard', 2),
         ];
         $spaceDock->price = new GameObjectPrice(200, 0, 50, 50, 2);
+        $spaceDock->consumesPlanetField = false; // Space Dock floats in orbit and doesn't consume a field
         $spaceDock->valid_planet_types = [PlanetType::Planet];
         $spaceDock->assets = new GameObjectAssets();
         $spaceDock->assets->imgMicro = 'space_dock_micro.jpg';

--- a/app/Services/PlanetService.php
+++ b/app/Services/PlanetService.php
@@ -1854,13 +1854,22 @@ class PlanetService
     }
 
     /**
-     * Get building count from planet
+     * Get building count from planet (number of fields used by buildings)
      *
      * @return int
      */
     public function getBuildingCount(): int
     {
-        return collect($this->getBuildingArray())->sum();
+        $count = 0;
+        $objects = [...ObjectService::getBuildingObjects(), ...ObjectService::getStationObjects()];
+        foreach ($objects as $object) {
+            // Only count buildings that consume planet fields
+            if ($object->consumesPlanetField && $this->planet->{$object->machine_name} > 0) {
+                $count += $this->planet->{$object->machine_name};
+            }
+        }
+
+        return $count;
     }
 
     /**

--- a/tests/Unit/PlanetServiceTest.php
+++ b/tests/Unit/PlanetServiceTest.php
@@ -221,4 +221,31 @@ class PlanetServiceTest extends UnitTestCase
         // Should only return valid buildings, ( ie metal_mine crystal_mine, solar_plant )
         $this->assertEquals(150, $this->planetService->getBuildingCount());
     }
+
+    /**
+     * Test that Space Dock does not count towards planet fields.
+     * Space Dock floats in orbit and should not consume a planet field.
+     */
+    public function testSpaceDockDoesNotConsumeField(): void
+    {
+        // Test with only Space Dock
+        $this->createAndSetPlanetModel([
+            'space_dock' => 5,
+        ]);
+
+        // Space Dock should not count towards building count (fields used)
+        $this->assertEquals(0, $this->planetService->getBuildingCount(), 'Space Dock should not consume planet fields.');
+
+        // Test with Space Dock and other buildings
+        $this->createAndSetPlanetModel([
+            'metal_mine' => 10,
+            'crystal_mine' => 5,
+            'space_dock' => 3,
+            'robot_factory' => 2,
+        ]);
+
+        // Should only count metal_mine (10) + crystal_mine (5) + robot_factory (2) = 17
+        // Space Dock (3) should NOT be counted
+        $this->assertEquals(17, $this->planetService->getBuildingCount(), 'Space Dock levels should not be included in building count.');
+    }
 }


### PR DESCRIPTION
## Description

Fixes bug where Space Dock incorrectly counted towards planet fields. Space Dock "floats in orbit" per its description and should not consume a field.

**Solution:** Added `consumesPlanetField` property to `GameObject` class (defaults to `true`), set to `false` for Space Dock. Updated field calculation logic to respect this property.

### Type of Change:

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues

Fixes #713

## Checklist

- [x] **Code Standards:** Code adheres to PSR-12 coding standards.
- [x] **Static Analysis:** Code passes PHPStan static code analysis.
- [x] **Testing:** Unit tests added and passing locally.
- [x] **CSS & JS Build:** N/A - no frontend changes.
- [x] **Documentation:** N/A - code is self-documenting.

## Additional Information

**Test Results:** All PlanetServiceTest tests pass (9/9). New test verifies Space Dock doesn't count towards fields.

**Example:** Planet with Metal Mine (10) + Space Dock (3) = 10 fields used (not 13).
