### PR TITLE
Change FleetDispatchEspionageTest.php to use clean planet

### DIFF
--- a/tests/Feature/FleetDispatch/FleetDispatchEspionageTest.php
+++ b/tests/Feature/FleetDispatch/FleetDispatchEspionageTest.php
@@ -263,10 +263,10 @@ class FleetDispatchEspionageTest extends FleetDispatchTestCase
         $response = $this->get('/shipyard');
         $this->assertObjectLevelOnPage($response, 'espionage_probe', 5, 'Espionage probe are not at 5 units at beginning of test.');
 
-        // Send fleet to a nearby foreign planet.
+        // Send fleet to a nearby foreign planet (use clean planet to avoid counter-espionage).
         $unitCollection = new UnitCollection();
         $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('espionage_probe'), 1);
-        $foreignPlanet = $this->sendMissionToOtherPlayerPlanet($unitCollection, new Resources(0, 0, 0, 0));
+        $foreignPlanet = $this->sendMissionToOtherPlayerCleanPlanet($unitCollection, new Resources(0, 0, 0, 0));
 
         // Get just dispatched fleet mission ID from database.
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
@@ -296,7 +296,7 @@ class FleetDispatchEspionageTest extends FleetDispatchTestCase
         $activeMissions = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer();
 
         // Assert that a return trip has been launched by checking the active missions for the current planet.
-        $this->assertCount(1, $activeMissions, 'No return trip launched after fleet with deployment mission has arrived at destination.');
+        $this->assertCount(1, $activeMissions, 'No return trip launched after fleet with espionage mission has arrived at destination.');
     }
 
     /**


### PR DESCRIPTION
## Description
This PR fixes the intermittent failure in `FleetDispatchEspionageTest::testDispatchFleetReturnTrip` by using a clean planet (without ships) to prevent counter-espionage from randomly destroying probes and blocking return trip creation. Also fixes a typo in the assertion message.

### Type of Change:
- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #863 

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [X] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [X] **Static Analysis:** Code passes PHPStan static code analysis.
- [X] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [ ] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [ ] **Documentation:** Documentation has been updated to reflect any changes made.

