### PR TITLE
fix: Bomber speed upgrade with Hyperspace Drive 8 #1036

### DIFF
--- a/app/GameObjects/MilitaryShipObjects.php
+++ b/app/GameObjects/MilitaryShipObjects.php
@@ -183,7 +183,7 @@ class MilitaryShipObjects
         ];
         $bomber->properties = new GameObjectProperties($bomber, 75000, 500, 1000, 4000, 500, 700);
         $bomber->properties->speed_upgrade = [
-            new GameObjectSpeedUpgrade('hyperspace_drive', 8),
+            new GameObjectSpeedUpgrade('hyperspace_drive', 8, 5000),
         ];
         $bomber->assets = new GameObjectAssets();
         $bomber->assets->imgSmall = 'bomber_small.jpg';

--- a/tests/Unit/ObjectPropertiesTest.php
+++ b/tests/Unit/ObjectPropertiesTest.php
@@ -131,9 +131,49 @@ class ObjectPropertiesTest extends UnitTestCase
         $this->assertEquals(11000, $recycler->properties->speed->calculate($this->playerService)->totalValue);
 
         // Bomber with hyperspace drive level 15
-        // Base 4.000 + 15*30% = 22.000
-        $recycler = ObjectService::getShipObjectByMachineName('bomber');
-        $this->assertEquals(22000, $recycler->properties->speed->calculate($this->playerService)->totalValue);
+        // Base 5.000 (upgraded at level 8) + 15*30% = 27.500
+        $bomber = ObjectService::getShipObjectByMachineName('bomber');
+        $this->assertEquals(27500, $bomber->properties->speed->calculate($this->playerService)->totalValue);
+    }
+
+    /**
+     * Test that Bomber speed upgrade works correctly at hyperspace drive level 8.
+     * @throws Exception
+     */
+    public function testBomberSpeedUpgradeAtHyperspaceDrive8(): void
+    {
+        $this->createAndSetPlanetModel([]);
+        $this->createAndSetUserTechModel([
+            'hyperspace_drive' => 8,
+        ]);
+
+        // Bomber with hyperspace drive level 8 (exact upgrade threshold)
+        // Base should be upgraded from 4.000 to 5.000 at level 8
+        // Speed: 5.000 + 8*30% = 17.000 (actual calculation)
+        $bomber = ObjectService::getShipObjectByMachineName('bomber');
+        $speed = $bomber->properties->speed->calculate($this->playerService);
+        $this->assertEquals(5000, $speed->rawValue); // Base speed should be upgraded
+        $this->assertEquals(17000, $speed->totalValue); // Total speed with bonus
+    }
+
+    /**
+     * Test that Bomber speed does NOT upgrade before hyperspace drive level 8.
+     * @throws Exception
+     */
+    public function testBomberSpeedBeforeHyperspaceDrive8(): void
+    {
+        $this->createAndSetPlanetModel([]);
+        $this->createAndSetUserTechModel([
+            'hyperspace_drive' => 7,
+        ]);
+
+        // Bomber with hyperspace drive level 7 (before upgrade threshold)
+        // Base should remain 4.000, uses impulse drive bonus: 20% per level
+        // Speed: 4.000 + 7*20% = 4.000 (actual calculation - no bonus applied)
+        $bomber = ObjectService::getShipObjectByMachineName('bomber');
+        $speed = $bomber->properties->speed->calculate($this->playerService);
+        $this->assertEquals(4000, $speed->rawValue); // Base speed should NOT be upgraded
+        $this->assertEquals(4000, $speed->totalValue); // Total speed with impulse drive bonus
     }
 
     /**


### PR DESCRIPTION
## Description

This PR fixes a bug where the Bomber ship was not receiving its base speed upgrade when Hyperspace Drive reached level 8. According to the game mechanics, the Bomber should be retrofitted with a hyperspace engine at level 8, increasing its base speed from 4000 to 5000.

The issue was in the Bomber's speed upgrade configuration in `MilitaryShipObjects.php`, where the `GameObjectSpeedUpgrade` constructor was missing the `base_speed` parameter.

### Type of Change:

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues

Fixes #1036

## Checklist

Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [x] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [x] **Static Analysis:** Code passes PHPStan static code analysis.
- [x] **Testing:**
  - [x] Relevant unit and feature tests are included or updated.
  - [x] Tests successfully run locally.
- [ ] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [ ] **Documentation:** Documentation has been updated to reflect any changes made.

## Additional Information
