### PR TITLE
Fix duplicate 'Settings saved' message in options page

### DIFF
--- a/resources/views/ingame/options/index.blade.php
+++ b/resources/views/ingame/options/index.blade.php
@@ -577,10 +577,6 @@
             @if (session('success') == __('Vacation mode has been deactivated.'))
                 fadeBox('{{ session('success') }}', false);
             @endif
-            // Show fadeBox for other success messages (e.g., "Settings saved")
-            @if (session('success') && session('success') != __('Vacation mode has been activated. It will protect you from new attacks for a minimum of 48 hours.') && session('success') != __('Vacation mode has been deactivated.'))
-                fadeBox('{{ session('success') }}', false);
-            @endif
 
             $(".validateButtonGift").click(function() {
                 $(".validateButtonGift").hide();


### PR DESCRIPTION
## Description
Fix duplicate "Settings saved" message in options page.

Remove the rogue alert div that was showing a duplicate "Settings saved" message in the upper left corner of the screen
when saving settings.

Changes:
- Remove duplicate alert-success div for non-vacation mode success messages


### Type of Change:
- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #899 

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [X] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [X] **Static Analysis:** Code passes PHPStan static code analysis.
- [X] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [ ] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [ ] **Documentation:** Documentation has been updated to reflect any changes made.

