### PR TITLE
Fix: Large Amounts of Resources cannot be sent

### DIFF
--- a/app/GameObjects/Services/Properties/Abstracts/ObjectPropertyService.php
+++ b/app/GameObjects/Services/Properties/Abstracts/ObjectPropertyService.php
@@ -41,7 +41,8 @@ abstract class ObjectPropertyService
     public function calculateProperty(PlayerService $player): GameObjectPropertyDetails
     {
         $bonusPercentage = $this->getBonusPercentage($player);
-        $bonusValue = (($this->base_value / 100) * $bonusPercentage);
+        // Use integer arithmetic to avoid floating point precision issues
+        $bonusValue = intdiv($this->base_value * $bonusPercentage, 100);
 
         $totalValue = $this->base_value + $bonusValue;
 

--- a/app/GameObjects/Services/Properties/CapacityPropertyService.php
+++ b/app/GameObjects/Services/Properties/CapacityPropertyService.php
@@ -25,7 +25,8 @@ class CapacityPropertyService extends ObjectPropertyService
     public function calculateProperty(PlayerService $player): GameObjectPropertyDetails
     {
         $bonusPercentage = $this->getBonusPercentage($player);
-        $bonusValue = (($this->base_value / 100) * $bonusPercentage);
+        // Use integer arithmetic to avoid floating point precision issues
+        $bonusValue = intdiv($this->base_value * $bonusPercentage, 100);
 
         $totalValue = $this->base_value + $bonusValue;
 
@@ -44,7 +45,8 @@ class CapacityPropertyService extends ObjectPropertyService
         // Apply character class cargo bonuses (based on base value only, not including research bonuses)
         $classBonus = $this->getCharacterClassCargoBonus($player);
         if ($classBonus > 0) {
-            $classBonusValue = (($this->base_value / 100) * $classBonus);
+            // Use integer arithmetic to avoid floating point precision issues
+            $classBonusValue = intdiv($this->base_value * $classBonus, 100);
             $totalValue += $classBonusValue;
 
             $breakdown['bonuses'][] = [


### PR DESCRIPTION
## Description
This PR fixes the "not enough resources" bug when sending large amount of resources. Bonus calculations (hyperspace tech, character class) used floating-point division `($value / 100) * $percent `which loses precision when cast to int.

Change:
Use integer `arithmetic intdiv($value * $percent, 100)` to maintain precision throughout the calculation.

### Type of Change:
- [X]  Bug fix


## Related Issues
Fixes #1014 

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [X] **Automated Refactoring:** Rector has been run and no outstanding issues remain.
- [X] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [X] **Static Analysis:** Code passes PHPStan static code analysis.
- [X] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [X] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [X] **Documentation:** Documentation has been updated to reflect any changes made.
