### PR TITLE
Fix: Expedition recall excludes hold time from return trip

### DIFF
--- a/app/GameMissions/Abstracts/GameMission.php
+++ b/app/GameMissions/Abstracts/GameMission.php
@@ -134,6 +134,13 @@ abstract class GameMission
         // This arrival time is used by the return mission to calculate the return time.
         $mission->time_arrival = (int)Carbon::now()->timestamp;
 
+        // Clear the holding time for recalled missions (expeditions, etc.)
+        // The fleet should return immediately without waiting at the destination.
+        // Only set to 0 if there was a holding time, to avoid changing null to 0 for missions that don't use holding time.
+        if ($mission->time_holding !== null) {
+            $mission->time_holding = 0;
+        }
+
         // Mark parent mission as canceled.
         $mission->canceled = 1;
         $mission->processed = 1;


### PR DESCRIPTION
## Description 
This PR fixes a bug in which the hold time of an expedition was always added to the time already travelled when recalling the fleet during approach. Solution:

- Clear `time_holding` when mission is canceled to prevent it from being added to return trip calculation
- Add test to verify recalled expeditions return in correct time


### Type of Change:
- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #920 

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [X] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [X] **Static Analysis:** Code passes PHPStan static code analysis.
- [X] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [ ] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [ ] **Documentation:** Documentation has been updated to reflect any changes made.
