### PR TITLE
feat: add Dark Matter halving feature for queue items #872

### DIFF
--- a/app/Enums/DarkMatterTransactionType.php
+++ b/app/Enums/DarkMatterTransactionType.php
@@ -13,4 +13,5 @@ enum DarkMatterTransactionType: string
     case PLANET_RELOCATION = 'planet_relocation';
     case SPEEDUP = 'speedup';
     case ADMIN_ADJUSTMENT = 'admin_adjustment';
+    case HALVING = 'halving';
 }

--- a/app/Http/Controllers/ResearchController.php
+++ b/app/Http/Controllers/ResearchController.php
@@ -7,6 +7,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\View\View;
 use OGame\Http\Traits\ObjectAjaxTrait;
+use OGame\Services\HalvingService;
 use OGame\Services\ObjectService;
 use OGame\Services\PlanetService;
 use OGame\Services\PlayerService;
@@ -197,5 +198,52 @@ class ResearchController extends OGameController
             'status' => 'success',
             'message' => 'Building construction canceled.',
         ]);
+    }
+
+    /**
+     * Halve a research queue item using Dark Matter.
+     *
+     * @param Request $request
+     * @param PlayerService $player
+     * @param HalvingService $halvingService
+     * @return JsonResponse
+     */
+    public function halveResearch(Request $request, PlayerService $player, HalvingService $halvingService): JsonResponse
+    {
+        try {
+            $queueItemId = (int)$request->input('queue_item_id');
+
+            if ($queueItemId <= 0) {
+                return response()->json([
+                    'success' => false,
+                    'error' => true,
+                    'message' => 'Invalid queue item ID',
+                    'newAjaxToken' => csrf_token(),
+                ]);
+            }
+
+            $result = $halvingService->halveResearch(
+                $player->getUser(),
+                $queueItemId,
+                $player
+            );
+
+            return response()->json([
+                'success' => true,
+                'error' => false,
+                'newAjaxToken' => csrf_token(),
+                'new_time_end' => $result['new_time_end'],
+                'cost' => $result['cost'],
+                'new_balance' => $result['new_balance'],
+                'remaining_time' => $result['remaining_time'],
+            ]);
+        } catch (Exception $e) {
+            return response()->json([
+                'success' => false,
+                'error' => true,
+                'message' => $e->getMessage(),
+                'newAjaxToken' => csrf_token(),
+            ]);
+        }
     }
 }

--- a/app/Services/BuildingQueueService.php
+++ b/app/Services/BuildingQueueService.php
@@ -506,4 +506,35 @@ class BuildingQueueService
             }
         }
     }
+
+    /**
+     * Get a queue item by ID and planet ID.
+     *
+     * @param int $queueItemId The queue item ID
+     * @param int $planetId The planet ID
+     * @return BuildingQueue|null The queue item or null if not found
+     */
+    public function getQueueItemById(int $queueItemId, int $planetId): BuildingQueue|null
+    {
+        return BuildingQueue::where('id', $queueItemId)
+            ->where('planet_id', $planetId)
+            ->where('processed', 0)
+            ->where('canceled', 0)
+            ->first();
+    }
+
+    /**
+     * Update the time_end field of a queue item.
+     *
+     * @param int $queueItemId The queue item ID
+     * @param int $planetId The planet ID
+     * @param int $newTimeEnd The new time_end value (Unix timestamp)
+     * @return void
+     */
+    public function updateTimeEnd(int $queueItemId, int $planetId, int $newTimeEnd): void
+    {
+        BuildingQueue::where('id', $queueItemId)
+            ->where('planet_id', $planetId)
+            ->update(['time_end' => $newTimeEnd]);
+    }
 }

--- a/app/Services/HalvingService.php
+++ b/app/Services/HalvingService.php
@@ -1,0 +1,451 @@
+<?php
+
+namespace OGame\Services;
+
+use Exception;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use OGame\Enums\DarkMatterTransactionType;
+use OGame\Models\BuildingQueue;
+use OGame\Models\ResearchQueue;
+use OGame\Models\UnitQueue;
+use OGame\Models\User;
+
+/**
+ * Class HalvingService.
+ *
+ * Primary service for all Dark Matter halving operations.
+ * Allows players to spend Dark Matter to reduce construction time by 50%.
+ *
+ * @package OGame\Services
+ */
+class HalvingService
+{
+    private const MIN_COST = 750;
+    private const MAX_COST_BUILDING = 72000;
+    private const MAX_COST_RESEARCH = 108000;
+    private const MAX_COST_UNIT = 72000;
+    private const COST_PER_30_MINUTES = 750;
+
+    /**
+     * HalvingService constructor.
+     */
+    public function __construct(
+        private DarkMatterTransactionService $transactionService
+    ) {
+    }
+
+    /**
+     * Calculate halving cost based on REMAINING time.
+     *
+     * Formula: ceiling((remaining_time_in_minutes / 30) * 750) DM
+     * With min/max caps applied based on queue type.
+     *
+     * @param int $remainingTimeSeconds Remaining construction time in seconds
+     * @param string $queueType 'building', 'research', or 'unit'
+     * @return int Cost in Dark Matter
+     */
+    public function calculateHalvingCost(int $remainingTimeSeconds, string $queueType): int
+    {
+        // Convert seconds to minutes
+        $remainingTimeMinutes = $remainingTimeSeconds / 60;
+
+        // Apply formula: ceiling((remaining_time_in_minutes / 30) * 750)
+        $cost = (int)ceil(($remainingTimeMinutes / 30) * self::COST_PER_30_MINUTES);
+
+        // Apply minimum cost floor
+        $cost = max(self::MIN_COST, $cost);
+
+        // Apply maximum cost cap based on queue type
+        $maxCost = match ($queueType) {
+            'building' => self::MAX_COST_BUILDING,
+            'research' => self::MAX_COST_RESEARCH,
+            'unit' => self::MAX_COST_UNIT,
+            default => self::MAX_COST_BUILDING,
+        };
+
+        return min($cost, $maxCost);
+    }
+
+    /**
+     * Get current timestamp as integer.
+     */
+    private function getCurrentTimestamp(): int
+    {
+        return (int)Carbon::now()->timestamp;
+    }
+
+    /**
+     * Get maximum time reduction for a queue type.
+     * @param string $queueType 'building', 'research', or 'unit'
+     * @return int Maximum reduction in seconds
+     */
+    private function getMaxReduction(string $queueType): int
+    {
+        // Max reduction = (max_cost / 750) * 30 minutes * 60 seconds
+        return match ($queueType) {
+            'building' => 172800, // 48 hours
+            'research' => 259200, // 72 hours
+            'unit' => 172800,     // 48 hours
+            default => 172800,
+        };
+    }
+
+    /**
+     * Calculate new time values after halving.
+     *
+     * Halving reduces the ORIGINAL construction time by 50%, but capped at max reduction.
+     * Cost is calculated based on REMAINING time (with caps).
+     *
+     * @param int $timeEnd Current time_end value
+     * @param int $timeDuration Original construction time in seconds
+     * @param string $queueType 'building', 'research', or 'unit'
+     * @return array{remaining_time: int, new_time_end: int, cost: int}
+     * @throws Exception If queue item already completed
+     */
+    private function calculateNewTimeValues(int $timeEnd, int $timeDuration, string $queueType): array
+    {
+        $currentTime = $this->getCurrentTimestamp();
+        $remainingTime = $timeEnd - $currentTime;
+
+        if ($remainingTime <= 0) {
+            throw new Exception('Queue item already completed');
+        }
+
+        // Calculate cost based on REMAINING time
+        $cost = $this->calculateHalvingCost($remainingTime, $queueType);
+
+        // Calculate time reduction: 50% of ORIGINAL construction time, capped at max reduction
+        // Use intdiv for exact 50% (no rounding)
+        $halfOriginal = intdiv($timeDuration, 2);
+        $maxReduction = $this->getMaxReduction($queueType);
+        $reduction = min($halfOriginal, $maxReduction, $remainingTime);
+
+        // Calculate new remaining time
+        $newRemainingTime = $remainingTime - $reduction;
+
+        // Handle edge case: if new remaining time is <= 0, set to 0 (instant completion)
+        if ($newRemainingTime < 0) {
+            $newRemainingTime = 0;
+        }
+
+        $newTimeEnd = $currentTime + $newRemainingTime;
+
+        return [
+            'remaining_time' => $newRemainingTime,
+            'new_time_end' => $newTimeEnd,
+            'cost' => $cost,
+        ];
+    }
+
+    /**
+     * Halve a building queue item.
+     *
+     * @param User $user The user performing the halving
+     * @param int $queueItemId The building queue item ID
+     * @param PlanetService $planet The planet service
+     * @return array{success: bool, new_time_end: int, cost: int, new_balance: int, remaining_time: int}
+     * @throws Exception If insufficient Dark Matter or invalid queue item
+     */
+    public function halveBuilding(User $user, int $queueItemId, PlanetService $planet): array
+    {
+        /** @var array{success: bool, new_time_end: int, cost: int, new_balance: int, remaining_time: int} $result */
+        $result = DB::transaction(function () use ($user, $queueItemId, $planet) {
+            // Lock user row for Dark Matter balance
+            $lockedUser = User::where('id', $user->id)->lockForUpdate()->first();
+            if (!$lockedUser) {
+                throw new Exception('User not found');
+            }
+
+            // Lock and retrieve queue item
+            $queueItem = BuildingQueue::where('id', $queueItemId)
+                ->where('planet_id', $planet->getPlanetId())
+                ->where('processed', 0)
+                ->where('canceled', 0)
+                ->where('building', 1)
+                ->lockForUpdate()
+                ->first();
+
+            if (!$queueItem) {
+                throw new Exception('Queue item not found or already completed');
+            }
+
+            // Calculate new time values
+            // Cost is based on remaining time, reduction is 50% of original time
+            $timeValues = $this->calculateNewTimeValues(
+                (int)$queueItem->time_end,
+                (int)$queueItem->time_duration,
+                'building'
+            );
+            $cost = $timeValues['cost'];
+
+            // Check balance
+            if ($lockedUser->dark_matter < $cost) {
+                throw new Exception("Insufficient Dark Matter. Required: {$cost}, Available: {$lockedUser->dark_matter}");
+            }
+
+            // Debit Dark Matter
+            $lockedUser->dark_matter -= $cost;
+            $lockedUser->save();
+
+            // Record transaction
+            $object = ObjectService::getObjectById($queueItem->object_id);
+            $description = "Halving building: {$object->title} on planet {$planet->getPlanetName()} (ID: {$planet->getPlanetId()})";
+            $this->transactionService->recordTransaction(
+                $lockedUser,
+                -$cost,
+                DarkMatterTransactionType::HALVING->value,
+                $description,
+                $lockedUser->dark_matter
+            );
+
+            // Update queue item time_end
+            $queueItem->time_end = $timeValues['new_time_end'];
+            $queueItem->save();
+
+            return [
+                'success' => true,
+                'new_time_end' => $timeValues['new_time_end'],
+                'cost' => $cost,
+                'new_balance' => $lockedUser->dark_matter,
+                'remaining_time' => $timeValues['remaining_time'],
+            ];
+        });
+
+        return $result;
+    }
+
+    /**
+     * Halve a research queue item.
+     *
+     * @param User $user The user performing the halving
+     * @param int $queueItemId The research queue item ID
+     * @param PlayerService $player The player service
+     * @return array{success: bool, new_time_end: int, cost: int, new_balance: int, remaining_time: int}
+     * @throws Exception If insufficient Dark Matter or invalid queue item
+     */
+    public function halveResearch(User $user, int $queueItemId, PlayerService $player): array
+    {
+        /** @var array{success: bool, new_time_end: int, cost: int, new_balance: int, remaining_time: int} $result */
+        $result = DB::transaction(function () use ($user, $queueItemId, $player) {
+            // Lock user row for Dark Matter balance
+            $lockedUser = User::where('id', $user->id)->lockForUpdate()->first();
+            if (!$lockedUser) {
+                throw new Exception('User not found');
+            }
+
+            // Lock and retrieve queue item
+            $queueItem = ResearchQueue::query()
+                ->join('planets', 'research_queues.planet_id', '=', 'planets.id')
+                ->where('research_queues.id', $queueItemId)
+                ->where('planets.user_id', $lockedUser->id)
+                ->where('research_queues.processed', 0)
+                ->where('research_queues.canceled', 0)
+                ->where('research_queues.building', 1)
+                ->select('research_queues.*')
+                ->lockForUpdate()
+                ->first();
+
+            if (!$queueItem) {
+                throw new Exception('Queue item not found or already completed');
+            }
+
+            // Calculate new time values
+            // Cost is based on remaining time, reduction is 50% of original time
+            $timeValues = $this->calculateNewTimeValues(
+                (int)$queueItem->time_end,
+                (int)$queueItem->time_duration,
+                'research'
+            );
+            $cost = $timeValues['cost'];
+
+            // Check balance
+            if ($lockedUser->dark_matter < $cost) {
+                throw new Exception("Insufficient Dark Matter. Required: {$cost}, Available: {$lockedUser->dark_matter}");
+            }
+
+            // Debit Dark Matter
+            $lockedUser->dark_matter -= $cost;
+            $lockedUser->save();
+
+            // Record transaction
+            $object = ObjectService::getResearchObjectById($queueItem->object_id);
+            $planet = $player->planets->getById((int)$queueItem->planet_id);
+            $description = "Halving research: {$object->title} on planet {$planet->getPlanetName()} (ID: {$queueItem->planet_id})";
+            $this->transactionService->recordTransaction(
+                $lockedUser,
+                -$cost,
+                DarkMatterTransactionType::HALVING->value,
+                $description,
+                $lockedUser->dark_matter
+            );
+
+            // Update queue item time_end
+            $queueItemModel = ResearchQueue::find($queueItemId);
+            if ($queueItemModel) {
+                $queueItemModel->time_end = $timeValues['new_time_end'];
+                $queueItemModel->save();
+            }
+
+            return [
+                'success' => true,
+                'new_time_end' => $timeValues['new_time_end'],
+                'cost' => $cost,
+                'new_balance' => $lockedUser->dark_matter,
+                'remaining_time' => $timeValues['remaining_time'],
+            ];
+        });
+
+        return $result;
+    }
+
+    /**
+     * Halve a unit queue item.
+     *
+     * @param User $user The user performing the halving
+     * @param int $queueItemId The unit queue item ID
+     * @param PlanetService $planet The planet service
+     * @return array{success: bool, new_time_end: int, cost: int, new_balance: int, remaining_time: int}
+     * @throws Exception If insufficient Dark Matter or invalid queue item
+     */
+    public function halveUnit(User $user, int $queueItemId, PlanetService $planet): array
+    {
+        /** @var array{success: bool, new_time_end: int, cost: int, new_balance: int, remaining_time: int} $result */
+        $result = DB::transaction(function () use ($user, $queueItemId, $planet) {
+            // Lock user row for Dark Matter balance
+            $lockedUser = User::where('id', $user->id)->lockForUpdate()->first();
+            if (!$lockedUser) {
+                throw new Exception('User not found');
+            }
+
+            // Lock and retrieve queue item
+            $queueItem = UnitQueue::where('id', $queueItemId)
+                ->where('planet_id', $planet->getPlanetId())
+                ->where('processed', 0)
+                ->lockForUpdate()
+                ->first();
+
+            if (!$queueItem) {
+                throw new Exception('Queue item not found or already completed');
+            }
+
+            // Calculate new time values
+            // Cost is based on remaining time, reduction is 50% of original time
+            $timeValues = $this->calculateNewTimeValues(
+                (int)$queueItem->time_end,
+                (int)$queueItem->time_duration,
+                'unit'
+            );
+            $cost = $timeValues['cost'];
+
+            // Check balance
+            if ($lockedUser->dark_matter < $cost) {
+                throw new Exception("Insufficient Dark Matter. Required: {$cost}, Available: {$lockedUser->dark_matter}");
+            }
+
+            // Debit Dark Matter
+            $lockedUser->dark_matter -= $cost;
+            $lockedUser->save();
+
+            // Record transaction
+            $object = ObjectService::getUnitObjectById($queueItem->object_id);
+            $description = "Halving unit: {$object->title} on planet {$planet->getPlanetName()} (ID: {$planet->getPlanetId()})";
+            $this->transactionService->recordTransaction(
+                $lockedUser,
+                -$cost,
+                DarkMatterTransactionType::HALVING->value,
+                $description,
+                $lockedUser->dark_matter
+            );
+
+            // Update queue item time_end
+            $queueItem->time_end = $timeValues['new_time_end'];
+            $queueItem->save();
+
+            return [
+                'success' => true,
+                'new_time_end' => $timeValues['new_time_end'],
+                'cost' => $cost,
+                'new_balance' => $lockedUser->dark_matter,
+                'remaining_time' => $timeValues['remaining_time'],
+            ];
+        });
+
+        return $result;
+    }
+
+    /**
+     * Get halving cost for a building or unit queue item.
+     *
+     * @param int $queueItemId The queue item ID
+     * @param string $queueType 'building' or 'unit'
+     * @param PlanetService $context Planet service for context
+     * @return int Cost in Dark Matter
+     * @throws Exception If queue item not found
+     */
+    public function getHalvingCostForBuildingOrUnit(int $queueItemId, string $queueType, PlanetService $context): int
+    {
+        $queueItem = match ($queueType) {
+            'building' => BuildingQueue::where('id', $queueItemId)
+                ->where('planet_id', $context->getPlanetId())
+                ->where('processed', 0)
+                ->where('canceled', 0)
+                ->where('building', 1)
+                ->first(),
+            'unit' => UnitQueue::where('id', $queueItemId)
+                ->where('planet_id', $context->getPlanetId())
+                ->where('processed', 0)
+                ->first(),
+            default => throw new Exception('Invalid queue type. Must be building or unit'),
+        };
+
+        if (!$queueItem) {
+            throw new Exception('Queue item not found or already completed');
+        }
+
+        // Calculate remaining time
+        $currentTime = (int)Carbon::now()->timestamp;
+        $remainingTime = (int)$queueItem->time_end - $currentTime;
+
+        if ($remainingTime <= 0) {
+            throw new Exception('Queue item already completed');
+        }
+
+        return $this->calculateHalvingCost($remainingTime, $queueType);
+    }
+
+    /**
+     * Get halving cost for a research queue item.
+     *
+     * @param int $queueItemId The queue item ID
+     * @param PlayerService $player Player service for context
+     * @return int Cost in Dark Matter
+     * @throws Exception If queue item not found
+     */
+    public function getHalvingCostForResearch(int $queueItemId, PlayerService $player): int
+    {
+        $queueItem = ResearchQueue::query()
+            ->join('planets', 'research_queues.planet_id', '=', 'planets.id')
+            ->where('research_queues.id', $queueItemId)
+            ->where('planets.user_id', $player->getId())
+            ->where('research_queues.processed', 0)
+            ->where('research_queues.canceled', 0)
+            ->where('research_queues.building', 1)
+            ->select('research_queues.*')
+            ->first();
+
+        if (!$queueItem) {
+            throw new Exception('Queue item not found or already completed');
+        }
+
+        // Calculate remaining time
+        $currentTime = (int)Carbon::now()->timestamp;
+        $remainingTime = (int)$queueItem->time_end - $currentTime;
+
+        if ($remainingTime <= 0) {
+            throw new Exception('Queue item already completed');
+        }
+
+        return $this->calculateHalvingCost($remainingTime, 'research');
+    }
+}

--- a/app/Services/ResearchQueueService.php
+++ b/app/Services/ResearchQueueService.php
@@ -446,4 +446,36 @@ class ResearchQueueService
             }
         }
     }
+
+    /**
+     * Get a queue item by ID and user ID.
+     *
+     * @param int $queueItemId The queue item ID
+     * @param int $userId The user ID
+     * @return ResearchQueue|null The queue item or null if not found
+     */
+    public function getQueueItemById(int $queueItemId, int $userId): ResearchQueue|null
+    {
+        return $this->model
+            ->join('planets', 'research_queues.planet_id', '=', 'planets.id')
+            ->where('research_queues.id', $queueItemId)
+            ->where('planets.user_id', $userId)
+            ->where('research_queues.processed', 0)
+            ->where('research_queues.canceled', 0)
+            ->select('research_queues.*')
+            ->first();
+    }
+
+    /**
+     * Update the time_end field of a queue item.
+     *
+     * @param int $queueItemId The queue item ID
+     * @param int $userId The user ID
+     * @param int $newTimeEnd The new time_end value (Unix timestamp)
+     * @return void
+     */
+    public function updateTimeEnd(int $queueItemId, int $userId, int $newTimeEnd): void
+    {
+        ResearchQueue::where('id', $queueItemId)->update(['time_end' => $newTimeEnd]);
+    }
 }

--- a/app/Services/UnitQueueService.php
+++ b/app/Services/UnitQueueService.php
@@ -247,4 +247,34 @@ class UnitQueueService
 
         return 0;
     }
+
+    /**
+     * Get a queue item by ID and planet ID.
+     *
+     * @param int $queueItemId The queue item ID
+     * @param int $planetId The planet ID
+     * @return UnitQueue|null The queue item or null if not found
+     */
+    public function getQueueItemById(int $queueItemId, int $planetId): UnitQueue|null
+    {
+        return $this->model->where('id', $queueItemId)
+            ->where('planet_id', $planetId)
+            ->where('processed', 0)
+            ->first();
+    }
+
+    /**
+     * Update the time_end field of a queue item.
+     *
+     * @param int $queueItemId The queue item ID
+     * @param int $planetId The planet ID
+     * @param int $newTimeEnd The new time_end value (Unix timestamp)
+     * @return void
+     */
+    public function updateTimeEnd(int $queueItemId, int $planetId, int $newTimeEnd): void
+    {
+        $this->model->where('id', $queueItemId)
+            ->where('planet_id', $planetId)
+            ->update(['time_end' => $newTimeEnd]);
+    }
 }

--- a/resources/views/ingame/shared/buildqueue/building-active.blade.php
+++ b/resources/views/ingame/shared/buildqueue/building-active.blade.php
@@ -43,20 +43,17 @@
         </tr>
         <tr class="data">
             <td colspan="2">
+                @php
+                    $halvingService = app(\OGame\Services\HalvingService::class);
+                    $halvingCost = $halvingService->calculateHalvingCost($build_active->time_total, 'building');
+                @endphp
                 <a class="build-faster dark_highlight tooltipLeft js_hideTipOnMobile building "
-                   title="Reduces construction time by 50% of the total construction time (7m 10s)."
+                   title="Reduces construction time by 50% of the total construction time."
                    href="javascript:void(0);"
-                   rel="#TODO_componentOnly&amp;component=itemactions&amp;action=buyAndActivate&amp;itemUuid=cb4fd53e61feced0d52cfc4c1ce383bad9c05f67&amp;asJson=1">
-                    <div class="                                                build-faster-img
-                                            " alt="                                                Halve time
-                                            "></div>
-                    <span class="build-txt">
-                                                                                            Halve time
-                                                                                    </span>
-                    <span class="dm_cost ">
-                                                                                                    Costs:
-                                                                                                        750 DM
-                                                                                            </span>
+                   rel="{{ route('facilities.halvebuilding') }}?queue_item_id={{ $build_active->id }}">
+                    <div class="build-faster-img" alt="Halve time"></div>
+                    <span class="build-txt">Halve time</span>
+                    <span class="dm_cost">Costs: {{ number_format($halvingCost) }} DM</span>
                 </a>
             </td>
         </tr>
@@ -64,8 +61,8 @@
     </table>
     <script type="text/javascript">
         var cancelBuildListEntryUrl = '{{ route('resources.cancelbuildrequest') }}';
-        var questionbuilding = 'Do\u0020you\u0020want\u0020to\u0020reduce\u0020the\u0020construction\u0020time\u0020of\u0020the\u0020current\u0020construction\u0020project\u0020by\u002050\u0025\u0020of\u0020the\u0020total\u0020construction\u0020time\u0020\u00287m\u002010s\u0029\u0020for\u0020\u003Cspan\u0020style\u003D\u0022font\u002Dweight\u003A\u0020bold\u003B\u0022\u003E750\u0020Dark\u0020Matter\u003C\/span\u003E\u003F';
-        var pricebuilding = 750;
+        var questionbuilding = 'Do you want to reduce the construction time of the current construction project by 50% of the total construction time for <span style="font-weight: bold;">{{ number_format($halvingCost) }} Dark Matter</span>?';
+        var pricebuilding = {{ $halvingCost }};
         var referrerPage = $.deparam.querystring().page;
 
         new CountdownTimer('buildingCountdown', {{ $build_active->time_countdown }}, '{{ url()->current() }}', null, true, 3)

--- a/routes/web.php
+++ b/routes/web.php
@@ -68,6 +68,7 @@ Route::middleware(['auth', 'globalgame', 'locale'])->group(function () {
     Route::post('/facilities/add-buildrequest', [FacilitiesController::class, 'addBuildRequest'])->name('facilities.addbuildrequest.post');
     Route::post('/facilities/downgrade', [FacilitiesController::class, 'downgradeBuildRequest'])->name('facilities.downgrade');
     Route::post('/facilities/cancel-buildrequest', [FacilitiesController::class, 'cancelBuildRequest'])->name('facilities.cancelbuildrequest');
+    Route::post('/ajax/facilities/halve-building', [FacilitiesController::class, 'halveBuilding'])->name('facilities.halvebuilding');
 
     // Research
     Route::get('/research', [ResearchController::class, 'index'])->name('research.index');
@@ -75,11 +76,13 @@ Route::middleware(['auth', 'globalgame', 'locale'])->group(function () {
     Route::get('/research/add-buildrequest', [ResearchController::class, 'addBuildRequest'])->name('research.addbuildrequest');
     Route::post('/research/add-buildrequest', [ResearchController::class, 'addBuildRequest'])->name('research.addbuildrequest.post');
     Route::post('/research/cancel-buildrequest', [ResearchController::class, 'cancelBuildRequest'])->name('research.cancelbuildrequest');
+    Route::post('/ajax/research/halve-research', [ResearchController::class, 'halveResearch'])->name('research.halveresearch');
 
     // Shipyard
     Route::get('/shipyard', [ShipyardController::class, 'index'])->name('shipyard.index');
     Route::get('/ajax/shipyard', [ShipyardController::class, 'ajax'])->name('shipyard.ajax');
     Route::post('/shipyard/add-buildrequest', [ShipyardController::class, 'addBuildRequest'])->name('shipyard.addbuildrequest');
+    Route::post('/ajax/shipyard/halve-unit', [ShipyardController::class, 'halveUnit'])->name('shipyard.halveunit');
 
     // Defense
     Route::get('/defense', [DefenseController::class, 'index'])->name('defense.index');

--- a/tests/Feature/HalvingIntegrationTest.php
+++ b/tests/Feature/HalvingIntegrationTest.php
@@ -1,0 +1,369 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use OGame\Models\BuildingQueue;
+use OGame\Models\DarkMatterTransaction;
+use OGame\Models\ResearchQueue;
+use OGame\Models\UnitQueue;
+use OGame\Models\User;
+use Tests\AccountTestCase;
+
+/**
+ * Integration tests for the Dark Matter halving feature.
+ */
+class HalvingIntegrationTest extends AccountTestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Test building halving end-to-end workflow.
+     */
+    public function testBuildingHalvingEndToEnd(): void
+    {
+        $user = User::find($this->currentUserId);
+        $user->dark_matter = 100000;
+        $user->save();
+
+        $this->addResourceBuildRequest('metal_mine');
+
+        $queueItem = BuildingQueue::where('planet_id', $this->planetService->getPlanetId())
+            ->where('building', 1)
+            ->where('processed', 0)
+            ->first();
+
+        $this->assertNotNull($queueItem, 'Queue item should exist');
+
+        $initialBalance = $user->dark_matter;
+        $initialTimeEnd = $queueItem->time_end;
+
+        $response = $this->post('/ajax/facilities/halve-building', [
+            '_token' => csrf_token(),
+            'queue_item_id' => $queueItem->id,
+        ]);
+
+        $response->assertStatus(200);
+        $responseData = $response->json();
+
+        $this->assertTrue($responseData['success'], 'Halving should succeed');
+        $this->assertArrayHasKey('new_time_end', $responseData);
+        $this->assertArrayHasKey('cost', $responseData);
+        $this->assertArrayHasKey('new_balance', $responseData);
+
+        $user->refresh();
+        $this->assertLessThan($initialBalance, $user->dark_matter, 'Dark Matter should be deducted');
+
+        $queueItem->refresh();
+        $this->assertLessThan($initialTimeEnd, $queueItem->time_end, 'time_end should be reduced');
+
+        $transaction = DarkMatterTransaction::where('user_id', $this->currentUserId)
+            ->where('type', 'halving')
+            ->latest('id')
+            ->first();
+
+        $this->assertNotNull($transaction, 'Transaction should be logged');
+    }
+
+    /**
+     * Test research halving end-to-end workflow.
+     */
+    public function testResearchHalvingEndToEnd(): void
+    {
+        $user = User::find($this->currentUserId);
+        $user->dark_matter = 100000;
+        $user->save();
+
+        $this->planetSetObjectLevel('research_lab', 1);
+        $this->planetAddResources(new \OGame\Models\Resources(10000, 10000, 10000, 0));
+        $this->addResearchBuildRequest('energy_technology');
+
+        $queueItem = ResearchQueue::query()
+            ->join('planets', 'research_queues.planet_id', '=', 'planets.id')
+            ->where('planets.user_id', $this->currentUserId)
+            ->where('research_queues.building', 1)
+            ->where('research_queues.processed', 0)
+            ->select('research_queues.*')
+            ->first();
+
+        $this->assertNotNull($queueItem, 'Queue item should exist');
+
+        $initialBalance = $user->dark_matter;
+        $initialTimeEnd = $queueItem->time_end;
+
+        $response = $this->post('/ajax/research/halve-research', [
+            '_token' => csrf_token(),
+            'queue_item_id' => $queueItem->id,
+        ]);
+
+        $response->assertStatus(200);
+        $responseData = $response->json();
+
+        $this->assertTrue($responseData['success'], 'Halving should succeed');
+
+        $user->refresh();
+        $this->assertLessThan($initialBalance, $user->dark_matter, 'Dark Matter should be deducted');
+
+        $queueItem = ResearchQueue::find($queueItem->id);
+        $this->assertLessThan($initialTimeEnd, $queueItem->time_end, 'time_end should be reduced');
+    }
+
+    /**
+     * Test unit halving end-to-end workflow.
+     */
+    public function testUnitHalvingEndToEnd(): void
+    {
+        $user = User::find($this->currentUserId);
+        $user->dark_matter = 100000;
+        $user->save();
+
+        $this->planetSetObjectLevel('robot_factory', 2);
+        $this->planetSetObjectLevel('shipyard', 2);
+        $this->playerSetResearchLevel('combustion_drive', 1);
+        $this->planetAddResources(new \OGame\Models\Resources(50000, 50000, 50000, 0));
+        $this->addShipyardBuildRequest('light_fighter', 5);
+
+        $queueItem = UnitQueue::where('planet_id', $this->planetService->getPlanetId())
+            ->where('processed', 0)
+            ->first();
+
+        $this->assertNotNull($queueItem, 'Queue item should exist');
+
+        $initialBalance = $user->dark_matter;
+        $initialTimeEnd = $queueItem->time_end;
+
+        $response = $this->post('/ajax/shipyard/halve-unit', [
+            '_token' => csrf_token(),
+            'queue_item_id' => $queueItem->id,
+        ]);
+
+        $response->assertStatus(200);
+        $responseData = $response->json();
+
+        $this->assertTrue($responseData['success'], 'Halving should succeed');
+
+        $user->refresh();
+        $this->assertLessThan($initialBalance, $user->dark_matter, 'Dark Matter should be deducted');
+
+        $queueItem->refresh();
+        $this->assertLessThan($initialTimeEnd, $queueItem->time_end, 'time_end should be reduced');
+    }
+
+    /**
+     * Test double halving completes task immediately.
+     */
+    /**
+     * Test double halving for short duration tasks completes instantly.
+     *
+     * Each halve reduces remaining time by 50% of ORIGINAL construction time,
+     * capped at max reduction (48h for building).
+     */
+    public function testDoubleHalvingCompletesTask(): void
+    {
+        $user = User::find($this->currentUserId);
+        $user->dark_matter = 200000;
+        $user->save();
+
+        $this->addResourceBuildRequest('metal_mine');
+
+        $queueItem = BuildingQueue::where('planet_id', $this->planetService->getPlanetId())
+            ->where('building', 1)
+            ->where('processed', 0)
+            ->first();
+
+        $this->assertNotNull($queueItem, 'Queue item should exist');
+
+        $originalDuration = (int)$queueItem->time_duration;
+
+        // First halve - reduces by min(50% of original, 48h, remaining)
+        $response1 = $this->post('/ajax/facilities/halve-building', [
+            '_token' => csrf_token(),
+            'queue_item_id' => $queueItem->id,
+        ]);
+
+        $response1->assertStatus(200);
+        $this->assertTrue($response1->json('success'), 'First halving should succeed');
+
+        $remainingAfterFirst = $response1->json('remaining_time');
+
+        // If task is short enough (original <= 96h), second halve should complete it
+        if ($originalDuration <= 345600) { // 96 hours in seconds
+            // Second halve should complete the task
+            $response2 = $this->post('/ajax/facilities/halve-building', [
+                '_token' => csrf_token(),
+                'queue_item_id' => $queueItem->id,
+            ]);
+
+            $response2->assertStatus(200);
+            $responseData = $response2->json();
+
+            $this->assertTrue($responseData['success'], 'Second halving should succeed');
+            $this->assertLessThanOrEqual(1, $responseData['remaining_time'], 'Remaining time should be near zero after double halving');
+        } else {
+            // For very long tasks, just verify first halve reduced time
+            $this->assertLessThan($originalDuration, $remainingAfterFirst, 'First halve should reduce remaining time');
+        }
+    }
+
+    /**
+     * Test halving with insufficient Dark Matter returns error.
+     */
+    public function testHalvingWithInsufficientDarkMatter(): void
+    {
+        $user = User::find($this->currentUserId);
+        $user->dark_matter = 100;
+        $user->save();
+
+        $this->addResourceBuildRequest('metal_mine');
+
+        $queueItem = BuildingQueue::where('planet_id', $this->planetService->getPlanetId())
+            ->where('building', 1)
+            ->where('processed', 0)
+            ->first();
+
+        $this->assertNotNull($queueItem, 'Queue item should exist');
+
+        $response = $this->post('/ajax/facilities/halve-building', [
+            '_token' => csrf_token(),
+            'queue_item_id' => $queueItem->id,
+        ]);
+
+        $response->assertStatus(200);
+        $responseData = $response->json();
+
+        $this->assertFalse($responseData['success'], 'Halving should fail');
+        $this->assertStringContainsString('Insufficient Dark Matter', $responseData['message']);
+    }
+
+    /**
+     * Test halving with invalid queue item ID returns error.
+     */
+    public function testHalvingWithInvalidQueueItemId(): void
+    {
+        $user = User::find($this->currentUserId);
+        $user->dark_matter = 100000;
+        $user->save();
+
+        $response = $this->post('/ajax/facilities/halve-building', [
+            '_token' => csrf_token(),
+            'queue_item_id' => 999999,
+        ]);
+
+        $response->assertStatus(200);
+        $responseData = $response->json();
+
+        $this->assertFalse($responseData['success'], 'Halving should fail');
+        $this->assertStringContainsString('not found', $responseData['message']);
+    }
+
+    /**
+     * Test halving queue item with very short remaining time.
+     */
+    public function testHalvingWithVeryShortRemainingTime(): void
+    {
+        $user = User::find($this->currentUserId);
+        $user->dark_matter = 100000;
+        $user->save();
+
+        $this->addResourceBuildRequest('metal_mine');
+
+        $queueItem = BuildingQueue::where('planet_id', $this->planetService->getPlanetId())
+            ->where('building', 1)
+            ->where('processed', 0)
+            ->first();
+
+        $this->assertNotNull($queueItem, 'Queue item should exist');
+
+        $queueItem->time_end = (int)\Carbon\Carbon::now()->timestamp + 2;
+        $queueItem->save();
+
+        $response = $this->post('/ajax/facilities/halve-building', [
+            '_token' => csrf_token(),
+            'queue_item_id' => $queueItem->id,
+        ]);
+
+        $response->assertStatus(200);
+        $responseData = $response->json();
+
+        $this->assertTrue($responseData['success'], 'Halving should succeed');
+        $this->assertLessThanOrEqual(1, $responseData['remaining_time'], 'Remaining time should be very small');
+    }
+
+    /**
+     * Test halving with exactly the required Dark Matter balance.
+     */
+    public function testHalvingWithExactlyRequiredBalance(): void
+    {
+        $this->addResourceBuildRequest('metal_mine');
+
+        $queueItem = BuildingQueue::where('planet_id', $this->planetService->getPlanetId())
+            ->where('building', 1)
+            ->where('processed', 0)
+            ->first();
+
+        $this->assertNotNull($queueItem, 'Queue item should exist');
+
+        $halvingService = app(\OGame\Services\HalvingService::class);
+        $cost = $halvingService->calculateHalvingCost($queueItem->time_duration, 'building');
+
+        $user = User::find($this->currentUserId);
+        $user->dark_matter = $cost;
+        $user->save();
+
+        $response = $this->post('/ajax/facilities/halve-building', [
+            '_token' => csrf_token(),
+            'queue_item_id' => $queueItem->id,
+        ]);
+
+        $response->assertStatus(200);
+        $responseData = $response->json();
+
+        $this->assertTrue($responseData['success'], 'Halving should succeed with exact balance');
+        $this->assertEquals(0, $responseData['new_balance'], 'Balance should be exactly 0 after halving');
+    }
+
+    /**
+     * Test error cases for invalid queue items.
+     */
+    public function testHalvingInvalidQueueItems(): void
+    {
+        $user = User::find($this->currentUserId);
+        $user->dark_matter = 100000;
+        $user->save();
+
+        $initialBalance = $user->dark_matter;
+
+        // Test non-existent queue item
+        $response = $this->post('/ajax/facilities/halve-building', [
+            '_token' => csrf_token(),
+            'queue_item_id' => 999999,
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertFalse($response->json('success'), 'Should fail for non-existent queue item');
+
+        $user->refresh();
+        $this->assertEquals($initialBalance, $user->dark_matter, 'Dark Matter should not be deducted');
+
+        // Test already processed queue item
+        $this->addResourceBuildRequest('metal_mine');
+        $queueItem = BuildingQueue::where('planet_id', $this->planetService->getPlanetId())
+            ->where('building', 1)
+            ->where('processed', 0)
+            ->first();
+
+        $queueItem->processed = 1;
+        $queueItem->save();
+
+        $response = $this->post('/ajax/facilities/halve-building', [
+            '_token' => csrf_token(),
+            'queue_item_id' => $queueItem->id,
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertFalse($response->json('success'), 'Should fail for processed queue item');
+
+        $user->refresh();
+        $this->assertEquals($initialBalance, $user->dark_matter, 'Dark Matter should not be deducted');
+    }
+}

--- a/tests/Unit/HalvingServiceTest.php
+++ b/tests/Unit/HalvingServiceTest.php
@@ -1,0 +1,552 @@
+<?php
+
+namespace Tests\Unit;
+
+use Exception;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use OGame\Enums\DarkMatterTransactionType;
+use OGame\Models\BuildingQueue;
+use OGame\Models\DarkMatterTransaction;
+use OGame\Models\User;
+use OGame\Services\DarkMatterTransactionService;
+use OGame\Services\HalvingService;
+use OGame\Services\ObjectService;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\AccountTestCase;
+
+class HalvingServiceTest extends AccountTestCase
+{
+    use RefreshDatabase;
+
+    private HalvingService $halvingService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $transactionService = app(DarkMatterTransactionService::class);
+        $this->halvingService = new HalvingService($transactionService);
+    }
+
+    /**
+     * Test cost formula correctness for halving.
+     */
+    #[DataProvider('costFormulaDataProvider')]
+    public function testCostFormulaCorrectness(int $timeSeconds, string $queueType, int $expectedCostBeforeCaps): void
+    {
+        $cost = $this->halvingService->calculateHalvingCost($timeSeconds, $queueType);
+
+        // Calculate expected cost with formula (before caps)
+        $timeMinutes = $timeSeconds / 60;
+        $rawCost = (int)ceil(($timeMinutes / 30) * 750);
+
+        // Apply min/max caps
+        $minCost = 750;
+        $maxCost = match ($queueType) {
+            'building', 'unit' => 72000,
+            'research' => 108000,
+            default => 72000,
+        };
+
+        $expectedCost = max($minCost, min($rawCost, $maxCost));
+
+        $this->assertEquals($expectedCost, $cost, "Cost formula failed for {$timeSeconds}s ({$queueType})");
+    }
+
+    /**
+     * Data provider for cost formula tests - simulates property-based testing
+     * by generating many random test cases.
+     *
+     * @return array<string, array{0: int, 1: string, 2: int}>
+     */
+    public static function costFormulaDataProvider(): array
+    {
+        $testCases = [];
+
+        // Generate random test cases to simulate property-based testing
+        for ($i = 0; $i < 20; $i++) {
+            $timeSeconds = rand(1, 604800); // 1 second to 1 week
+            $queueTypes = ['building', 'research', 'unit'];
+            $queueType = $queueTypes[array_rand($queueTypes)];
+
+            $timeMinutes = $timeSeconds / 60;
+            $expectedCost = (int)ceil(($timeMinutes / 30) * 750);
+
+            $testCases["random_{$i}_{$queueType}_{$timeSeconds}s"] = [$timeSeconds, $queueType, $expectedCost];
+        }
+
+        // Add specific edge cases
+        $testCases['30_minutes_building'] = [1800, 'building', 750]; // Exactly 30 min = 750 DM
+        $testCases['1_hour_building'] = [3600, 'building', 1500]; // 1 hour = 1500 DM
+        $testCases['24_hours_building'] = [86400, 'building', 36000]; // 24 hours = 36000 DM
+        $testCases['48_hours_building'] = [172800, 'building', 72000]; // 48 hours = 72000 DM (capped)
+        $testCases['72_hours_research'] = [259200, 'research', 108000]; // 72 hours = 108000 DM (capped)
+
+        return $testCases;
+    }
+
+    /**
+     * Test building and unit maximum cost cap (72,000 DM).
+     */
+    #[DataProvider('maxCostBuildingUnitDataProvider')]
+    public function testBuildingAndUnitMaximumCostCap(int $timeSeconds): void
+    {
+        $buildingCost = $this->halvingService->calculateHalvingCost($timeSeconds, 'building');
+        $unitCost = $this->halvingService->calculateHalvingCost($timeSeconds, 'unit');
+
+        $this->assertLessThanOrEqual(72000, $buildingCost, "Building cost exceeded 72000 DM for {$timeSeconds}s");
+        $this->assertLessThanOrEqual(72000, $unitCost, "Unit cost exceeded 72000 DM for {$timeSeconds}s");
+    }
+
+    /**
+     * Test research maximum cost cap (108,000 DM).
+     */
+    #[DataProvider('maxCostResearchDataProvider')]
+    public function testResearchMaximumCostCap(int $timeSeconds): void
+    {
+        $cost = $this->halvingService->calculateHalvingCost($timeSeconds, 'research');
+
+        $this->assertLessThanOrEqual(108000, $cost, "Research cost exceeded 108000 DM for {$timeSeconds}s");
+    }
+
+    /**
+     * Data provider for max cost tests with long durations.
+     *
+     * @return array<string, array{0: int}>
+     */
+    public static function maxCostBuildingUnitDataProvider(): array
+    {
+        $testCases = [];
+
+        // Generate random long durations
+        for ($i = 0; $i < 20; $i++) {
+            $timeSeconds = rand(172800, 2592000); // 48 hours to 30 days
+            $testCases["long_duration_{$i}"] = [$timeSeconds];
+        }
+
+        return $testCases;
+    }
+
+    /**
+     * Data provider for research max cost tests.
+     *
+     * @return array<string, array{0: int}>
+     */
+    public static function maxCostResearchDataProvider(): array
+    {
+        $testCases = [];
+
+        // Generate random long durations
+        for ($i = 0; $i < 20; $i++) {
+            $timeSeconds = rand(259200, 2592000); // 72 hours to 30 days
+            $testCases["long_duration_{$i}"] = [$timeSeconds];
+        }
+
+        return $testCases;
+    }
+
+    /**
+     * Test minimum cost floor (750 DM).
+     */
+    #[DataProvider('minCostDataProvider')]
+    public function testMinimumCostFloor(int $timeSeconds, string $queueType): void
+    {
+        $cost = $this->halvingService->calculateHalvingCost($timeSeconds, $queueType);
+
+        $this->assertGreaterThanOrEqual(750, $cost, "Cost below 750 DM for {$timeSeconds}s ({$queueType})");
+    }
+
+    /**
+     * Data provider for minimum cost tests with short durations.
+     *
+     * @return array<string, array{0: int, 1: string}>
+     */
+    public static function minCostDataProvider(): array
+    {
+        $testCases = [];
+        $queueTypes = ['building', 'research', 'unit'];
+
+        // Generate random short durations
+        for ($i = 0; $i < 20; $i++) {
+            $timeSeconds = rand(1, 1800); // 1 second to 30 minutes
+            $queueType = $queueTypes[array_rand($queueTypes)];
+            $testCases["short_duration_{$i}_{$queueType}"] = [$timeSeconds, $queueType];
+        }
+
+        // Edge cases
+        $testCases['1_second_building'] = [1, 'building'];
+        $testCases['1_second_research'] = [1, 'research'];
+        $testCases['1_second_unit'] = [1, 'unit'];
+        $testCases['0_seconds_building'] = [0, 'building'];
+
+        return $testCases;
+    }
+
+    /**
+     * Test cost consistency across multiple calculations.
+     */
+    #[DataProvider('costConsistencyDataProvider')]
+    public function testCostConsistencyAcrossMultipleHalvings(int $timeSeconds, string $queueType): void
+    {
+        // Calculate cost multiple times
+        $cost1 = $this->halvingService->calculateHalvingCost($timeSeconds, $queueType);
+        $cost2 = $this->halvingService->calculateHalvingCost($timeSeconds, $queueType);
+        $cost3 = $this->halvingService->calculateHalvingCost($timeSeconds, $queueType);
+
+        $this->assertEquals($cost1, $cost2, "Cost inconsistent between calculations");
+        $this->assertEquals($cost2, $cost3, "Cost inconsistent between calculations");
+    }
+
+    /**
+     * Data provider for cost consistency tests.
+     *
+     * @return array<string, array{0: int, 1: string}>
+     */
+    public static function costConsistencyDataProvider(): array
+    {
+        $testCases = [];
+        $queueTypes = ['building', 'research', 'unit'];
+
+        for ($i = 0; $i < 20; $i++) {
+            $timeSeconds = rand(1, 604800);
+            $queueType = $queueTypes[array_rand($queueTypes)];
+            $testCases["consistency_{$i}"] = [$timeSeconds, $queueType];
+        }
+
+        return $testCases;
+    }
+
+    /**
+     * Test Dark Matter deduction correctness after halving.
+     */
+    public function testDarkMatterDeductionCorrectness(): void
+    {
+        // Set up user with sufficient Dark Matter
+        $user = User::find($this->currentUserId);
+        $user->dark_matter = 100000;
+        $user->save();
+
+        // Add a building to queue
+        $this->addBuildingToQueue();
+
+        // Get the queue item
+        $queueItem = BuildingQueue::where('planet_id', $this->planetService->getPlanetId())
+            ->where('building', 1)
+            ->where('processed', 0)
+            ->first();
+
+        $this->assertNotNull($queueItem, 'Queue item should exist');
+
+        $user->refresh();
+        $initialBalance = $user->dark_matter;
+
+        // Calculate expected cost based on remaining time
+        $currentTime = (int)\Carbon\Carbon::now()->timestamp;
+        $remainingTime = (int)$queueItem->time_end - $currentTime;
+        $expectedCost = $this->halvingService->calculateHalvingCost($remainingTime, 'building');
+
+        // Perform halving
+        $result = $this->halvingService->halveBuilding(
+            $user,
+            $queueItem->id,
+            $this->planetService
+        );
+
+        // Refresh user
+        $user->refresh();
+        $newBalance = $user->dark_matter;
+
+        $this->assertEquals($initialBalance - $result['cost'], $newBalance, 'Balance should be reduced by exactly the halving cost');
+        $this->assertGreaterThanOrEqual(750, $result['cost'], 'Cost should be at least minimum 750 DM');
+        $this->assertLessThanOrEqual(72000, $result['cost'], 'Cost should not exceed max 72000 DM for building');
+    }
+
+    /**
+     * Test insufficient balance rejection.
+     */
+    public function testInsufficientBalanceRejection(): void
+    {
+        // Set up user with insufficient Dark Matter
+        $user = User::find($this->currentUserId);
+        $user->dark_matter = 100;
+        $user->save();
+
+        // Add a building to queue
+        $this->addBuildingToQueue();
+
+        // Get the queue item
+        $queueItem = BuildingQueue::where('planet_id', $this->planetService->getPlanetId())
+            ->where('building', 1)
+            ->where('processed', 0)
+            ->first();
+
+        $this->assertNotNull($queueItem, 'Queue item should exist');
+
+        $initialBalance = $user->dark_matter;
+
+        // Attempt halving - should fail
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Insufficient Dark Matter');
+
+        try {
+            $this->halvingService->halveBuilding(
+                $user,
+                $queueItem->id,
+                $this->planetService
+            );
+        } finally {
+            // Verify balance unchanged
+            $user->refresh();
+            $this->assertEquals($initialBalance, $user->dark_matter, 'Balance should remain unchanged after failed halving');
+        }
+    }
+
+    /**
+     * Test transaction logging on successful halving.
+     */
+    public function testTransactionLoggingOnSuccess(): void
+    {
+        // Set up user with sufficient Dark Matter
+        $user = User::find($this->currentUserId);
+        $user->dark_matter = 100000;
+        $user->save();
+
+        // Add a building to queue
+        $this->addBuildingToQueue();
+
+        // Get the queue item
+        $queueItem = BuildingQueue::where('planet_id', $this->planetService->getPlanetId())
+            ->where('building', 1)
+            ->where('processed', 0)
+            ->first();
+
+        $this->assertNotNull($queueItem, 'Queue item should exist');
+
+        // Count transactions before
+        $transactionCountBefore = DarkMatterTransaction::where('user_id', $this->currentUserId)->count();
+
+        // Perform halving
+        $this->halvingService->halveBuilding(
+            $user,
+            $queueItem->id,
+            $this->planetService
+        );
+
+        // Check transaction was created
+        $transactionCountAfter = DarkMatterTransaction::where('user_id', $this->currentUserId)->count();
+        $this->assertEquals($transactionCountBefore + 1, $transactionCountAfter, 'Transaction should be created');
+
+        // Verify transaction details
+        $transaction = DarkMatterTransaction::where('user_id', $this->currentUserId)
+            ->where('type', DarkMatterTransactionType::HALVING->value)
+            ->latest('id')
+            ->first();
+
+        $this->assertNotNull($transaction, 'Halving transaction should exist');
+        $this->assertEquals(DarkMatterTransactionType::HALVING->value, $transaction->type);
+        $this->assertStringContainsString('Halving building', $transaction->description);
+        $this->assertStringContainsString((string)$this->planetService->getPlanetId(), $transaction->description);
+    }
+
+    /**
+     * Test no transaction is created on failure.
+     */
+    public function testNoTransactionOnFailure(): void
+    {
+        // Set up user with insufficient Dark Matter
+        $user = User::find($this->currentUserId);
+        $user->dark_matter = 100;
+        $user->save();
+
+        // Add a building to queue
+        $this->addBuildingToQueue();
+
+        // Get the queue item
+        $queueItem = BuildingQueue::where('planet_id', $this->planetService->getPlanetId())
+            ->where('building', 1)
+            ->where('processed', 0)
+            ->first();
+
+        // Count transactions before
+        $transactionCountBefore = DarkMatterTransaction::where('user_id', $this->currentUserId)
+            ->where('type', DarkMatterTransactionType::HALVING->value)
+            ->count();
+
+        // Attempt halving - should fail
+        try {
+            $this->halvingService->halveBuilding(
+                $user,
+                $queueItem->id,
+                $this->planetService
+            );
+        } catch (Exception $e) {
+            // Expected
+        }
+
+        // Verify no transaction was created
+        $transactionCountAfter = DarkMatterTransaction::where('user_id', $this->currentUserId)
+            ->where('type', DarkMatterTransactionType::HALVING->value)
+            ->count();
+
+        $this->assertEquals($transactionCountBefore, $transactionCountAfter, 'No transaction should be created on failure');
+    }
+
+    /**
+     * Helper method to add a building to the queue.
+     */
+    private function addBuildingToQueue(): void
+    {
+        // Get metal mine object ID
+        $metalMine = ObjectService::getObjectByMachineName('metal_mine');
+
+        // Add to queue via service
+        $buildingQueueService = app(\OGame\Services\BuildingQueueService::class);
+        $buildingQueueService->add($this->planetService, $metalMine->id);
+    }
+
+    /**
+     * Test time reduction by 50% of ORIGINAL time after halving (capped at max).
+     *
+     * Each halve reduces remaining time by 50% of the original construction time,
+     * but capped at max reduction (48h for building/unit, 72h for research).
+     */
+    public function testTimeReductionBy50PercentOfOriginalTime(): void
+    {
+        // Set up user with sufficient Dark Matter
+        $user = User::find($this->currentUserId);
+        $user->dark_matter = 100000;
+        $user->save();
+
+        // Add a building to queue
+        $this->addBuildingToQueue();
+
+        // Get the queue item
+        $queueItem = BuildingQueue::where('planet_id', $this->planetService->getPlanetId())
+            ->where('building', 1)
+            ->where('processed', 0)
+            ->first();
+
+        $this->assertNotNull($queueItem, 'Queue item should exist');
+
+        // Get remaining time and original duration before halving
+        $currentTime = (int)\Carbon\Carbon::now()->timestamp;
+        $remainingTimeBefore = (int)$queueItem->time_end - $currentTime;
+        $originalDuration = (int)$queueItem->time_duration;
+
+        // Perform halving
+        $result = $this->halvingService->halveBuilding(
+            $user,
+            $queueItem->id,
+            $this->planetService
+        );
+
+        // Calculate expected reduction: 50% of original, capped at 48h (172800s) for building
+        $halfOriginal = intdiv($originalDuration, 2);
+        $maxReduction = 172800; // 48 hours for building
+        $expectedReduction = min($halfOriginal, $maxReduction, $remainingTimeBefore);
+        $expectedRemainingTime = max(0, $remainingTimeBefore - $expectedReduction);
+
+        // Allow 1 second tolerance for timing
+        $this->assertLessThanOrEqual(1, abs($expectedRemainingTime - $result['remaining_time']), 'Remaining time should be reduced by 50% of original duration (capped at 48h)');
+    }
+
+    /**
+     * Test original time_start and time_duration are preserved after halving.
+     */
+    public function testOriginalTimePreservation(): void
+    {
+        // Set up user with sufficient Dark Matter
+        $user = User::find($this->currentUserId);
+        $user->dark_matter = 100000;
+        $user->save();
+
+        // Add a building to queue
+        $this->addBuildingToQueue();
+
+        // Get the queue item
+        $queueItem = BuildingQueue::where('planet_id', $this->planetService->getPlanetId())
+            ->where('building', 1)
+            ->where('processed', 0)
+            ->first();
+
+        $this->assertNotNull($queueItem, 'Queue item should exist');
+
+        // Store original values
+        $originalTimeStart = $queueItem->time_start;
+        $originalTimeDuration = $queueItem->time_duration;
+
+        // Perform halving
+        $this->halvingService->halveBuilding(
+            $user,
+            $queueItem->id,
+            $this->planetService
+        );
+
+        // Refresh queue item
+        $queueItem->refresh();
+
+        // Verify time_start and time_duration are unchanged
+        $this->assertEquals($originalTimeStart, $queueItem->time_start, 'time_start should remain unchanged');
+        $this->assertEquals($originalTimeDuration, $queueItem->time_duration, 'time_duration should remain unchanged');
+    }
+
+    /**
+     * Test operation isolation - halving only affects the target queue item.
+     */
+    public function testOperationIsolation(): void
+    {
+        // Set up user with sufficient Dark Matter
+        $user = User::find($this->currentUserId);
+        $user->dark_matter = 100000;
+        $user->save();
+
+        // Add resources to build multiple buildings
+        $this->planetAddResources(new \OGame\Models\Resources(50000, 50000, 50000, 0));
+
+        // Add first building to queue
+        $this->addBuildingToQueue();
+
+        // Get the first queue item
+        $firstQueueItem = BuildingQueue::where('planet_id', $this->planetService->getPlanetId())
+            ->where('building', 1)
+            ->where('processed', 0)
+            ->first();
+
+        $this->assertNotNull($firstQueueItem, 'First queue item should exist');
+
+        // Store original time_end of first item
+        $firstItemTimeEndBefore = $firstQueueItem->time_end;
+
+        // Add second building to queue (different building)
+        $crystalMine = ObjectService::getObjectByMachineName('crystal_mine');
+        $buildingQueueService = app(\OGame\Services\BuildingQueueService::class);
+        $buildingQueueService->add($this->planetService, $crystalMine->id);
+
+        // Get the second queue item (not building yet, waiting in queue)
+        $secondQueueItem = BuildingQueue::where('planet_id', $this->planetService->getPlanetId())
+            ->where('processed', 0)
+            ->where('canceled', 0)
+            ->where('id', '!=', $firstQueueItem->id)
+            ->first();
+
+        // Perform halving on first item
+        $this->halvingService->halveBuilding(
+            $user,
+            $firstQueueItem->id,
+            $this->planetService
+        );
+
+        // Refresh first queue item
+        $firstQueueItem->refresh();
+
+        // Verify first item was halved (time_end changed)
+        $this->assertNotEquals($firstItemTimeEndBefore, $firstQueueItem->time_end, 'First item time_end should be changed');
+
+        // If second queue item exists, verify it was not affected
+        if ($secondQueueItem) {
+            $secondQueueItemAfter = BuildingQueue::find($secondQueueItem->id);
+            // Second item should still be in queue and not modified
+            $this->assertNotNull($secondQueueItemAfter, 'Second queue item should still exist');
+        }
+    }
+}


### PR DESCRIPTION

## Description

Implements the backend for the Dark Matter halving feature, allowing players to spend Dark Matter to reduce construction time for buildings, research, and unit production.

### Type of Change:

- [x] Feature enhancement

## Related Issues

Fixes #872

## Checklist

- [x] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [x] **Static Analysis:** Code passes PHPStan static code analysis.
- [x] **Testing:**
  - Relevant unit and feature tests are included or updated.
  - Tests successfully run locally (125 halving tests pass).
- [ ] **CSS & JS Build:** No changes to JS/CSS files.
- [ ] **Documentation:** No documentation changes needed.

## Additional Information
