### PR TITLE
Fix: Apply survival rate to loot when cargo ships are destroyed

### DIFF
--- a/app/GameMissions/AttackMission.php
+++ b/app/GameMissions/AttackMission.php
@@ -173,11 +173,20 @@ class AttackMission extends GameMission
             0
         );
 
-        // Total resources = remaining + loot
+        // Calculate loot remaining on surviving ships
+        // Loot is also subject to the survival rate (if cargo ships carrying loot are destroyed, loot is lost)
+        $remainingLoot = new Resources(
+            max(0, (int)($battleResult->loot->metal->get() * $survivalRate)),
+            max(0, (int)($battleResult->loot->crystal->get() * $survivalRate)),
+            max(0, (int)($battleResult->loot->deuterium->get() * $survivalRate)),
+            0
+        );
+
+        // Total resources = remaining mission resources + remaining loot
         $totalResources = new Resources(
-            $remainingResources->metal->get() + $battleResult->loot->metal->get(),
-            $remainingResources->crystal->get() + $battleResult->loot->crystal->get(),
-            $remainingResources->deuterium->get() + $battleResult->loot->deuterium->get(),
+            $remainingResources->metal->get() + $remainingLoot->metal->get(),
+            $remainingResources->crystal->get() + $remainingLoot->crystal->get(),
+            $remainingResources->deuterium->get() + $remainingLoot->deuterium->get(),
             0
         );
 


### PR DESCRIPTION
## Description
When cargo ships are destroyed in battle, both mission resources and loot should be reduced proportionally by the survival rate. Previously only mission resources were reduced, but loot was added at full value, causing scenarios where resources exceeded cargo capacity. This fixes `FleetDispatchAttackCargoCapacityTest` failures where total returned resources exceeded remaining cargo capacity.

### Type of Change:
- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #869 

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [X] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [X] **Static Analysis:** Code passes PHPStan static code analysis.
- [X] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [ ] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [ ] **Documentation:** Documentation has been updated to reflect any changes made.


