### PR TITLE
feat(expeditions): display dark matter amount in expedition gain message

### DIFF
--- a/app/GameMessages/ExpeditionGainDarkMatter.php
+++ b/app/GameMessages/ExpeditionGainDarkMatter.php
@@ -23,4 +23,24 @@ class ExpeditionGainDarkMatter extends ExpeditionGameMessage
      * @var int
      */
     protected static int $numberOfVariations = 8;
+
+    /**
+     * Overrides the body of the message to append the Dark Matter amount based on the params.
+     */
+    public function getBody(): string
+    {
+        // Get the base body with the random variation message.
+        $translatedBody = parent::getBody();
+
+        // Get the params to access the dark matter amount.
+        $params = parent::checkParams($this->message->params);
+        $params = parent::formatReservedParams($params);
+
+        // Append the Dark Matter amount to the body if the param is set.
+        if (!empty($params['dark_matter_amount'])) {
+            $translatedBody .= '<br /><br />' . __('t_messages.expedition_dark_matter_captured', ['dark_matter_amount' => $params['dark_matter_amount']]);
+        }
+
+        return $translatedBody;
+    }
 }

--- a/resources/lang/en/t_messages.php
+++ b/resources/lang/en/t_messages.php
@@ -133,6 +133,7 @@ Metal: :metal Crystal: :crystal Deuterium: :deuterium',
     // ------------------------
     // Expedition generic message parts
     'expedition_resources_captured' => ':resource_type :resource_amount have been captured.',
+    'expedition_dark_matter_captured' => '(:dark_matter_amount Dark Matter)',
     'expedition_units_captured' => 'The following ships are now part of the fleet:',
 
     'expedition_unexplored_statement' => 'Entry from the communication officers logbook: It seems that this part of the universe has not been explored yet.',


### PR DESCRIPTION
## Description

Display the amount of Dark Matter gained in expedition messages. Previously, players were not informed about how much Dark Matter they received from expeditions.

### Type of Change:

- [x] Bug fix

## Related Issues

Fixes #956

## Checklist

- [x] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [x] **Static Analysis:** Code passes PHPStan static code analysis.
- [x] **Testing:**
  - Relevant unit and feature tests are included or updated.
  - Tests successfully run locally.
- [x] **CSS & JS Build:** N/A - No changes to JS/CSS files.
- [x] **Documentation:** N/A - No documentation changes required.

## Additional Information
