### PR TITLE
Update run-phpstan-code-analysis.yml

### DIFF
--- a/.github/workflows/run-phpstan-code-analysis.yml
+++ b/.github/workflows/run-phpstan-code-analysis.yml
@@ -15,6 +15,8 @@ jobs:
   phpstan-code-analysis:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v6
+
     - uses: shivammathur/setup-php@v2
       with:
         php-version: '8.5'


### PR DESCRIPTION
I noticed this seems to be running weird couple things I noticed: 

1. We only need the dev composer installed, as its static analysis 
2. We dont need to generate anything,  or adjust any storage bits re keys - laravel etc.
3. Added cache to make it even quicker
