### PR TITLE
fix: add dynamic galaxy count to developer shortcuts and missile atta…

### DIFF
--- a/app/Http/Controllers/Admin/DeveloperShortcutsController.php
+++ b/app/Http/Controllers/Admin/DeveloperShortcutsController.php
@@ -24,7 +24,7 @@ class DeveloperShortcutsController extends OGameController
      *
      * @return View
      */
-    public function index(PlayerService $playerService): View
+    public function index(PlayerService $playerService, SettingsService $settingsService): View
     {
         // Get all unit objects
         $units = ObjectService::getUnitObjects();
@@ -34,6 +34,7 @@ class DeveloperShortcutsController extends OGameController
             'buildings' => [...ObjectService::getBuildingObjects(), ...ObjectService::getStationObjects()],
             'research' => ObjectService::getResearchObjects(),
             'currentPlanet' => $playerService->planets->current(),
+            'settings' => $settingsService,
         ]);
     }
 

--- a/public/js/ingame.js
+++ b/public/js/ingame.js
@@ -65394,7 +65394,8 @@ function outlawWarning(order, galaxy, system, planet, planettype, shipCount, cal
 
   function openMissleLaunchBox() {
     openOverlay(missleAttackLink + '&galaxy=' + galaxy + '&system=' + system + '&position=' + planet + '&planetType=' + planettype, {
-      modal: true
+      modal: true,
+      title: loca.LOCA_FLEET_MISSILEATTACK || 'Missile Attack'
     });
   }
 }
@@ -78608,7 +78609,7 @@ function getPlanetOrMoonTooltipLinks(planet, galaxyContentObject, systemData) {
                             ${loca.LOCA_FLEET_MISSILEATTACK}
                         </a></li>`;
       } else {
-        linkHTML += `<li><a class="overlay" href="${galaxyContentObject.actions.missileAttackLink}&planetType=${planet.planetType}" data-overlay-modal='true'>${loca.LOCA_FLEET_MISSILEATTACK}</a></li>`;
+        linkHTML += `<li><a class="overlay" href="${galaxyContentObject.actions.missileAttackLink}&planetType=${planet.planetType}" data-overlay-modal='true' data-overlay-title="${loca.LOCA_FLEET_MISSILEATTACK}">${loca.LOCA_FLEET_MISSILEATTACK}</a></li>`;
       }
     }
 
@@ -79057,6 +79058,7 @@ function getActions(galaxyContentObject, systemData) {
                title="${loca.LOCA_FLEET_MISSILEATTACK}"
                href="${galaxyContentObject.actions.missileAttackLink}&planetType=${mainPlanet.planetType}"
                data-overlay-modal='true'
+               data-overlay-title="${loca.LOCA_FLEET_MISSILEATTACK}"
             >
                 <span class="icon icon_missile"></span>
             </a>`;

--- a/public/js/ingame.min.js
+++ b/public/js/ingame.min.js
@@ -65394,7 +65394,8 @@ function outlawWarning(order, galaxy, system, planet, planettype, shipCount, cal
 
   function openMissleLaunchBox() {
     openOverlay(missleAttackLink + '&galaxy=' + galaxy + '&system=' + system + '&position=' + planet + '&planetType=' + planettype, {
-      modal: true
+      modal: true,
+      title: loca.LOCA_FLEET_MISSILEATTACK || 'Missile Attack'
     });
   }
 }
@@ -78608,7 +78609,7 @@ function getPlanetOrMoonTooltipLinks(planet, galaxyContentObject, systemData) {
                             ${loca.LOCA_FLEET_MISSILEATTACK}
                         </a></li>`;
       } else {
-        linkHTML += `<li><a class="overlay" href="${galaxyContentObject.actions.missileAttackLink}&planetType=${planet.planetType}" data-overlay-modal='true'>${loca.LOCA_FLEET_MISSILEATTACK}</a></li>`;
+        linkHTML += `<li><a class="overlay" href="${galaxyContentObject.actions.missileAttackLink}&planetType=${planet.planetType}" data-overlay-modal='true' data-overlay-title="${loca.LOCA_FLEET_MISSILEATTACK}">${loca.LOCA_FLEET_MISSILEATTACK}</a></li>`;
       }
     }
 
@@ -79057,6 +79058,7 @@ function getActions(galaxyContentObject, systemData) {
                title="${loca.LOCA_FLEET_MISSILEATTACK}"
                href="${galaxyContentObject.actions.missileAttackLink}&planetType=${mainPlanet.planetType}"
                data-overlay-modal='true'
+               data-overlay-title="${loca.LOCA_FLEET_MISSILEATTACK}"
             >
                 <span class="icon icon_missile"></span>
             </a>`;

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,8 +1,8 @@
 {
     "/css/ingame.css": "/css/ingame.css?id=800e965533eae99862b354d9de26471c",
     "/css/outgame.css": "/css/outgame.css?id=0edfd34484fc3ec74eca0604a470461f",
-    "/js/ingame.js": "/js/ingame.js?id=27c4ca1a015c2129e488086da1cbb13c",
-    "/js/ingame.min.js": "/js/ingame.min.js?id=27c4ca1a015c2129e488086da1cbb13c",
+    "/js/ingame.js": "/js/ingame.js?id=a52083da8b630c96be4382716cb9246a",
+    "/js/ingame.min.js": "/js/ingame.min.js?id=a52083da8b630c96be4382716cb9246a",
     "/js/outgame.js": "/js/outgame.js?id=5fa6ee5cdc34001db0bdccd06a7f676c",
     "/js/outgame.min.js": "/js/outgame.min.js?id=5fa6ee5cdc34001db0bdccd06a7f676c"
 }

--- a/resources/views/ingame/admin/developershortcuts.blade.php
+++ b/resources/views/ingame/admin/developershortcuts.blade.php
@@ -102,7 +102,7 @@
                                             <div>
                                                 <label for="galaxy">@lang('Galaxy:')</label>
                                                 <input type="text" id="galaxy" pattern="^[-+0-9,.kmb]+$" class="textInput w50 textCenter textBeefy"
-                                                       value="{{ $currentPlanet->getPlanetCoordinates()->galaxy }}" min="1" max="6" name="galaxy">
+                                                       value="{{ $currentPlanet->getPlanetCoordinates()->galaxy }}" min="1" max="{{ $settings->numberOfGalaxies() }}" name="galaxy">
                                             </div>
                                             <div>
                                                 <label for="system">@lang('System:')</label>
@@ -145,7 +145,7 @@
                                             <div>
                                                 <label for="galaxy">@lang('Galaxy:')</label>
                                                 <input type="text" id="galaxy" pattern="^[-+0-9,.kmb]+$" class="textInput w50 textCenter textBeefy"
-                                                       value="{{ $currentPlanet->getPlanetCoordinates()->galaxy }}" min="1" max="6" name="galaxy">
+                                                       value="{{ $currentPlanet->getPlanetCoordinates()->galaxy }}" min="1" max="{{ $settings->numberOfGalaxies() }}" name="galaxy">
                                             </div>
                                             <div>
                                                 <label for="system">@lang('System:')</label>
@@ -196,7 +196,7 @@
                                             <div>
                                                 <label for="galaxy">@lang('Galaxy:')</label>
                                                 <input type="text" id="galaxy" pattern="^[-+0-9,.kmb]+$" class="textInput w50 textCenter textBeefy"
-                                                       value="{{ $currentPlanet->getPlanetCoordinates()->galaxy }}" min="1" max="6" name="galaxy">
+                                                       value="{{ $currentPlanet->getPlanetCoordinates()->galaxy }}" min="1" max="{{ $settings->numberOfGalaxies() }}" name="galaxy">
                                             </div>
                                             <div>
                                                 <label for="system">@lang('System:')</label>

--- a/resources/views/ingame/galaxy/index.blade.php
+++ b/resources/views/ingame/galaxy/index.blade.php
@@ -61,7 +61,7 @@
                         }
                     })
                     .keyup(function() {
-                        checkIntInput($(this), 1, 6)
+                        checkIntInput($(this), 1, maxGalaxies)
                     })
                     .focus(function() {
                         $(this).val("");
@@ -74,7 +74,7 @@
                         }
                     })
                     .keyup(function() {
-                        checkIntInput($(this), 1, 6)
+                        checkIntInput($(this), 1, maxSystems)
                     })
                     .focus(function() {
                         $(this).val("");
@@ -97,7 +97,7 @@
                         }
                     })
                     .keyup(function() {
-                        checkIntInput($(this), 1, 6)
+                        checkIntInput($(this), 1, maxGalaxies)
                     })
                     .focus(function() {
                         $(this).val("");
@@ -110,7 +110,7 @@
                         }
                     })
                     .keyup(function() {
-                        checkIntInput($(this), 1, 499)
+                        checkIntInput($(this), 1, maxSystems)
                     })
                     .focus(function() {
                         $(this).val("");


### PR DESCRIPTION
## Description

Fix galaxy input validation in `/galaxy` page that was hardcoded to max 6 instead of using the server's configured `maxGalaxies` setting. This prevented users from navigating to galaxies 7, 8, or 9 by typing the number directly.

### Type of Change:

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues

Fixes #969

## Checklist

Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [x] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [x] **Static Analysis:** Code passes PHPStan static code analysis.
- [x] **Testing:**
  - Relevant unit and feature tests are included or updated.
  - Tests successfully run locally.
- [x] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [ ] **Documentation:** Documentation has been updated to reflect any changes made.

## Additional Information
