### PR TITLE
fix(options): increase espionage probes input field size limit

### DIFF
--- a/resources/views/ingame/options/index.blade.php
+++ b/resources/views/ingame/options/index.blade.php
@@ -202,7 +202,7 @@
                                             <div class="fieldwrapper">
                                                 <label class="styled textBeefy">Number of espionage probes:</label>
                                                 <div class="thefield">
-                                                    <input type="text" pattern="[0-9]*" class="textInput w50 textCenter textBeefy" value="{{ old('espionage_probes_amount', $espionage_probes_amount ?? '') }}" size="2" maxlength="2" name="espionage_probes_amount">
+                                                    <input type="text" pattern="[0-9]*" class="textInput w50 textCenter textBeefy" value="{{ old('espionage_probes_amount', $espionage_probes_amount ?? '') }}" size="4" maxlength="4" name="espionage_probes_amount">
                                                 </div>
                                             </div>
                                         </div>


### PR DESCRIPTION
## Description

Increased the maximum number of espionage probes that can be set in settings from 99 to 9999, matching OGame's behavior.

### Type of Change:

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues

Fixes #964

## Checklist

Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [x] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [x] **Static Analysis:** Code passes PHPStan static code analysis.
- [x] **Testing:**
  - Relevant unit and feature tests are included or updated.
  - Tests successfully run locally.
- [ ] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [x] **Documentation:** Documentation has been updated to reflect any changes made.

## Additional Information
