### PR TITLE
Skip PHP checks when only frontend files are changed

### DIFF
--- a/.github/workflows/run-laravel-pint-code-style-checker.yml
+++ b/.github/workflows/run-laravel-pint-code-style-checker.yml
@@ -3,8 +3,28 @@ name: Laravel Pint PSR-12 Code Style Checker
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - 'resources/css/**'
+      - 'resources/js/**'
+      - 'public/css/**'
+      - 'public/js/**'
+      - 'public/mix-manifest.json'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'yarn.lock'
+      - 'webpack.mix.js'
   pull_request:
     branches: [ "main" ]
+    paths-ignore:
+      - 'resources/css/**'
+      - 'resources/js/**'
+      - 'public/css/**'
+      - 'public/js/**'
+      - 'public/mix-manifest.json'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'yarn.lock'
+      - 'webpack.mix.js'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/run-phpstan-code-analysis.yml
+++ b/.github/workflows/run-phpstan-code-analysis.yml
@@ -3,8 +3,28 @@ name: PHPStan Code Analysis
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - 'resources/css/**'
+      - 'resources/js/**'
+      - 'public/css/**'
+      - 'public/js/**'
+      - 'public/mix-manifest.json'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'yarn.lock'
+      - 'webpack.mix.js'
   pull_request:
     branches: [ "main" ]
+    paths-ignore:
+      - 'resources/css/**'
+      - 'resources/js/**'
+      - 'public/css/**'
+      - 'public/js/**'
+      - 'public/mix-manifest.json'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'yarn.lock'
+      - 'webpack.mix.js'
 
 
 concurrency:

--- a/.github/workflows/run-tests-docker-compose.yml
+++ b/.github/workflows/run-tests-docker-compose.yml
@@ -3,8 +3,28 @@ name: Docker Compose Unit Tests
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - 'resources/css/**'
+      - 'resources/js/**'
+      - 'public/css/**'
+      - 'public/js/**'
+      - 'public/mix-manifest.json'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'yarn.lock'
+      - 'webpack.mix.js'
   pull_request:
     branches: [ "main" ]
+    paths-ignore:
+      - 'resources/css/**'
+      - 'resources/js/**'
+      - 'public/css/**'
+      - 'public/js/**'
+      - 'public/mix-manifest.json'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'yarn.lock'
+      - 'webpack.mix.js'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- Add `paths-ignore` to PHP-related GitHub Actions workflows (unit tests, PHPStan, Laravel Pint)
- Tests/checks are skipped when only frontend files are modified (CSS/JS)
- Production build workflow still runs to verify assets compile correctly

## Ignored paths
- `resources/css/**`, `resources/js/**`
- `public/css/**`, `public/js/**`
- `public/mix-manifest.json`
- `package.json`, `package-lock.json`, `yarn.lock`
- `webpack.mix.js`

## Test plan
- [ ] Create a PR with only CSS/JS changes and verify PHP workflows are skipped
- [ ] Create a PR with PHP changes and verify workflows still run

Closes #1032