### PR TITLE
Add WithCachedConfig / WithCachedRoutes to speed up tests

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,9 +5,14 @@ namespace Tests;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use Illuminate\Foundation\Testing\WithCachedConfig;
+use Illuminate\Foundation\Testing\WithCachedRoutes;
 
 abstract class TestCase extends BaseTestCase
 {
+    use WithCachedConfig;
+    use WithCachedRoutes;
+
     /**
      * Creates the application.
      *


### PR DESCRIPTION
This adds WithCachedConfig / WithCachedRoutes trait to the test case to speed up tests. 

This was added in [12.38.0](https://github.com/laravel/framework/releases/tag/v12.38.0) 

Essentially this just speeds up tests because we don't tap into the config / routes. Mainly noticeable locally, but should give us a bit of speed in CI too. 

P.S sorry I haven't been too active, I don't play the game- but I know Laravel so popping in to do some Laravel bits 🫡 