### PR TITLE
fix #897: prevent galaxy view access when in vacation mode

### DIFF
--- a/app/Http/Controllers/GalaxyController.php
+++ b/app/Http/Controllers/GalaxyController.php
@@ -65,6 +65,7 @@ class GalaxyController extends OGameController
             'used_slots' => 0,
             'max_slots' => 1,
             'max_galaxies' => $settingsService->numberOfGalaxies(),
+            'is_in_vacation_mode' => $player->isInVacationMode(),
         ]);
     }
 
@@ -502,6 +503,13 @@ class GalaxyController extends OGameController
     {
         $this->playerService = $player;
         $this->planetServiceFactory = $planetServiceFactory;
+
+        if ($player->isInVacationMode()) {
+            return response()->json([
+                'success' => false,
+                'error' => __('You cannot use the galaxy view whilst in vacation mode!'),
+            ], 403);
+        }
 
         $planet = $player->planets->current();
         $galaxy = $request->input('galaxy');

--- a/resources/views/ingame/galaxy/index.blade.php
+++ b/resources/views/ingame/galaxy/index.blade.php
@@ -8,6 +8,26 @@
         </div>
     @endif
 
+    @if ($is_in_vacation_mode ?? false)
+    <div id="galaxycomponent" class="maincontent">
+        <div id="inhalt">
+            <div id="galaxyContent">
+                <div class="galaxyTable" style="background: #000; border: none !important;">
+                    <div class="galaxyRow ctGalaxyFleetInfo" id="fleetstatusrow" style="text-align: center;">
+                        <span class="fleetStatus" style="color: #B00001; font-weight: bold; font-size: 12px;">@lang('Player in vacation mode')</span>
+                    </div>
+                    <div class="galaxyRow" style="display: flex; justify-content: center; align-items: center; padding: 10px 0 30px 0;">
+                        <span style="color: #B00001; font-weight: bold; text-align: center; display: flex; align-items: center; gap: 5px;">
+                            <span class="icon icon_warning" style="display: inline-block; margin: 0 !important; vertical-align: middle;"></span>
+                            <span style="display: inline-block; line-height: 16px; vertical-align: middle;">@lang('You cannot use the galaxy view whilst in vacation mode!')</span>
+                            <span class="icon icon_warning" style="display: inline-block; margin: 0 !important; vertical-align: middle;"></span>
+                        </span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    @else
     <div id="galaxycomponent" class="maincontent">
         <script type="text/javascript">
             var galaxy = {{ $current_galaxy }};
@@ -818,4 +838,5 @@
             });
         </script>
     </div>
+    @endif
 @endsection


### PR DESCRIPTION
## Description
This PR fixes the issue where players in vacation mode could still access the galaxy view. When a player is in vacation mode, the galaxy page now displays a clear message indicating that the galaxy view is not accessible during vacation mode.

### Type of Change:
- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #897

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [x] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [x] **Static Analysis:** Code passes PHPStan static code analysis.
- [x] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [ ] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [ ] **Documentation:** Documentation has been updated to reflect any changes made.

## Additional Information

