### PR TITLE
feat: add pagination context to full message view overlay #203

### DIFF
--- a/app/GameMessages/Abstracts/GameMessage.php
+++ b/app/GameMessages/Abstracts/GameMessage.php
@@ -199,6 +199,18 @@ abstract class GameMessage
     }
 
     /**
+     * Build the URL for the full message view with tab/subtab context.
+     *
+     * @return string
+     */
+    protected function getFullMessageUrl(): string
+    {
+        $url = route('messages.ajax.getmessage', ['messageId' => $this->message->id]);
+        $url .= '?tab=' . urlencode($this->tab) . '&subtab=' . urlencode($this->subtab);
+        return $url;
+    }
+
+    /**
      * Get the params that the message requires to be filled.
      *
      * @return array<int, string>

--- a/app/GameMessages/BattleReport.php
+++ b/app/GameMessages/BattleReport.php
@@ -115,9 +115,9 @@ class BattleReport extends GameMessage
      */
     public function getFooterDetails(): string
     {
-        // Show more details link in the footer of the espionage report.
+        // Show more details link in the footer of the battle report.
         return ' <a class="fright txt_link msg_action_link overlay"
-                   href="' . route('messages.ajax.getmessage', ['messageId' => $this->message->id])  .'"
+                   href="' . $this->getFullMessageUrl() . '"
                    data-overlay-title="More details">
                     More details
                 </a>';

--- a/app/GameMessages/EspionageReport.php
+++ b/app/GameMessages/EspionageReport.php
@@ -110,7 +110,7 @@ class EspionageReport extends GameMessage
     {
         // Show more details link in the footer of the espionage report.
         return ' <a class="fright txt_link msg_action_link overlay"
-                   href="' . route('messages.ajax.getmessage', ['messageId' => $this->message->id])  .'"
+                   href="' . $this->getFullMessageUrl() . '"
                    data-overlay-title="More details">
                     More details
                 </a>';
@@ -216,6 +216,7 @@ class EspionageReport extends GameMessage
             'subject' => $this->getSubject(),
             'from' => $this->getFrom(),
             'playername' => $player->getUsername(),
+            'date' => $this->getDateFormatted(),
             'resources' => $resources,
             'debris' => $debris,
             'ships' => $ships,

--- a/app/Http/Controllers/MessagesController.php
+++ b/app/Http/Controllers/MessagesController.php
@@ -139,20 +139,26 @@ class MessagesController extends OGameController
     }
 
     /**
-     * Returns an individual message for a full screen view.
+     * Returns an individual message for a full screen view with pagination context.
      *
      * @param int $messageId
+     * @param Request $request
      * @param MessageService $messageService
      * @return View
      */
-    public function ajaxGetMessage(int $messageId, MessageService $messageService): View
+    public function ajaxGetMessage(int $messageId, Request $request, MessageService $messageService): View
     {
-        // Get full message view model.
-        $messageObject = $messageService->getFullMessage($messageId);
+        // Get tab and subtab from request for pagination context
+        $tab = $request->get('tab');
+        $subtab = $request->get('subtab');
+
+        // Get full message with pagination context
+        $paginationData = $messageService->getMessagePaginationContext($messageId, $tab, $subtab);
 
         return view('ingame.messages.message')->with([
             'messageId' => $messageId,
-            'messageBody' => $messageObject->getBodyFull(),
+            'messageBody' => $paginationData['message']->getBodyFull(),
+            'pagination' => $paginationData['pagination'],
         ]);
     }
 

--- a/public/js/ingame.js
+++ b/public/js/ingame.js
@@ -84311,3 +84311,82 @@ TechnologyDetails.prototype.setMaximumBuildableAmount = function () {
   var $buildAmount = $('#technologydetails #build_amount');
   $buildAmount.val($buildAmount.attr('max'));
 };
+
+(function () {
+  var originalInitDetailMessages = ogame.messages.initDetailMessages;
+
+  ogame.messages.initDetailMessages = function (commentsAllowed) {
+    originalInitDetailMessages.call(ogame.messages, commentsAllowed);
+
+    $(".overlayDiv ul.pagination")
+      .off("click.msgPagination")
+      .on("click.msgPagination", "li.p_li a", function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        if ($(this).hasClass("disabled")) {
+          return false;
+        }
+
+        var messageId = $(this).data("messageid");
+        var tab = $(this).data("tab");
+        var subtab = $(this).data("subtab");
+
+        if (!messageId) {
+          return false;
+        }
+
+        var url = "/ajax/messages/" + messageId;
+        if (tab) {
+          url += "?tab=" + encodeURIComponent(tab);
+          if (subtab) {
+            url += "&subtab=" + encodeURIComponent(subtab);
+          }
+        }
+
+        var $overlayDiv = $(this).closest(".overlayDiv");
+        if ($overlayDiv.length === 0) {
+          $overlayDiv = $(".overlayDiv");
+        }
+
+        var $uiDialog = $overlayDiv.closest(".ui-dialog");
+        var dialogWidth = $uiDialog.length ? $uiDialog.width() : null;
+        var dialogHeight = $uiDialog.length ? $uiDialog.height() : null;
+        var dialogPosition = $uiDialog.length ? $uiDialog.position() : null;
+
+        $.get(url, function (response) {
+          try {
+            removeTooltip($overlayDiv.find(getTooltipSelector()));
+          } catch (err) {}
+
+          $overlayDiv.empty().append(response);
+
+          if ($uiDialog.length && dialogWidth && dialogHeight) {
+            $uiDialog.css({
+              width: dialogWidth,
+              height: dialogHeight,
+            });
+            if (dialogPosition) {
+              $uiDialog.css({
+                top: dialogPosition.top,
+                left: dialogPosition.left,
+              });
+            }
+            $uiDialog.hide().show();
+          }
+
+          ogame.messages.initDetailMessages(true);
+
+          try {
+            initTooltips();
+          } catch (err) {}
+        }).fail(function () {
+          if (typeof fadeBox === "function" && typeof loca !== "undefined") {
+            fadeBox(loca.LOCA_GALAXY_ERROR_OCCURED, 1);
+          }
+        });
+
+        return false;
+      });
+  };
+})();

--- a/public/js/ingame.min.js
+++ b/public/js/ingame.min.js
@@ -84311,3 +84311,82 @@ TechnologyDetails.prototype.setMaximumBuildableAmount = function () {
   var $buildAmount = $('#technologydetails #build_amount');
   $buildAmount.val($buildAmount.attr('max'));
 };
+
+(function () {
+  var originalInitDetailMessages = ogame.messages.initDetailMessages;
+
+  ogame.messages.initDetailMessages = function (commentsAllowed) {
+    originalInitDetailMessages.call(ogame.messages, commentsAllowed);
+
+    $(".overlayDiv ul.pagination")
+      .off("click.msgPagination")
+      .on("click.msgPagination", "li.p_li a", function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        if ($(this).hasClass("disabled")) {
+          return false;
+        }
+
+        var messageId = $(this).data("messageid");
+        var tab = $(this).data("tab");
+        var subtab = $(this).data("subtab");
+
+        if (!messageId) {
+          return false;
+        }
+
+        var url = "/ajax/messages/" + messageId;
+        if (tab) {
+          url += "?tab=" + encodeURIComponent(tab);
+          if (subtab) {
+            url += "&subtab=" + encodeURIComponent(subtab);
+          }
+        }
+
+        var $overlayDiv = $(this).closest(".overlayDiv");
+        if ($overlayDiv.length === 0) {
+          $overlayDiv = $(".overlayDiv");
+        }
+
+        var $uiDialog = $overlayDiv.closest(".ui-dialog");
+        var dialogWidth = $uiDialog.length ? $uiDialog.width() : null;
+        var dialogHeight = $uiDialog.length ? $uiDialog.height() : null;
+        var dialogPosition = $uiDialog.length ? $uiDialog.position() : null;
+
+        $.get(url, function (response) {
+          try {
+            removeTooltip($overlayDiv.find(getTooltipSelector()));
+          } catch (err) {}
+
+          $overlayDiv.empty().append(response);
+
+          if ($uiDialog.length && dialogWidth && dialogHeight) {
+            $uiDialog.css({
+              width: dialogWidth,
+              height: dialogHeight,
+            });
+            if (dialogPosition) {
+              $uiDialog.css({
+                top: dialogPosition.top,
+                left: dialogPosition.left,
+              });
+            }
+            $uiDialog.hide().show();
+          }
+
+          ogame.messages.initDetailMessages(true);
+
+          try {
+            initTooltips();
+          } catch (err) {}
+        }).fail(function () {
+          if (typeof fadeBox === "function" && typeof loca !== "undefined") {
+            fadeBox(loca.LOCA_GALAXY_ERROR_OCCURED, 1);
+          }
+        });
+
+        return false;
+      });
+  };
+})();

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,8 +1,8 @@
 {
     "/css/ingame.css": "/css/ingame.css?id=187eb3c9a997d0496baa94d59cca9f72",
     "/css/outgame.css": "/css/outgame.css?id=0edfd34484fc3ec74eca0604a470461f",
-    "/js/ingame.js": "/js/ingame.js?id=ac103cd540a1115d2ee4da4aa3567d78",
-    "/js/ingame.min.js": "/js/ingame.min.js?id=ac103cd540a1115d2ee4da4aa3567d78",
+    "/js/ingame.js": "/js/ingame.js?id=db7cf8bf893be2ec1221ef5091018cf6",
+    "/js/ingame.min.js": "/js/ingame.min.js?id=db7cf8bf893be2ec1221ef5091018cf6",
     "/js/outgame.js": "/js/outgame.js?id=5fa6ee5cdc34001db0bdccd06a7f676c",
     "/js/outgame.min.js": "/js/outgame.min.js?id=5fa6ee5cdc34001db0bdccd06a7f676c"
 }

--- a/resources/js/ingame/messages-pagination.js
+++ b/resources/js/ingame/messages-pagination.js
@@ -1,0 +1,78 @@
+(function () {
+  var originalInitDetailMessages = ogame.messages.initDetailMessages;
+
+  ogame.messages.initDetailMessages = function (commentsAllowed) {
+    originalInitDetailMessages.call(ogame.messages, commentsAllowed);
+
+    $(".overlayDiv ul.pagination")
+      .off("click.msgPagination")
+      .on("click.msgPagination", "li.p_li a", function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        if ($(this).hasClass("disabled")) {
+          return false;
+        }
+
+        var messageId = $(this).data("messageid");
+        var tab = $(this).data("tab");
+        var subtab = $(this).data("subtab");
+
+        if (!messageId) {
+          return false;
+        }
+
+        var url = "/ajax/messages/" + messageId;
+        if (tab) {
+          url += "?tab=" + encodeURIComponent(tab);
+          if (subtab) {
+            url += "&subtab=" + encodeURIComponent(subtab);
+          }
+        }
+
+        var $overlayDiv = $(this).closest(".overlayDiv");
+        if ($overlayDiv.length === 0) {
+          $overlayDiv = $(".overlayDiv");
+        }
+
+        var $uiDialog = $overlayDiv.closest(".ui-dialog");
+        var dialogWidth = $uiDialog.length ? $uiDialog.width() : null;
+        var dialogHeight = $uiDialog.length ? $uiDialog.height() : null;
+        var dialogPosition = $uiDialog.length ? $uiDialog.position() : null;
+
+        $.get(url, function (response) {
+          try {
+            removeTooltip($overlayDiv.find(getTooltipSelector()));
+          } catch (err) {}
+
+          $overlayDiv.empty().append(response);
+
+          if ($uiDialog.length && dialogWidth && dialogHeight) {
+            $uiDialog.css({
+              width: dialogWidth,
+              height: dialogHeight,
+            });
+            if (dialogPosition) {
+              $uiDialog.css({
+                top: dialogPosition.top,
+                left: dialogPosition.left,
+              });
+            }
+            $uiDialog.hide().show();
+          }
+
+          ogame.messages.initDetailMessages(true);
+
+          try {
+            initTooltips();
+          } catch (err) {}
+        }).fail(function () {
+          if (typeof fadeBox === "function" && typeof loca !== "undefined") {
+            fadeBox(loca.LOCA_GALAXY_ERROR_OCCURED, 1);
+          }
+        });
+
+        return false;
+      });
+  };
+})();

--- a/resources/views/ingame/messages/message.blade.php
+++ b/resources/views/ingame/messages/message.blade.php
@@ -1,15 +1,50 @@
+@php
+    $isFirstMessage = !isset($pagination['prevId']) || $pagination['prevId'] === null;
+    $isLastMessage = !isset($pagination['nextId']) || $pagination['nextId'] === null;
+    $currentIndex = $pagination['currentIndex'] ?? 1;
+    $totalCount = $pagination['totalCount'] ?? 1;
+    $tab = $pagination['tab'] ?? '';
+    $subtab = $pagination['subtab'] ?? '';
+@endphp
+
 <ul class="pagination">
-    <li class="p_li last"><a class="fright txt_link msg_action_link" data-messageid="1741736"
-                             data-tabid="20">|&lt;&lt;</a></li>
-    <li class="p_li"><a class="fright txt_link msg_action_link" data-messageid="1659201" data-tabid="20">&lt;</a></li>
-    <li class="p_li active"><a class="fright txt_link msg_action_link active" data-messageid="1645218" data-tabid="20">1/1</a>
+    <li class="p_li last">
+        <a class="fright txt_link msg_action_link @if($isFirstMessage) disabled @endif"
+           data-messageid="{{ $pagination['firstId'] ?? $messageId }}"
+           data-tab="{{ $tab }}"
+           data-subtab="{{ $subtab }}"
+           @if($isFirstMessage) style="opacity: 0.5; cursor: default;" @endif>|&lt;&lt;</a>
     </li>
-    <li class="p_li"><a class="fright txt_link msg_action_link" data-messageid="1645113" data-tabid="20">&gt;</a></li>
-    <li class="p_li last"><a class="fright txt_link msg_action_link" data-messageid="1587644"
-                             data-tabid="20">&gt;&gt;|</a></li>
+    <li class="p_li">
+        <a class="fright txt_link msg_action_link @if($isFirstMessage) disabled @endif"
+           data-messageid="{{ $pagination['prevId'] ?? $messageId }}"
+           data-tab="{{ $tab }}"
+           data-subtab="{{ $subtab }}"
+           @if($isFirstMessage) style="opacity: 0.5; cursor: default;" @endif>&lt;</a>
+    </li>
+    <li class="p_li active">
+        <a class="fright txt_link msg_action_link active"
+           data-messageid="{{ $messageId }}"
+           data-tab="{{ $tab }}"
+           data-subtab="{{ $subtab }}">{{ $currentIndex }}/{{ $totalCount }}</a>
+    </li>
+    <li class="p_li">
+        <a class="fright txt_link msg_action_link @if($isLastMessage) disabled @endif"
+           data-messageid="{{ $pagination['nextId'] ?? $messageId }}"
+           data-tab="{{ $tab }}"
+           data-subtab="{{ $subtab }}"
+           @if($isLastMessage) style="opacity: 0.5; cursor: default;" @endif>&gt;</a>
+    </li>
+    <li class="p_li last">
+        <a class="fright txt_link msg_action_link @if($isLastMessage) disabled @endif"
+           data-messageid="{{ $pagination['lastId'] ?? $messageId }}"
+           data-tab="{{ $tab }}"
+           data-subtab="{{ $subtab }}"
+           @if($isLastMessage) style="opacity: 0.5; cursor: default;" @endif>&gt;&gt;|</a>
+    </li>
 </ul>
 
-<div class="detail_msg" data-msg-id="1645218" data-message-type="10">
+<div class="detail_msg" data-msg-id="{{ $messageId }}" data-message-type="10">
     {!! $messageBody !!}
 </div>
 <script type="text/javascript">

--- a/resources/views/ingame/messages/templates/espionage_report_full.blade.php
+++ b/resources/views/ingame/messages/templates/espionage_report_full.blade.php
@@ -1,7 +1,7 @@
 <div class="detail_msg_head">
     <div class="msg_status"></div>
     <span class="msg_title new blue_txt">{!! $subject !!}</span>
-    <span class="msg_date fright">21.05.2024 19:00:28</span>
+    <span class="msg_date fright">{{ $date }}</span>
     <br/>
     <span class="msg_sender_label">@lang('From'): </span>
     <span class="msg_sender">{{ $from }}</span>

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -30,6 +30,7 @@ mix.scripts([
     //'resources/js/ingame/percentagebar.js',
     'resources/js/ingame/timerhandler.js',
     'resources/js/ingame/e7c74974620fa35b197315ebdbb8c2.js',
+    'resources/js/ingame/messages-pagination.js',
 ], 'public/js/ingame.js').minify('public/js/ingame.js').version();
 
 // ---


### PR DESCRIPTION
## Description
This PR adds pagination functionality to the full message view overlay, allowing users to navigate between messages within the same category (tab/subtab) without closing the overlay. Previously, users could only view individual messages in isolation.

### Type of Change:
- [x] Feature enhancement
- [ ] Bug fix
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #203

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [x] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint (PASS - 294 files).
- [x] **Static Analysis:** Code passes PHPStan static code analysis (PASS - No errors).
- [x] **Testing:**
    - Existing test suite covers related functionality.
    - All 420 tests successfully pass locally (6,417 assertions).
- [x] **CSS & JS Build:** CSS and JS assets compiled using Laravel Mix. New `messages-pagination.js` module added.
- [ ] **Documentation:** No documentation changes required for this feature.

## Additional Information
The pagination feature enhances the user experience by allowing seamless navigation through messages of the same type without modal dismissal.
