### PR TITLE
chore: Upgrade actions/checkout

### DIFF
--- a/.github/workflows/run-docker-compose-prod.yml
+++ b/.github/workflows/run-docker-compose-prod.yml
@@ -18,7 +18,7 @@ jobs:
         image: docker:26.0.0
         options: --privileged
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Modify Dockerfile to disable USER www (which is not supported by GitHub Actions, as it runs as root)
         run: |
           sed -i '/USER www/s/^/#/' ./Dockerfile

--- a/.github/workflows/run-laravel-pint-code-style-checker.yml
+++ b/.github/workflows/run-laravel-pint-code-style-checker.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: shivammathur/setup-php@15c43e89cdef867065b0213be354c2841860869e
         with:
           php-version: '8.3'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Laravel Pint PSR-12 Code Style Checker
         uses: aglipanci/laravel-pint-action@2.4
         with:

--- a/.github/workflows/run-phpstan-code-analysis.yml
+++ b/.github/workflows/run-phpstan-code-analysis.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: shivammathur/setup-php@15c43e89cdef867065b0213be354c2841860869e
       with:
         php-version: '8.3'
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Copy .env
       run: php -r "file_exists('.env') || copy('.env.example', '.env');"
     - name: Composer update

--- a/.github/workflows/run-tests-docker-compose.yml
+++ b/.github/workflows/run-tests-docker-compose.yml
@@ -18,7 +18,7 @@ jobs:
         image: docker:26.0.0
         options: --privileged
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Setup Docker Compose
         uses: ./.github/actions/docker-compose-setup

--- a/.github/workflows/run-tests-flaky-detection.yml
+++ b/.github/workflows/run-tests-flaky-detection.yml
@@ -22,7 +22,7 @@ jobs:
         options: --privileged
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Setup Docker Compose
         uses: ./.github/actions/docker-compose-setup


### PR DESCRIPTION
V6 is the latest version, a lot of 'em were outdated.