### PR TITLE
Fix: Exclude Missiles from Combat

### DIFF
--- a/app/GameMissions/BattleEngine/Models/DefenderFleet.php
+++ b/app/GameMissions/BattleEngine/Models/DefenderFleet.php
@@ -2,6 +2,7 @@
 
 namespace OGame\GameMissions\BattleEngine\Models;
 
+use OGame\Services\ObjectService;
 use OGame\Factories\PlayerServiceFactory;
 use OGame\GameObjects\Models\Units\UnitCollection;
 use OGame\Models\FleetMission;
@@ -81,7 +82,7 @@ class DefenderFleet
     private static function getDefenseUnitsForCombat(PlanetService $planet): UnitCollection
     {
         $units = new UnitCollection();
-        $objects = \OGame\Services\ObjectService::getDefenseObjects();
+        $objects = ObjectService::getDefenseObjects();
         foreach ($objects as $object) {
             // Skip missiles - they should not participate in combat
             if (in_array($object->machine_name, [


### PR DESCRIPTION
## Description
This PR introduces a fix to ensure Interplanetary Missiles and Anti-Ballistic Missiles do not take part in combat. It also introduces two feature tests to prevent regression in the future.

### Type of Change:
- [X] Bug fix


## Related Issues
Fixes #1022 

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [X] **Automated Refactoring:** Rector has been run and no outstanding issues remain.
- [X] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [X] **Static Analysis:** Code passes PHPStan static code analysis.
- [X] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [X] **CSS & JS Build:** No changes.
- [X] **Documentation:** Documentation has been updated to reflect any changes made.

