### PR TITLE
fix: when in vacation mode, quickbuild buttons should not be visible …

### DIFF
--- a/resources/views/ingame/facilities/index.blade.php
+++ b/resources/views/ingame/facilities/index.blade.php
@@ -76,6 +76,7 @@
                             @elseif (!$building->valid_planet_type)
                             @elseif (!$building->enough_resources)
                             @elseif ($build_queue_max)
+                            @elseif ($is_in_vacation_mode)
                             @elseif ($building->research_in_progress && $building->object->machine_name == 'research_lab')
                             @elseif ($building->ship_or_defense_in_progress  && ( $building->object->machine_name == 'shipyard' || $building->object->machine_name == 'nano_factory' ) )
                             @else

--- a/resources/views/ingame/resources/index.blade.php
+++ b/resources/views/ingame/resources/index.blade.php
@@ -67,6 +67,7 @@
                             @elseif (!$building->valid_planet_type)
                             @elseif (!$building->enough_resources)
                             @elseif ($build_queue_max)
+                            @elseif ($is_in_vacation_mode)
                             @elseif ($building->object->type === \OGame\GameObjects\Models\Enums\GameObjectType::Ship || $building->object->type === \OGame\GameObjects\Models\Enums\GameObjectType::Defense)
                             @else
                                 <button


### PR DESCRIPTION
## Description

This PR fixes a bug where quick build buttons (green buttons in the top left corner of building tiles) were still visible when a player is in vacation mode. These buttons should be hidden as players cannot build anything while in vacation mode.

### Type of Change:

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues

Fixes #898

## Checklist

Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [x] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [x] **Static Analysis:** Code passes PHPStan static code analysis.
- [ ] **Testing:**
  - Relevant unit and feature tests are included or updated.
  - Tests successfully run locally.
- [ ] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [x] **Documentation:** Documentation has been updated to reflect any changes made.

## Additional Information
