### PR TITLE
fix: include nanite factory level in build time calculation

### DIFF
--- a/app/Services/PlanetService.php
+++ b/app/Services/PlanetService.php
@@ -776,17 +776,17 @@ class PlanetService
             $universe_speed = 1;
         }
 
-        // Nanite Factory uses a different formula - it doesn't benefit from itself
-        // Formula: (Metal + Crystal) / (2500 * (1 + Robotics Factory Level) * Universe Speed)
+        // Nanite Factory uses the simplified formula without the level-based factor
+        // Formula: (Metal + Crystal) / (2500 * (1 + Robotics Factory Level) * 2^Nanite Factory Level * Universe Speed)
         if ($machine_name === 'nano_factory') {
             $time_hours =
                 (
                     ($price->metal->get() + $price->crystal->get())
                     /
-                    (2500 * (1 + $robotfactory_level) * $universe_speed)
+                    (2500 * (1 + $robotfactory_level) * $universe_speed * (2 ** $nanitefactory_level))
                 );
         } else {
-            // The actual formula which return time in seconds
+            // Other buildings use the formula with level-based factor
             $time_hours =
                 (
                     ($price->metal->get() + $price->crystal->get())
@@ -837,17 +837,17 @@ class PlanetService
             $universe_speed = 1;
         }
 
-        // Nanite Factory uses a different formula - it doesn't benefit from itself
-        // Formula: (Metal + Crystal) / (2500 * (1 + Robotics Factory Level) * Universe Speed)
+        // Nanite Factory uses the simplified formula without the level-based factor
+        // Formula: (Metal + Crystal) / (2500 * (1 + Robotics Factory Level) * 2^Nanite Factory Level * Universe Speed)
         if ($machine_name === 'nano_factory') {
             $time_hours =
                 (
                     ($price->metal->get() + $price->crystal->get())
                     /
-                    (2500 * (1 + $robotfactory_level) * $universe_speed)
+                    (2500 * (1 + $robotfactory_level) * $universe_speed * (2 ** $nanitefactory_level))
                 );
         } else {
-            // The actual formula which return time in seconds
+            // Other buildings use the formula with level-based factor
             // Same formula as construction time but for level instead of next_level
             $time_hours =
                 (


### PR DESCRIPTION
## Description

This PR fixes the Nanite Factory build time calculation to match the correct OGame mechanics. Previously, the Nanite Factory's build time would double with each level upgrade, which is incorrect behavior.

### Type of Change:

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues

Fixes #940
Continue PR #950
## Checklist

Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [x] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [x] **Static Analysis:** Code passes PHPStan static code analysis.
- [x] **Testing:**
  - Relevant unit and feature tests are included or updated.
  - Tests successfully run locally.
- [ ] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [x] **Documentation:** Documentation has been updated to reflect any changes made.

## Additional Information

**Changes Made:**

