### PR TITLE
Fix FleetDispatchCounterEspionageTest.php skipping due to caching issues

### DIFF
--- a/tests/Feature/FleetDispatch/FleetDispatchCounterEspionageTest.php
+++ b/tests/Feature/FleetDispatch/FleetDispatchCounterEspionageTest.php
@@ -318,6 +318,9 @@ class FleetDispatchCounterEspionageTest extends FleetDispatchTestCase
         $foreignPlanet->addUnit('battlecruiser', 1000);
         $foreignPlanet->save();
 
+        // Reload application to ensure planet changes are not cached
+        $this->reloadApplication();
+
         // Send only 1 probe (high chance to be destroyed)
         $unitCollection = new UnitCollection();
         $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('espionage_probe'), 1);
@@ -363,6 +366,9 @@ class FleetDispatchCounterEspionageTest extends FleetDispatchTestCase
         $foreignPlanet = $this->getNearbyForeignPlanet();
         $foreignPlanet->addUnit('battlecruiser', 1000);
         $foreignPlanet->save();
+
+        // Reload application to ensure planet changes are not cached
+        $this->reloadApplication();
 
         // Send only 1 probe (high chance to be destroyed)
         $unitCollection = new UnitCollection();


### PR DESCRIPTION
## Description
This PR adds two `reloadApplication()` calls in `FleetDispatchCounterEspionageTest.php` to ensure the espionage mission processor sees the foreign planet with 1000 battlecruisers. This gives the expected 100% counter-espionage chance, so the tests now pass reliably instead of skipping with "random chance" messages.

### Type of Change:
- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #867 

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [X] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [X] **Static Analysis:** Code passes PHPStan static code analysis.
- [X] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [ ] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [ ] **Documentation:** Documentation has been updated to reflect any changes made.

