### PR TITLE
fix: block ship/defense construction while Nanite Factory is upgradin…

### DIFF
--- a/app/Http/Controllers/DefenseController.php
+++ b/app/Http/Controllers/DefenseController.php
@@ -67,16 +67,25 @@ class DefenseController extends AbstractUnitsController
      */
     public function addBuildRequest(Request $request, PlayerService $player): JsonResponse
     {
-        // If the shipyard isn't upgrading, we can continue to process the request.
-        if (!$player->planets->current()->isBuildingObject('shipyard')) {
-            return parent::addBuildRequest($request, $player);
-        } else {
-            // Otherwise, it shouldn't be allowed.
+        $planet = $player->planets->current();
+
+        // If the shipyard is upgrading, block the request.
+        if ($planet->isBuildingObject('shipyard')) {
             return response()->json([
                 'success' => false,
                 'errors' => [['message' => __('Shipyard is being upgraded.')]],
             ]);
         }
+
+        // If the nanite factory is upgrading, block the request.
+        if ($planet->isBuildingObject('nano_factory')) {
+            return response()->json([
+                'success' => false,
+                'errors' => [['message' => __('Nanite Factory is being upgraded.')]],
+            ]);
+        }
+
+        return parent::addBuildRequest($request, $player);
     }
 
     /**

--- a/app/Http/Controllers/ShipyardController.php
+++ b/app/Http/Controllers/ShipyardController.php
@@ -71,16 +71,25 @@ class ShipyardController extends AbstractUnitsController
      */
     public function addBuildRequest(Request $request, PlayerService $player): JsonResponse
     {
-        // If the shipyard isn't upgrading, we can continue to process the request.
-        if (!$player->planets->current()->isBuildingObject('shipyard')) {
-            return parent::addBuildRequest($request, $player);
-        } else {
-            // Otherwise, it shouldn't be allowed.
+        $planet = $player->planets->current();
+
+        // If the shipyard is upgrading, block the request.
+        if ($planet->isBuildingObject('shipyard')) {
             return response()->json([
                 'success' => false,
                 'errors' => [['message' => __('Shipyard is being upgraded.')]],
             ]);
         }
+
+        // If the nanite factory is upgrading, block the request.
+        if ($planet->isBuildingObject('nano_factory')) {
+            return response()->json([
+                'success' => false,
+                'errors' => [['message' => __('Nanite Factory is being upgraded.')]],
+            ]);
+        }
+
+        return parent::addBuildRequest($request, $player);
     }
 
     /**


### PR DESCRIPTION
## Description

Block ship and defense construction while the Nanite Factory is being upgraded. Previously, only Shipyard upgrades blocked unit construction, but according to OGame mechanics, Nanite Factory upgrades should also prevent building ships and defenses.

### Type of Change:

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues

Fixes #967

## Checklist

Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [x] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [x] **Static Analysis:** Code passes PHPStan static code analysis.
- [x] **Testing:**
  - Relevant unit and feature tests are included or updated.
  - Tests successfully run locally.
- [ ] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [ ] **Documentation:** Documentation has been updated to reflect any changes made.

## Additional Information
