### PR TITLE
Fix flaky test caused by counter-espionage in FleetDispatchEspionageTest.php

### DIFF
--- a/tests/Feature/FleetDispatch/FleetDispatchEspionageTest.php
+++ b/tests/Feature/FleetDispatch/FleetDispatchEspionageTest.php
@@ -199,24 +199,12 @@ class FleetDispatchEspionageTest extends FleetDispatchTestCase
     {
         $this->basicSetup();
 
-        // Send fleet to a nearby foreign planet.
+        // Send fleet to a clean foreign planet.
         $unitCollection = new UnitCollection();
         $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('espionage_probe'), 1);
-        $foreignPlanet = $this->sendMissionToOtherPlayerPlanet($unitCollection, new Resources(0, 0, 0, 0));
+        $foreignPlanet = $this->sendMissionToOtherPlayerCleanPlanet($unitCollection, new Resources(0, 0, 0, 0));
 
-        // Clean up all debris fields except Legor's at 1:1:2 to prevent state leakage from previous tests
-        DB::table('debris_fields')
-            ->whereNot(function ($query) {
-                $query->where('galaxy', 1)
-                    ->where('system', 1)
-                    ->where('planet', 2);
-            })
-            ->delete();
-
-        // Create a new debris field service instance to ensure we start fresh
-        $debrisField = resolve(DebrisFieldService::class);
-        // Create a new debris field for the foreign planet with an exact amount of resources
-        // that we later test for.
+        // Create a debris field for the foreign planet with an exact amount of resources that we later test for.
         $debrisField = resolve(DebrisFieldService::class);
         $debrisField->loadOrCreateForCoordinates($foreignPlanet->getPlanetCoordinates());
         $debrisField->appendResources(new Resources(1337, 443, 259, 0));


### PR DESCRIPTION
## Description
Fix flaky test. It was caused by possible counter-espionage affecting the asserted outcome of resources in the debris field. By using a clean planet, we ensure no counter-espionage can happen as the defending planet has no defending units.

### Type of Change:
- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #1091 