### PR TITLE
Fix: Expand $header_filename_objects to include 15 and 33

### DIFF
--- a/app/Http/Controllers/FacilitiesController.php
+++ b/app/Http/Controllers/FacilitiesController.php
@@ -42,7 +42,7 @@ class FacilitiesController extends AbstractBuildingsController
         // Header filename objects are the building IDs that make up the header filename
         // to be used in the background image of the page header.
         if ($this->planet->isPlanet()) {
-            $this->header_filename_objects = [14, 21, 31, 34];
+            $this->header_filename_objects = [14, 15, 21, 31, 33, 34];
             $this->objects = [
                 ['robot_factory', 'shipyard', 'research_lab', 'alliance_depot', 'missile_silo', 'nano_factory', 'terraformer', 'space_dock'],
             ];


### PR DESCRIPTION
## Description
This PR expands the `$header_filename_objects` array to include the recently added /facilities header images.

### Type of Change:
- [X] Bug fix


## Related Issues
Fixes #1093 

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [X] **Automated Refactoring:** Rector has been run and no outstanding issues remain.
- [X] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [X] **Static Analysis:** Code passes PHPStan static code analysis.
- [X] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [X] **CSS & JS Build:** No changes.
- [X] **Documentation:** No changes.

## Additional Information
Add any additional context, screenshots, or explanations to help reviewers understand your PR. If this change introduces any breaking changes or significant impacts, please detail them here.
