### PR TITLE
fix: allow General class to use 5% fleet speed #1013

### DIFF
--- a/app/Http/Controllers/FleetController.php
+++ b/app/Http/Controllers/FleetController.php
@@ -384,10 +384,11 @@ class FleetController extends OGameController
      * @param PlayerService $player
      * @param FleetMissionService $fleetMissionService
      * @param SettingsService $settingsService
+     * @param CharacterClassService $characterClassService
      * @return JsonResponse
      * @throws Exception
      */
-    public function dispatchSendFleet(PlayerService $player, FleetMissionService $fleetMissionService, SettingsService $settingsService): JsonResponse
+    public function dispatchSendFleet(PlayerService $player, FleetMissionService $fleetMissionService, SettingsService $settingsService, CharacterClassService $characterClassService): JsonResponse
     {
         $galaxy = (int)request()->input('galaxy');
         $system = (int)request()->input('system');
@@ -441,6 +442,12 @@ class FleetController extends OGameController
         // Input validation
         // Speed is sent as 1-10 range (where 1 = 10%, 10 = 100%), in 0.5 increments (representing 5% steps).
         $validSpeeds = [1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0, 5.5, 6.0, 6.5, 7.0, 7.5, 8.0, 8.5, 9.0, 9.5, 10.0];
+
+        // Add 5% speed (0.5) for General class
+        if ($characterClassService->hasDetailedFleetSpeedSettings($player->getUser())) {
+            $validSpeeds[] = 0.5;
+        }
+
         if (!\in_array($speed_percent, $validSpeeds, true)) {
             return $this->validationErrorResponse(__('Fleet speed must be between 10% and 100% in 5% increments.'));
         }

--- a/tests/Feature/FleetSpeedGeneralClassTest.php
+++ b/tests/Feature/FleetSpeedGeneralClassTest.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\AccountTestCase;
+
+class FleetSpeedGeneralClassTest extends AccountTestCase
+{
+    /**
+     * Test that General class can use 5% fleet speed.
+     */
+    public function testGeneralClassCanUse5PercentFleetSpeed(): void
+    {
+        // Set user character class to General
+        $user = $this->planetService->getPlayer()->getUser();
+        $user->character_class = \OGame\Enums\CharacterClass::GENERAL->value;
+        $user->save();
+
+        // Add a ship to the planet
+        $this->planetAddUnit('light_fighter', 1);
+
+        // Test data for fleet dispatch with 5% speed
+        $fleetData = [
+            'galaxy' => 1,
+            'system' => 2,
+            'position' => 1,
+            'type' => 1,
+            'metal' => 0,
+            'crystal' => 0,
+            'deuterium' => 0,
+            'mission' => 3, // Transport mission
+            'speed' => 0.5, // 5% speed
+            'holdingtime' => 0,
+            'token' => csrf_token(),
+            'am202' => ['light_fighter' => 1],
+        ];
+
+        // This should not throw a validation error for General class
+        $response = $this->postJson('/ajax/fleet/dispatch/send-fleet', $fleetData);
+
+        // Should not return validation error for speed
+        $response->assertStatus(200);
+        $response->assertJsonMissing(['errors' => ['Fleet speed must be between 10% and 100% in 5% increments.']]);
+    }
+
+    /**
+     * Test that non-General class cannot use 5% fleet speed.
+     */
+    public function testNonGeneralClassCannotUse5PercentFleetSpeed(): void
+    {
+        // Ensure user is not General class (default is no class)
+        $user = $this->planetService->getPlayer()->getUser();
+        $user->character_class = null;
+        $user->save();
+
+        // Add a ship to the planet
+        $this->planetAddUnit('light_fighter', 1);
+
+        // Test data for fleet dispatch with 5% speed
+        $fleetData = [
+            'galaxy' => 1,
+            'system' => 2,
+            'position' => 1,
+            'type' => 1,
+            'metal' => 0,
+            'crystal' => 0,
+            'deuterium' => 0,
+            'mission' => 3, // Transport mission
+            'speed' => 0.5, // 5% speed
+            'holdingtime' => 0,
+            'token' => csrf_token(),
+            'am202' => ['light_fighter' => 1],
+        ];
+
+        // This should throw a validation error for non-General class
+        $response = $this->postJson('/ajax/fleet/dispatch/send-fleet', $fleetData);
+
+        // Should return validation error for speed
+        $response->assertStatus(200);
+        $response->assertJsonFragment(['errors' => [['message' => 'Fleet speed must be between 10% and 100% in 5% increments.', 'error' => 140020]]]);
+    }
+
+    /**
+     * Test that Collector class cannot use 5% fleet speed.
+     */
+    public function testCollectorClassCannotUse5PercentFleetSpeed(): void
+    {
+        // Set user character class to Collector
+        $user = $this->planetService->getPlayer()->getUser();
+        $user->character_class = \OGame\Enums\CharacterClass::COLLECTOR->value;
+        $user->save();
+
+        // Add a ship to the planet
+        $this->planetAddUnit('light_fighter', 1);
+
+        // Test data for fleet dispatch with 5% speed
+        $fleetData = [
+            'galaxy' => 1,
+            'system' => 2,
+            'position' => 1,
+            'type' => 1,
+            'metal' => 0,
+            'crystal' => 0,
+            'deuterium' => 0,
+            'mission' => 3, // Transport mission
+            'speed' => 0.5, // 5% speed
+            'holdingtime' => 0,
+            'token' => csrf_token(),
+            'am202' => ['light_fighter' => 1],
+        ];
+
+        // This should throw a validation error for Collector class
+        $response = $this->postJson('/ajax/fleet/dispatch/send-fleet', $fleetData);
+
+        // Should return validation error for speed
+        $response->assertStatus(200);
+        $response->assertJsonFragment(['errors' => [['message' => 'Fleet speed must be between 10% and 100% in 5% increments.', 'error' => 140020]]]);
+    }
+
+    /**
+     * Test that Discoverer class cannot use 5% fleet speed.
+     */
+    public function testDiscovererClassCannotUse5PercentFleetSpeed(): void
+    {
+        // Set user character class to Discoverer
+        $user = $this->planetService->getPlayer()->getUser();
+        $user->character_class = \OGame\Enums\CharacterClass::DISCOVERER->value;
+        $user->save();
+
+        // Add a ship to the planet
+        $this->planetAddUnit('light_fighter', 1);
+
+        // Test data for fleet dispatch with 5% speed
+        $fleetData = [
+            'galaxy' => 1,
+            'system' => 2,
+            'position' => 1,
+            'type' => 1,
+            'metal' => 0,
+            'crystal' => 0,
+            'deuterium' => 0,
+            'mission' => 3, // Transport mission
+            'speed' => 0.5, // 5% speed
+            'holdingtime' => 0,
+            'token' => csrf_token(),
+            'am202' => ['light_fighter' => 1],
+        ];
+
+        // This should throw a validation error for Discoverer class
+        $response = $this->postJson('/ajax/fleet/dispatch/send-fleet', $fleetData);
+
+        // Should return validation error for speed
+        $response->assertStatus(200);
+        $response->assertJsonFragment(['errors' => [['message' => 'Fleet speed must be between 10% and 100% in 5% increments.', 'error' => 140020]]]);
+    }
+
+    /**
+     * Test that General class can still use normal speed ranges.
+     */
+    public function testGeneralClassCanUseNormalSpeedRanges(): void
+    {
+        // Set user character class to General
+        $user = $this->planetService->getPlayer()->getUser();
+        $user->character_class = \OGame\Enums\CharacterClass::GENERAL->value;
+        $user->save();
+
+        // Add a ship to the planet
+        $this->planetAddUnit('light_fighter', 1);
+
+        // Test data for fleet dispatch with 10% speed (minimum normal speed)
+        $fleetData = [
+            'galaxy' => 1,
+            'system' => 2,
+            'position' => 1,
+            'type' => 1,
+            'metal' => 0,
+            'crystal' => 0,
+            'deuterium' => 0,
+            'mission' => 3, // Transport mission
+            'speed' => 1.0, // 10% speed
+            'holdingtime' => 0,
+            'token' => csrf_token(),
+            'am202' => ['light_fighter' => 1],
+        ];
+
+        // This should work fine for General class
+        $response = $this->postJson('/ajax/fleet/dispatch/send-fleet', $fleetData);
+
+        // Should not return validation error for speed
+        $response->assertStatus(200);
+        $response->assertJsonMissing(['errors' => ['Fleet speed must be between 10% and 100% in 5% increments.']]);
+    }
+}


### PR DESCRIPTION
## Description

This PR fixes a bug where players with the "General" character class could not select a fleet speed of 5%, despite it being an advertised feature. The General class has "Detailed fleet speed settings" as one of their bonuses, which should include access to 5% fleet speed.

The issue was in the fleet speed validation logic in `FleetController.php`, which only allowed speeds from 10% to 100% in 5% increments. This fix adds conditional logic to include 5% speed (0.5 in the application's scale) specifically for General class players.

### Type of Change:

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues

Fixes #1013

## Checklist

Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [x] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [x] **Static Analysis:** Code passes PHPStan static code analysis.
- [x] **Testing:**
  - [x] Relevant unit and feature tests are included or updated.
  - [x] Tests successfully run locally.
- [ ] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [ ] **Documentation:** Documentation has been updated to reflect any changes made.

## Additional Information
