### PR TITLE
Fix flaky fleet dispatch tests

### DIFF
--- a/tests/AccountTestCase.php
+++ b/tests/AccountTestCase.php
@@ -5,7 +5,6 @@ namespace Tests;
 use Carbon\Carbon;
 use Exception;
 use Illuminate\Contracts\Container\BindingResolutionException;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Illuminate\Testing\TestResponse;


### PR DESCRIPTION
## Description
The `getNearbyForeignPlanet()` and `getNearbyForeignMoon()` helpers were randomly selecting planets owned by admin users, causing test failures when missions like buddy requests or attacks were attempted against admin-protected planets.
Modified both helpers to check the `model_has_roles `table to properly exclude users with the 'admin' role, rather than relying on username filtering alone.

### Type of Change:
- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #976 

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [X] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [X] **Static Analysis:** Code passes PHPStan static code analysis.
- [X] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [ ] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [ ] **Documentation:** Documentation has been updated to reflect any changes made.

## Additional Information
Add any additional context, screenshots, or explanations to help reviewers understand your PR. If this change introduces any breaking changes or significant impacts, please detail them here.
