### PR TITLE
fix: cross out ships and defensive buildings when nanite factory is b…

### DIFF
--- a/app/Http/Controllers/DefenseController.php
+++ b/app/Http/Controllers/DefenseController.php
@@ -51,7 +51,10 @@ class DefenseController extends AbstractUnitsController
 
         return view(view: 'ingame.defense.index')->with(
             array_merge(
-                ['shipyard_upgrading' => $player->planets->current()->isBuildingObject('shipyard')],
+                [
+                    'shipyard_upgrading' => $player->planets->current()->isBuildingObject('shipyard'),
+                    'nanite_upgrading' => $player->planets->current()->isBuildingObject('nano_factory')
+                ],
                 parent::indexPage($request, $player)
             )
         );

--- a/app/Http/Controllers/ShipyardController.php
+++ b/app/Http/Controllers/ShipyardController.php
@@ -44,7 +44,10 @@ class ShipyardController extends AbstractUnitsController
 
         return view(view: 'ingame.shipyard.index')->with(
             array_merge(
-                ['shipyard_upgrading' => $player->planets->current()->isBuildingObject('shipyard')],
+                [
+                    'shipyard_upgrading' => $player->planets->current()->isBuildingObject('shipyard'),
+                    'nanite_upgrading' => $player->planets->current()->isBuildingObject('nano_factory')
+                ],
                 parent::indexPage($request, $player)
             )
         );

--- a/app/Http/Traits/ObjectAjaxTrait.php
+++ b/app/Http/Traits/ObjectAjaxTrait.php
@@ -77,12 +77,14 @@ trait ObjectAjaxTrait
                 $production_datetime = AppUtil::formatDateTimeDuration($planet->getUnitConstructionTime($object->machine_name));
 
                 $shipyard_upgrading = $player->planets->current()->isBuildingObject('shipyard');
+                $nanite_upgrading = $player->planets->current()->isBuildingObject('nano_factory');
                 break;
             case GameObjectType::Defense:
                 $production_time = AppUtil::formatTimeDuration($planet->getUnitConstructionTime($object->machine_name));
                 $production_datetime = AppUtil::formatDateTimeDuration($planet->getUnitConstructionTime($object->machine_name));
 
                 $shipyard_upgrading = $player->planets->current()->isBuildingObject('shipyard');
+                $nanite_upgrading = $player->planets->current()->isBuildingObject('nano_factory');
                 break;
             case GameObjectType::Research:
                 $production_time = AppUtil::formatTimeDuration($planet->getTechnologyResearchTime($object->machine_name));
@@ -254,6 +256,7 @@ trait ObjectAjaxTrait
             'research_lab_upgrading' => $research_lab_upgrading ?? false,
             'research_in_progress' => $research_in_progress ?? false,
             'shipyard_upgrading' => $shipyard_upgrading ?? false,
+            'nanite_upgrading' => $nanite_upgrading ?? false,
             'ship_or_defense_in_progress' => $ship_or_defense_in_progress ?? false,
             'downgrade_price' => $downgrade_price,
             'downgrade_duration' => $downgrade_duration,

--- a/resources/lang/en/t_messages.php
+++ b/resources/lang/en/t_messages.php
@@ -396,4 +396,8 @@ Defenses destroyed: :defenses_destroyed',
 Application message:
 :application_message',
     ],
+
+    // Building upgrade messages
+    'Shipyard is being upgraded.' => 'Shipyard is being upgraded.',
+    'Nanite Factory is being upgraded.' => 'Nanite Factory is being upgraded.',
 ];

--- a/resources/views/ingame/defense/index.blade.php
+++ b/resources/views/ingame/defense/index.blade.php
@@ -22,7 +22,7 @@
                 <ul class="icons">
                     @php /** @var OGame\ViewModels\BuildingViewModel $building */ @endphp
                     @foreach ($units[0] as $building)
-                        @include('ingame.shipyard.unit-item', ['building' => $building, 'is_in_vacation_mode' => $is_in_vacation_mode ?? false])
+                        @include('ingame.shipyard.unit-item', ['building' => $building, 'shipyard_upgrading' => $shipyard_upgrading, 'nanite_upgrading' => $nanite_upgrading, 'is_in_vacation_mode' => $is_in_vacation_mode ?? false])
                     @endforeach
                 </ul>
             </div>

--- a/resources/views/ingame/shipyard/index.blade.php
+++ b/resources/views/ingame/shipyard/index.blade.php
@@ -23,7 +23,7 @@
                     <ul class="icons">
                         @php /** @var OGame\ViewModels\BuildingViewModel $building */ @endphp
                         @foreach ($units[0] as $building)
-                            @include('ingame.shipyard.unit-item', ['building' => $building, 'shipyard_upgrading' => $shipyard_upgrading, 'is_in_vacation_mode' => $is_in_vacation_mode ?? false])
+                            @include('ingame.shipyard.unit-item', ['building' => $building, 'shipyard_upgrading' => $shipyard_upgrading, 'nanite_upgrading' => $nanite_upgrading, 'is_in_vacation_mode' => $is_in_vacation_mode ?? false])
                         @endforeach
                     </ul>
                 </div>
@@ -32,7 +32,7 @@
                     <ul class="icons">
                         @php /** @var OGame\ViewModels\BuildingViewModel $building */ @endphp
                         @foreach ($units[1] as $building)
-                            @include('ingame.shipyard.unit-item', ['building' => $building, 'shipyard_upgrading' => $shipyard_upgrading, 'is_in_vacation_mode' => $is_in_vacation_mode ?? false])
+                            @include('ingame.shipyard.unit-item', ['building' => $building, 'shipyard_upgrading' => $shipyard_upgrading, 'nanite_upgrading' => $nanite_upgrading, 'is_in_vacation_mode' => $is_in_vacation_mode ?? false])
                         @endforeach
                     </ul>
                 </div>

--- a/resources/views/ingame/shipyard/unit-item.blade.php
+++ b/resources/views/ingame/shipyard/unit-item.blade.php
@@ -32,6 +32,9 @@
     @elseif ($shipyard_upgrading ?? false)
         data-status="disabled"
     title="{{ $building->object->title }}<br/>@lang('Shipyard is being upgraded.')"
+    @elseif ($nanite_upgrading ?? false)
+        data-status="disabled"
+    title="{{ $building->object->title }}<br/>@lang('Nanite Factory is being upgraded.')"
     @else
         data-status="on"
     title="{{ $building->object->title }}"


### PR DESCRIPTION
## Description

This PR fixes the UI bug where ships and defensive buildings were not crossed out while the nanite factory was being built/upgraded. The backend logic correctly blocked requests, but the UI didn't reflect this by showing crossed-out items.

### Type of Change:

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues

Fixes #995

## Checklist

Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [x] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [x] **Static Analysis:** Code passes PHPStan static code analysis.
- [x] **Testing:**
  - Relevant unit and feature tests are included or updated.
  - Tests successfully run locally.
- [ ] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [ ] **Documentation:** Documentation has been updated to reflect any changes made.

## Additional Information
