### PR TITLE
Fix: Add FleetMissionStatus::Hostile to MissileMission.php

### DIFF
--- a/app/GameMissions/MissileMission.php
+++ b/app/GameMissions/MissileMission.php
@@ -4,6 +4,7 @@ namespace OGame\GameMissions;
 
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use OGame\Enums\FleetMissionStatus;
 use OGame\GameMissions\Abstracts\GameMission;
 use OGame\GameMissions\Models\MissionPossibleStatus;
 use OGame\GameObjects\Models\Units\UnitCollection;
@@ -34,6 +35,7 @@ class MissileMission extends GameMission
     protected static string $name = 'Missile Attack';
     protected static int $typeId = 10;
     protected static bool $hasReturnMission = false;
+    protected static FleetMissionStatus $friendlyStatus = FleetMissionStatus::Hostile;
 
     /**
      * @inheritdoc


### PR DESCRIPTION
## Description
Added `FleetMissionStatus::Hostile` to `MissileMission.php` to follow the same pattern as `AttackMission.php` in displaying the hostile fleet warning in the fleet widget.

### Type of Change:
- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #973 

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [X] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [X] **Static Analysis:** Code passes PHPStan static code analysis.
- [X] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [ ] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [ ] **Documentation:** Documentation has been updated to reflect any changes made.

## Additional Information
Add any additional context, screenshots, or explanations to help reviewers understand your PR. If this change introduces any breaking changes or significant impacts, please detail them here.
