### PR TITLE
fix: add separate fuel capacity for ships to fix espionage probe carg…

### DIFF
--- a/app/GameMissions/Abstracts/GameMission.php
+++ b/app/GameMissions/Abstracts/GameMission.php
@@ -202,9 +202,10 @@ abstract class GameMission
         $this->startMissionSanityChecks($planet, $targetCoordinate, $targetType, $units, $deduct_resources);
 
         $totalCargoCapacity = $units->getTotalCargoCapacity($planet->getPlayer());
+        $totalFuelCapacity = $units->getTotalFuelCapacity($planet->getPlayer());
 
         // Check if the player has sufficient deuterium storage capacity for the fleet.
-        if ($totalCargoCapacity < $consumption) {
+        if ($totalFuelCapacity < $consumption) {
             throw new Exception(__('You don\'t have sufficient storage capacity!'));
         }
 

--- a/app/GameObjects/CivilShipObjects.php
+++ b/app/GameObjects/CivilShipObjects.php
@@ -150,7 +150,7 @@ As soon as Impulse Drive research has reached level 17, Recyclers are refitted w
             new GameObjectRequirement('espionage_technology', 2),
         ];
         $espionageProbe->price = new GameObjectPrice(0, 1000, 0, 0);
-        $espionageProbe->properties = new GameObjectProperties($espionageProbe, 1000, 0, 0, 100000000, 5, 1);
+        $espionageProbe->properties = new GameObjectProperties($espionageProbe, 1000, 0, 0, 100000000, 0, 1, 5);
 
         $espionageProbe->assets = new GameObjectAssets();
         $espionageProbe->assets->imgSmall = 'espionage_probe_small.jpg';

--- a/app/GameObjects/Models/Fields/GameObjectProperties.php
+++ b/app/GameObjects/Models/Fields/GameObjectProperties.php
@@ -5,6 +5,7 @@ namespace OGame\GameObjects\Models\Fields;
 use OGame\GameObjects\Models\Abstracts\GameObject;
 use OGame\GameObjects\Services\Properties\AttackPropertyService;
 use OGame\GameObjects\Services\Properties\CapacityPropertyService;
+use OGame\GameObjects\Services\Properties\FuelCapacityPropertyService;
 use OGame\GameObjects\Services\Properties\FuelPropertyService;
 use OGame\GameObjects\Services\Properties\ShieldPropertyService;
 use OGame\GameObjects\Services\Properties\SpeedPropertyService;
@@ -18,6 +19,7 @@ class GameObjectProperties
     public GameObjectProperty $speed;
     public GameObjectProperty $capacity;
     public GameObjectProperty $fuel;
+    public GameObjectProperty $fuel_capacity;
 
     /**
      * Upgrades to speed for this object depending on alternative drive technology level. Items with higher
@@ -36,10 +38,11 @@ class GameObjectProperties
      * @param int $shield
      * @param int $attack
      * @param int $speed
-     * @param int $capacity
-     * @param int $fuel
+     * @param int $capacity Cargo capacity for transporting resources
+     * @param int $fuel Fuel consumption rate (Deuterium)
+     * @param int|null $fuel_capacity Fuel capacity for holding deuterium. Defaults to $capacity if not provided for backward compatibility.
      */
-    public function __construct(GameObject $parentObject, int $structural_integrity, int $shield, int $attack, int $speed, int $capacity, int $fuel)
+    public function __construct(GameObject $parentObject, int $structural_integrity, int $shield, int $attack, int $speed, int $capacity, int $fuel, int|null $fuel_capacity = null)
     {
         $calculationService = new StructuralIntegrityPropertyService($parentObject, $structural_integrity);
         $this->structural_integrity = new GameObjectProperty('Structural Integrity', $structural_integrity, $calculationService);
@@ -58,5 +61,9 @@ class GameObjectProperties
 
         $calculationService = new FuelPropertyService($parentObject, $fuel);
         $this->fuel = new GameObjectProperty('Fuel usage (Deuterium)', $fuel, $calculationService);
+
+        $fuelCapacityValue = $fuel_capacity ?? $capacity;
+        $calculationService = new FuelCapacityPropertyService($parentObject, $fuelCapacityValue);
+        $this->fuel_capacity = new GameObjectProperty('Fuel Capacity', $fuelCapacityValue, $calculationService);
     }
 }

--- a/app/GameObjects/Models/Units/UnitCollection.php
+++ b/app/GameObjects/Models/Units/UnitCollection.php
@@ -264,4 +264,19 @@ class UnitCollection
         }
         return $total;
     }
+
+    /**
+     * Get the total fuel capacity of the units in the collection.
+     *
+     * @param PlayerService $player
+     * @return int
+     */
+    public function getTotalFuelCapacity(PlayerService $player): int
+    {
+        $total = 0;
+        foreach ($this->units as $entry) {
+            $total += $entry->unitObject->properties->fuel_capacity->calculate($player)->totalValue * $entry->amount;
+        }
+        return $total;
+    }
 }

--- a/app/GameObjects/Services/Properties/FuelCapacityPropertyService.php
+++ b/app/GameObjects/Services/Properties/FuelCapacityPropertyService.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace OGame\GameObjects\Services\Properties;
+
+use OGame\GameObjects\Services\Properties\Abstracts\ObjectPropertyService;
+use OGame\Services\PlayerService;
+
+/**
+ * Class FuelCapacityPropertyService.
+ *
+ * Handles fuel capacity calculations for ships. Fuel capacity determines
+ * how much deuterium a ship can hold for consumption during flight,
+ * separate from cargo capacity used for transporting resources.
+ *
+ * @package OGame\Services
+ */
+class FuelCapacityPropertyService extends ObjectPropertyService
+{
+    protected string $propertyName = 'fuel_capacity';
+
+    /**
+     * @inheritDoc
+     */
+    protected function getBonusPercentage(PlayerService $player): int
+    {
+        // Fuel capacity uses the same bonus as cargo capacity (hyperspace technology)
+        $hyperspace_technology_level = $player->getResearchLevel('hyperspace_technology');
+        return 5 * $hyperspace_technology_level;
+    }
+}

--- a/app/Http/Controllers/FleetController.php
+++ b/app/Http/Controllers/FleetController.php
@@ -112,7 +112,7 @@ class FleetController extends OGameController
             $shipsData[$shipObject->id] = [
                 'id' => $shipObject->id,
                 'name' => $shipObject->title,
-                'baseFuelCapacity' => $shipObject->properties->capacity->calculate($currentPlayer)->totalValue,
+                'baseFuelCapacity' => $shipObject->properties->fuel_capacity->calculate($currentPlayer)->totalValue,
                 'baseCargoCapacity' => $shipObject->properties->capacity->calculate($currentPlayer)->totalValue,
                 'fuelConsumption' => $shipObject->properties->fuel->calculate($currentPlayer)->totalValue,
                 'speed' => $shipObject->properties->speed->calculate($currentPlayer)->totalValue

--- a/tests/Feature/FleetDispatchCheckTargetTest.php
+++ b/tests/Feature/FleetDispatchCheckTargetTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\FleetDispatchTestCase;
+
+/**
+ * Test FleetController dispatchCheckTarget API response.
+ */
+class FleetDispatchCheckTargetTest extends FleetDispatchTestCase
+{
+    /**
+     * Prepare the planet for the test.
+     */
+    protected function basicSetup(): void
+    {
+        $this->planetSetObjectLevel('shipyard', 1);
+        $this->playerSetResearchLevel('combustion_drive', 1);
+        $this->planetAddUnit('small_cargo', 5);
+        $this->planetAddUnit('espionage_probe', 3);
+    }
+
+    /**
+     * Test API returns both cargo and fuel capacity for all ships.
+     */
+    public function testDispatchCheckTargetCapacityFields(): void
+    {
+        $this->basicSetup();
+
+        $response = $this->post('/ajax/fleet/dispatch/check-target', [
+            'galaxy' => 1,
+            'system' => 1,
+            'position' => 5,
+            'type' => 1,
+        ]);
+
+        $response->assertStatus(200);
+        $data = $response->json();
+
+        // All ships must have both capacity fields
+        foreach ($data['shipsData'] as $shipId => $shipData) {
+            $this->assertArrayHasKey('baseFuelCapacity', $shipData);
+            $this->assertArrayHasKey('baseCargoCapacity', $shipData);
+        }
+
+        // Small cargo: equal capacities (backward compatibility)
+        $this->assertEquals(5000, $data['shipsData'][202]['baseCargoCapacity']);
+        $this->assertEquals(5000, $data['shipsData'][202]['baseFuelCapacity']);
+
+        // Espionage probe: cargo=0, fuel=5
+        $this->assertEquals(0, $data['shipsData'][210]['baseCargoCapacity']);
+        $this->assertEquals(5, $data['shipsData'][210]['baseFuelCapacity']);
+    }
+}

--- a/tests/Unit/ObjectPropertiesTest.php
+++ b/tests/Unit/ObjectPropertiesTest.php
@@ -211,4 +211,26 @@ class ObjectPropertiesTest extends UnitTestCase
         $this->assertEquals(400, $calculated->bonusValue);
         $this->assertEquals(4400, $calculated->totalValue);
     }
+
+    /**
+     * Test fuel capacity: defaults to cargo capacity for backward compatibility,
+     * but can be set independently (e.g., espionage probe).
+     *
+     * @throws Exception
+     */
+    public function testFuelCapacityProperty(): void
+    {
+        $this->createAndSetPlanetModel([]);
+        $this->createAndSetUserTechModel([]);
+
+        // Backward compatibility: fuel_capacity defaults to capacity
+        $smallCargo = ObjectService::getShipObjectByMachineName('small_cargo');
+        $this->assertEquals(5000, $smallCargo->properties->capacity->rawValue);
+        $this->assertEquals(5000, $smallCargo->properties->fuel_capacity->rawValue);
+
+        // Independent values: espionage probe has cargo=0, fuel=5
+        $espionageProbe = ObjectService::getShipObjectByMachineName('espionage_probe');
+        $this->assertEquals(0, $espionageProbe->properties->capacity->rawValue);
+        $this->assertEquals(5, $espionageProbe->properties->fuel_capacity->rawValue);
+    }
 }


### PR DESCRIPTION
## Description

Introduces a separate `fuel_capacity` property for ships to fix the espionage probe exploit. Espionage probes now have cargo capacity = 0 (cannot transport resources) but fuel capacity = 5 (can still fly). Fully backward compatible - existing ships default fuel capacity to cargo capacity.

### Type of Change:
- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues

Fixes #206

## Checklist

- [x] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [x] **Static Analysis:** Code passes PHPStan static code analysis.
- [x] **Testing:** Relevant unit and feature tests are included or updated. Tests successfully run locally.
- [x] **CSS & JS Build:** N/A - No JS/CSS changes.
- [x] **Documentation:** N/A - Code is self-documenting with comprehensive tests.

## Additional Information

**Changes:**
- Added `FuelCapacityPropertyService` for fuel capacity calculations
- Updated `GameObjectProperties` with fuel_capacity property (defaults to capacity for backward compatibility)
- Espionage probe: cargo=0, fuel=5
- Fleet validation now uses fuel capacity for deuterium checks

