### PR TITLE
fix: integer overflow in score calculations on PHP 8.5+ #1047

### DIFF
--- a/app/Services/HighscoreService.php
+++ b/app/Services/HighscoreService.php
@@ -182,6 +182,11 @@ class HighscoreService
         // Get score for fleets that are on missions (in transit)
         $score += $this->getPlayerFleetMissionScore($player);
 
+        // Cap at PHP_INT_MAX to prevent overflow on PHP 8.5+
+        if ($score > PHP_INT_MAX) {
+            return PHP_INT_MAX;
+        }
+
         return $score;
     }
 

--- a/app/Services/PlayerService.php
+++ b/app/Services/PlayerService.php
@@ -748,7 +748,14 @@ class PlayerService
 
         // Divide the score by 1000 to get the amount of points. Floor the result.
         $resources_sum = $resources_spent->metal->get() + $resources_spent->crystal->get() + $resources_spent->deuterium->get();
-        return (int)floor($resources_sum / 1000);
+        $score = floor($resources_sum / 1000);
+        
+        // Cap at PHP_INT_MAX to prevent overflow on PHP 8.5+
+        if ($score > PHP_INT_MAX) {
+            return PHP_INT_MAX;
+        }
+        
+        return (int)$score;
     }
 
     /**

--- a/tests/Unit/HighscoreCalculationTest.php
+++ b/tests/Unit/HighscoreCalculationTest.php
@@ -326,4 +326,46 @@ class HighscoreCalculationTest extends UnitTestCase
         $score_diff = abs(floor($optimized->sum() / 1000) - floor($iterative->sum() / 1000));
         $this->assertLessThanOrEqual(1, $score_diff);
     }
+
+    /**
+     * Unit Test: Integer overflow protection for research score
+     */
+    public function testResearchScoreOverflowProtection(): void
+    {
+        // Set extremely high research levels that would cause overflow
+        $this->createAndSetUserTechModel([
+            'laser_technology' => 200,  // Very high level
+            'astrophysics' => 200,       // Very high level
+            'shielding_technology' => 200, // Very high level
+        ]);
+
+        $score = $this->playerService->getResearchScore();
+
+        // Should not throw an error and should return PHP_INT_MAX
+        $this->assertEquals(PHP_INT_MAX, $score);
+    }
+
+    /**
+     * Unit Test: Integer overflow protection for player total score
+     */
+    public function testPlayerScoreOverflowProtection(): void
+    {
+        // Create a planet with very high buildings
+        $this->createAndSetPlanetModel([
+            'metal_mine' => 200,  // Very high level
+            'crystal_mine' => 200, // Very high level
+        ]);
+
+        // Set very high research levels
+        $this->createAndSetUserTechModel([
+            'laser_technology' => 200,
+            'astrophysics' => 200,
+        ]);
+
+        $highscoreService = app(\OGame\Services\HighscoreService::class);
+        $score = $highscoreService->getPlayerScore($this->playerService);
+
+        // Should not throw an error and should return PHP_INT_MAX
+        $this->assertEquals(PHP_INT_MAX, $score);
+    }
 }


### PR DESCRIPTION
## Description

This PR fixes integer overflow errors that occur in PHP 8.5+ when calculating player scores with extremely high research levels. PHP 8.5 introduced stricter type casting that throws an error when attempting to cast a float exceeding PHP_INT_MAX to an integer.

The fix adds overflow protection to cap scores at PHP_INT_MAX before casting to int, preventing crashes while maintaining the original calculation logic for normal cases.

### Type of Change:

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues

Fixes #1047

## Checklist

Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [x] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [x] **Static Analysis:** Code passes PHPStan static code analysis.
- [x] **Testing:**
  - [x] Relevant unit and feature tests are included or updated.
  - [x] Tests successfully run locally.
- [x] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files. (No CSS/JS changes)
- [x] **Documentation:** Documentation has been updated to reflect any changes made. (No documentation changes needed)

## Additional Information
