### PR TITLE
Fix: Implement reloadApplication() call before processing fleet missions

### DIFF
--- a/tests/Feature/FleetDispatch/FleetDispatchAttackTest.php
+++ b/tests/Feature/FleetDispatch/FleetDispatchAttackTest.php
@@ -115,11 +115,20 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
         $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 1);
         $foreignPlanet = $this->sendMissionToOtherPlayerPlanet($unitCollection, new Resources(0, 0, 0, 0));
 
+        // Get just dispatched fleet mission service.
+        $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
+
+        // Get time it takes for the fleet to travel to the second planet.
+        $fleetMissionDuration = $fleetMissionService->calculateFleetMissionDuration($this->planetService, $foreignPlanet->getPlanetCoordinates(), $unitCollection, resolve(AttackMission::class));
+
+        // Set time to fleet mission duration + 1 second.
+        $this->travel($fleetMissionDuration + 1)->seconds();
+
+        // Reload application to make sure the defender planet is not cached.
+        $this->reloadApplication();
+
         // Set all messages as read to avoid unread messages count in the overview.
         $this->playerSetAllMessagesRead();
-
-        // Increase time by 10 hours to ensure the mission is done.
-        $this->travel(10)->hours();
 
         // Do a request to trigger the update logic.
         $response = $this->get('/overview');
@@ -158,11 +167,20 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
         $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 1);
         $foreignMoon = $this->sendMissionToOtherPlayerMoon($unitCollection, new Resources(0, 0, 0, 0));
 
+        // Get just dispatched fleet mission service.
+        $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
+
+        // Get time it takes for the fleet to travel to the moon.
+        $fleetMissionDuration = $fleetMissionService->calculateFleetMissionDuration($this->planetService, $foreignMoon->getPlanetCoordinates(), $unitCollection, resolve(AttackMission::class));
+
+        // Set time to fleet mission duration + 1 second.
+        $this->travel($fleetMissionDuration + 1)->seconds();
+
+        // Reload application to make sure the defender moon is not cached.
+        $this->reloadApplication();
+
         // Set all messages as read to avoid unread messages count in the overview.
         $this->playerSetAllMessagesRead();
-
-        // Increase time by 10 hours to ensure the mission is done.
-        $this->travel(10)->hours();
 
         // Do a request to trigger the update logic.
         $response = $this->get('/overview');


### PR DESCRIPTION
## Description
This PR updates two tests in `tests/Feature/FleetDispatch/FleetDispatchAttackTest.php` to follow the same pattern as working tests like `testDispatchFleetReturnTrip()`:

  **Changes:**
  1. Added `$this->reloadApplication()` call before processing missions to clear cached state
  2. Changed from fixed time travel (`10 hours`) to calculated fleet mission duration for precision,  matching the pattern in other working tests.
  3. Moved `playerSetAllMessagesRead()` to after time travel but before the overview request

### Type of Change:
- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #865 

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [X] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [X] **Static Analysis:** Code passes PHPStan static code analysis.
- [X] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [ ] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [ ] **Documentation:** Documentation has been updated to reflect any changes made.

