### PR TITLE
fix: add debris field handling in counter-espionage mission

### DIFF
--- a/app/GameMissions/EspionageMission.php
+++ b/app/GameMissions/EspionageMission.php
@@ -113,6 +113,19 @@ class EspionageMission extends GameMission
             // Execute counter-espionage battle
             $battleResult = $this->executeCounterEspionageBattle($origin_planet, $target_planet, $units, $counterEspionageService);
 
+            // Create or append debris field.
+            // TODO: we could change this debris field append logic to do everything in a single query to
+            // prevent race conditions. Check this later when looking into reducing chance of race conditions occurring.
+            // (This TODO is copied from AttackMission.php for consistency)
+            $debrisFieldService = resolve(DebrisFieldService::class);
+            $debrisFieldService->loadOrCreateForCoordinates($target_planet->getPlanetCoordinates());
+
+            // Add debris to the field
+            $debrisFieldService->appendResources($battleResult->debris);
+
+            // Save the debris field
+            $debrisFieldService->save();
+
             // Create battle report for defender
             $battleReportId = $this->createCounterEspionageBattleReport($origin_planet->getPlayer(), $target_planet, $battleResult);
             $this->messageService->sendBattleReportMessageToPlayer($target_planet->getPlayer(), $battleReportId);


### PR DESCRIPTION
## Description
This PR fixes a bug where counter-espionage battles were not generating debris fields. When a battle was triggered via counter-espionage, the combat would occur and create a battle report, but no debris field was created in the database for players to recycle. Regular attack missions correctly generated debris fields as expected.

### Type of Change:
- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #924

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [x] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [x] **Static Analysis:** Code passes PHPStan static code analysis.
- [ ] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [ ] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [ ] **Documentation:** Documentation has been updated to reflect any changes made.

## Additional Information
