### PR TITLE
Feat: Implement wreck field for General class

### DIFF
--- a/app/GameMissions/Abstracts/GameMission.php
+++ b/app/GameMissions/Abstracts/GameMission.php
@@ -398,7 +398,7 @@ abstract class GameMission
      * @param int $additionalReturnTripTime Time in seconds to add to the return trip duration (optional, used by expeditions). Can be positive or negative.
      * @return void
      */
-    protected function startReturn(FleetMission $parentMission, Resources $resources, UnitCollection $units, int $additionalReturnTripTime = 0): void
+    protected function startReturn(FleetMission $parentMission, Resources $resources, UnitCollection $units, int $additionalReturnTripTime = 0, array|null $wreckFieldData = null): void
     {
         if ($units->getAmount() === 0) {
             // No units to return, no need to create a return mission.
@@ -464,6 +464,11 @@ abstract class GameMission
         $mission->metal = (int)$resources->metal->get();
         $mission->crystal = (int)$resources->crystal->get();
         $mission->deuterium = (int)$resources->deuterium->get();
+
+        // Set wreck field data if provided (for General class attacks)
+        if ($wreckFieldData !== null) {
+            $mission->wreck_field_data = $wreckFieldData;
+        }
 
         // Save the new fleet return mission.
         $mission->save();

--- a/app/GameMissions/AttackMission.php
+++ b/app/GameMissions/AttackMission.php
@@ -12,6 +12,7 @@ use OGame\GameMissions\BattleEngine\PhpBattleEngine;
 use OGame\GameMissions\BattleEngine\RustBattleEngine;
 use OGame\GameMissions\BattleEngine\Services\LootService;
 use OGame\GameMissions\Models\MissionPossibleStatus;
+use OGame\GameObjects\Models\Enums\GameObjectType;
 use OGame\GameObjects\Models\Units\UnitCollection;
 use OGame\Models\BattleReport;
 use OGame\Models\Enums\PlanetType;
@@ -253,16 +254,9 @@ class AttackMission extends GameMission
         // Save the debris field
         $debrisFieldService->save();
 
-        // Create or extend wreck field if conditions are met
-        //
-        // TODO: When the General class is implemented, wreck fields generated during attacks with a General
-        // should behave differently: the wreck field should only be spawned at the General's origin planet
-        // once the attacking fleet has returned from the mission. This means the wreck field data needs to
-        // be stored with the fleet mission and created at the origin planet coordinates upon mission return.
-        //
-        // Current behavior: wreck field is created immediately at the battle location.
-        // General behavior (future): wreck field data stored with mission, created at origin planet on return.
-        //
+        // Create or extend wreck field at defender's location if conditions are met
+        // Note: If attacker is General class, a separate wreck field will be created at the attacker's
+        // origin planet when the return mission arrives (see processReturn method).
         // IMPORTANT: If the battle is on a moon, the wreck field is created at the planet's coordinates
         // (not the moon's), and can only be interacted with from the planet.
         if (!empty($battleResult->wreckField) && $battleResult->wreckField['formed']) {
@@ -404,7 +398,20 @@ class AttackMission extends GameMission
             $totalResources = LootService::distributeLoot($totalResources, $remainingCargoCapacity);
         }
 
-        $this->startReturn($mission, $totalResources, $battleResult->attackerUnitsResult);
+        // Calculate wreck field for General class attacker
+        // General perk: wreck field from attacker's lost ships is transported back with the return mission
+        $attackerWreckFieldData = null;
+        $characterClassService = resolve(CharacterClassService::class);
+        if ($characterClassService->isGeneral($attackerPlayer->getUser())) {
+            // Calculate attacker's lost units (start - result = lost)
+            $attackerUnitsLost = clone $battleResult->attackerUnitsStart;
+            $attackerUnitsLost->subtractCollection($battleResult->attackerUnitsResult);
+
+            // Calculate wreck field data if conditions are met
+            $attackerWreckFieldData = $this->calculateAttackerWreckField($attackerUnitsLost, $battleResult->attackerUnitsStart);
+        }
+
+        $this->startReturn($mission, $totalResources, $battleResult->attackerUnitsResult, 0, $attackerWreckFieldData);
     }
 
     /**
@@ -424,12 +431,82 @@ class AttackMission extends GameMission
             $target_planet->addResources($return_resources);
         }
 
+        // Create wreck field at origin planet if data exists (General class perk)
+        // The wreck field is created from the attacker's lost ships and appears at the origin planet
+        if (!empty($mission->wreck_field_data) && is_array($mission->wreck_field_data)) {
+            $wreckFieldService = new WreckFieldService($target_planet->getPlayer(), $this->settings);
+
+            // Determine coordinates for wreck field
+            // If returning to a moon, create wreck field at the planet's coordinates
+            $wreckFieldCoordinates = $target_planet->isMoon()
+                ? $target_planet->planet()->getPlanetCoordinates()
+                : $target_planet->getPlanetCoordinates();
+
+            // Create wreck field at origin planet
+            $wreckFieldService->createWreckField(
+                $wreckFieldCoordinates,
+                $mission->wreck_field_data,
+                $target_planet->getPlayer()->getId()
+            );
+        }
+
         // Send message to player that the return mission has arrived.
         $this->sendFleetReturnMessage($mission, $target_planet->getPlayer());
 
         // Mark the return mission as processed
         $mission->processed = 1;
         $mission->save();
+    }
+
+    /**
+     * Calculate the wreck field for attacker's lost ships (General class perk).
+     * Similar logic to defender wreck field but for attacker's ships.
+     *
+     * @param UnitCollection $attackerUnitsLost Units lost by the attacker.
+     * @param UnitCollection $attackerUnitsStart Starting units of the attacker.
+     * @return array<array{machine_name: string, quantity: int, repair_progress: int}>|null Wreck field data with ships array, or null if conditions not met.
+     */
+    private function calculateAttackerWreckField(UnitCollection $attackerUnitsLost, UnitCollection $attackerUnitsStart): array|null
+    {
+        $wreckFieldData = [];
+        $wreckFieldPercentage = (100.0 - $this->settings->debrisFieldFromShips()) / 100;
+
+        // Only ships (not defenses) can go into wreck fields
+        foreach ($attackerUnitsLost->units as $unit) {
+            if ($unit->amount > 0 && $unit->unitObject->type === GameObjectType::Ship) {
+                $wreckFieldCount = (int) floor($unit->amount * $wreckFieldPercentage);
+                if ($wreckFieldCount > 0) {
+                    $wreckFieldData[] = [
+                        'machine_name' => $unit->unitObject->machine_name,
+                        'quantity' => $wreckFieldCount,
+                        'repair_progress' => 0,
+                    ];
+                }
+            }
+        }
+
+        // Check if wreck field conditions are met
+        $totalLostValue = $attackerUnitsLost->toResources()->metal->get() +
+                         $attackerUnitsLost->toResources()->crystal->get() +
+                         $attackerUnitsLost->toResources()->deuterium->get();
+        $totalFleetValue = $attackerUnitsStart->toResources()->metal->get() +
+                          $attackerUnitsStart->toResources()->crystal->get() +
+                          $attackerUnitsStart->toResources()->deuterium->get();
+
+        if ($totalFleetValue > 0) {
+            $destroyedPercentage = ($totalLostValue / $totalFleetValue) * 100;
+            $minResourcesRequired = $this->settings->wreckFieldMinResourcesLoss();
+            $minFleetPercentageRequired = $this->settings->wreckFieldMinFleetPercentage();
+
+            // Only return wreck field data if conditions are met and there are ships
+            if ($totalLostValue >= $minResourcesRequired
+                && $destroyedPercentage >= $minFleetPercentageRequired
+                && !empty($wreckFieldData)) {
+                return $wreckFieldData;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/app/Models/FleetMission.php
+++ b/app/Models/FleetMission.php
@@ -40,6 +40,7 @@ use Illuminate\Support\Carbon;
  * @property int|null $target_priority
  * @property int $processed
  * @property int $canceled
+ * @property array|null $wreck_field_data
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  * @property-read Planet|null $planetFrom
@@ -99,6 +100,15 @@ use Illuminate\Support\Carbon;
  */
 class FleetMission extends Model
 {
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'wreck_field_data' => 'array',
+    ];
+
     /**
      * Get the planet that this fleet mission is going from.
      */

--- a/database/migrations/2026_01_16_000001_add_wreck_field_data_to_fleet_missions_table.php
+++ b/database/migrations/2026_01_16_000001_add_wreck_field_data_to_fleet_missions_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('fleet_missions', function (Blueprint $table) {
+            $table->json('wreck_field_data')->after('canceled')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('fleet_missions', function (Blueprint $table) {
+            $table->dropColumn('wreck_field_data');
+        });
+    }
+};

--- a/tests/Feature/FleetDispatch/GeneralWreckFieldTest.php
+++ b/tests/Feature/FleetDispatch/GeneralWreckFieldTest.php
@@ -1,0 +1,427 @@
+<?php
+
+namespace Tests\Feature\FleetDispatch;
+
+use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Support\Facades\DB;
+use OGame\Enums\CharacterClass;
+use OGame\GameObjects\Models\Units\UnitCollection;
+use OGame\Models\BattleReport;
+use OGame\Models\Message;
+use OGame\Models\Resources;
+use OGame\Models\WreckField;
+use OGame\Services\FleetMissionService;
+use OGame\Services\ObjectService;
+use OGame\Services\SettingsService;
+use Tests\FleetDispatchTestCase;
+
+/**
+ * Test that General class generates wreck fields at their origin planet from their lost ships.
+ */
+class GeneralWreckFieldTest extends FleetDispatchTestCase
+{
+    protected int $missionType = 1; // Attack mission
+    protected string $missionName = 'Attack';
+
+    /**
+     * Prepare the planet for the test, so it has the required buildings and research.
+     *
+     * @return void
+     */
+    protected function basicSetup(): void
+    {
+        // Clear any existing battle reports and wreck fields to ensure test isolation
+        Message::where('battle_report_id', '!=', null)->delete();
+        BattleReport::query()->delete();
+        WreckField::query()->delete();
+
+        // Configure wreck field settings
+        $settingsService = resolve(SettingsService::class);
+        $settingsService->set('debris_field_from_ships', 30); // 30% becomes debris, 70% becomes wreck field
+        $settingsService->set('wreck_field_min_resources_loss', 150000); // Minimum resource loss for wreck field
+        $settingsService->set('wreck_field_min_fleet_percentage', 5); // Minimum 5% fleet destroyed
+    }
+
+    /**
+     * Test that General class creates wreck field at origin planet from lost ships.
+     *
+     * @throws BindingResolutionException
+     */
+    public function testGeneralCreatesWreckFieldAtOriginPlanet(): void
+    {
+        // Clear all battle reports and wreck fields to ensure test isolation
+        Message::where('battle_report_id', '!=', null)->delete();
+        BattleReport::query()->delete();
+        WreckField::query()->delete();
+
+        // Configure wreck field settings
+        $settingsService = resolve(SettingsService::class);
+        $settingsService->set('debris_field_from_ships', 30); // 30% becomes debris, 70% becomes wreck field
+        $settingsService->set('wreck_field_min_resources_loss', 150000);
+        $settingsService->set('wreck_field_min_fleet_percentage', 5);
+
+        // Set up: attacker with General class
+        $attacker = $this->planetService;
+        $attackerPlayer = $attacker->getPlayer();
+
+        // Set character class to General (required for wreck field generation)
+        $attackerPlayer->getUser()->character_class = CharacterClass::GENERAL->value;
+        $attackerPlayer->getUser()->save();
+
+        // Clear any existing units from previous tests to ensure test isolation
+        $attacker->removeUnits($attacker->getShipUnits(), true);
+        $attacker->save(); // Save after removing units
+        $attacker->reloadPlanet(); // Reload to ensure clean state
+
+        // Set up: Attacker with 500 cruisers for balanced battle
+        $attacker->addUnit('cruiser', 500);
+        $attacker->save();
+
+        // Add deuterium for fleet travel
+        $this->planetAddResources(new Resources(0, 0, 200000, 0));
+
+        // Launch attack mission
+        $units = new UnitCollection();
+        $units->addUnit(ObjectService::getShipObjectByMachineName('cruiser'), 500);
+        $foreignPlanet = $this->sendMissionToOtherPlayerPlanet($units, new Resources(0, 0, 0, 0));
+
+        // Get the mission
+        $fleetMissionService = resolve(FleetMissionService::class, ['player' => $attacker->getPlayer()]);
+        $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        $fleetMissionDuration = $fleetMission->time_arrival - $fleetMission->time_departure;
+
+        // Set up: Defender with 500 cruisers for balanced draw
+        DB::table('planets')->where('id', $foreignPlanet->getPlanetId())->update([
+            'light_fighter' => 0, 'heavy_fighter' => 0, 'cruiser' => 500, 'battle_ship' => 0,
+            'battlecruiser' => 0, 'bomber' => 0, 'destroyer' => 0, 'deathstar' => 0,
+            'small_cargo' => 0, 'large_cargo' => 0, 'colony_ship' => 0, 'recycler' => 0, 'espionage_probe' => 0
+        ]);
+
+        // Process arrival (battle happens)
+        $this->travel($fleetMissionDuration + 1)->seconds();
+        $this->get('/overview');
+
+        // Process return mission
+        $this->travel($fleetMissionDuration + 5)->seconds();
+        $this->get('/overview');
+
+        // Check for attacker wreck field at attacker's planet
+        $attackerCoords = $attacker->getPlanetCoordinates();
+        $attackerWreckField = WreckField::where('galaxy', $attackerCoords->galaxy)
+            ->where('system', $attackerCoords->system)
+            ->where('planet', $attackerCoords->position)
+            ->where('owner_player_id', $attacker->getPlayer()->getId())
+            ->first();
+        $this->assertNotNull($attackerWreckField, 'Wreck field should be created at attacker origin planet for General');
+        $this->assertEquals('active', $attackerWreckField->status, 'Wreck field should be active');
+        $this->assertEquals($attacker->getPlayer()->getId(), $attackerWreckField->owner_player_id, 'Wreck field should belong to attacker');
+        $this->assertGreaterThan(0, $attackerWreckField->getTotalShips(), 'Wreck field should contain ships');
+    }
+
+    /**
+     * Test that wreck field is NOT created if all attacker ships are destroyed.
+     *
+     * @throws BindingResolutionException
+     */
+    public function testNoWreckFieldIfAllAttackerShipsDestroyed(): void
+    {
+        // Clear all battle reports and wreck fields to ensure test isolation
+        Message::where('battle_report_id', '!=', null)->delete();
+        BattleReport::query()->delete();
+        WreckField::query()->delete();
+
+        // Configure wreck field settings
+        $settingsService = resolve(SettingsService::class);
+        $settingsService->set('debris_field_from_ships', 30);
+        $settingsService->set('wreck_field_min_resources_loss', 150000);
+        $settingsService->set('wreck_field_min_fleet_percentage', 5);
+
+        // Set up: attacker with General class
+        $attacker = $this->planetService;
+        $attackerPlayer = $attacker->getPlayer();
+
+        // Set character class to General
+        $attackerPlayer->getUser()->character_class = CharacterClass::GENERAL->value;
+        $attackerPlayer->getUser()->save();
+
+        // Clear any existing units
+        $attacker->removeUnits($attacker->getShipUnits(), true);
+        $attacker->save();
+        $attacker->reloadPlanet();
+
+        // Set up: Attacker with few ships (will be destroyed)
+        $attacker->addUnit('light_fighter', 10);
+        $attacker->save();
+
+        // Add deuterium for fleet travel
+        $this->planetAddResources(new Resources(0, 0, 50000, 0));
+
+        // Launch attack mission
+        $units = new UnitCollection();
+        $units->addUnit(ObjectService::getShipObjectByMachineName('light_fighter'), 10);
+        $foreignPlanet = $this->sendMissionToOtherPlayerPlanet($units, new Resources(0, 0, 0, 0));
+
+        // Set up: Defender with overwhelming force to destroy all attackers
+        $foreignPlanet->addUnit('cruiser', 1000);
+        $foreignPlanet->save();
+
+        // Get the mission
+        $fleetMissionService = resolve(FleetMissionService::class, ['player' => $attacker->getPlayer()]);
+        $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        $fleetMissionDuration = $fleetMission->time_arrival - $fleetMission->time_departure;
+
+        // Process arrival (battle happens, all attackers destroyed)
+        $this->travel($fleetMissionDuration + 1)->seconds();
+        $this->get('/overview');
+
+        // Wait for return mission time (but it shouldn't exist since all ships destroyed)
+        $this->travel($fleetMissionDuration + 5)->seconds();
+        $this->get('/overview');
+
+        // Check that NO wreck field exists at attacker planet (no return mission = no wreck field)
+        $coords = $attacker->getPlanetCoordinates();
+        $wreckFieldAfterReturn = WreckField::where('galaxy', $coords->galaxy)
+            ->where('system', $coords->system)
+            ->where('planet', $coords->position)
+            ->where('owner_player_id', $attacker->getPlayer()->getId())
+            ->first();
+        $this->assertNull($wreckFieldAfterReturn, 'No wreck field should exist if all attacker ships were destroyed');
+    }
+
+    /**
+     * Test that both attacker (General) and defender wreck fields can exist simultaneously.
+     *
+     * @throws BindingResolutionException
+     */
+    public function testBothAttackerAndDefenderWreckFieldsExist(): void
+    {
+        // Clear all battle reports and wreck fields to ensure test isolation
+        Message::where('battle_report_id', '!=', null)->delete();
+        BattleReport::query()->delete();
+        WreckField::query()->delete();
+
+        // Configure wreck field settings
+        $settingsService = resolve(SettingsService::class);
+        $settingsService->set('debris_field_from_ships', 30);
+        $settingsService->set('wreck_field_min_resources_loss', 150000);
+        $settingsService->set('wreck_field_min_fleet_percentage', 5);
+
+        // Set up: attacker with General class
+        $attacker = $this->planetService;
+        $attackerPlayer = $attacker->getPlayer();
+
+        // Set character class to General
+        $attackerPlayer->getUser()->character_class = CharacterClass::GENERAL->value;
+        $attackerPlayer->getUser()->save();
+
+        // Clear any existing units
+        $attacker->removeUnits($attacker->getShipUnits(), true);
+        $attacker->save();
+        $attacker->reloadPlanet();
+
+        // Set up: Attacker with cruisers
+        $attacker->addUnit('cruiser', 100);
+        $attacker->save();
+
+        // Add deuterium for fleet travel
+        $this->planetAddResources(new Resources(0, 0, 50000, 0));
+
+        // Launch attack mission
+        $units = new UnitCollection();
+        $units->addUnit(ObjectService::getShipObjectByMachineName('cruiser'), 100);
+        $foreignPlanet = $this->sendMissionToOtherPlayerPlanet($units, new Resources(0, 0, 0, 0));
+
+        // Set up: Defender with ships and space dock (required for defender wreck field)
+        $foreignPlanet->addUnit('cruiser', 100);
+        $foreignPlanet->save();
+
+        // Add space dock and shipyard to defender planet
+        DB::table('planets')
+            ->where('id', $foreignPlanet->getPlanetId())
+            ->update(['space_dock' => 1, 'shipyard' => 1]);
+
+        // Get the mission
+        $fleetMissionService = resolve(FleetMissionService::class, ['player' => $attacker->getPlayer()]);
+        $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        $fleetMissionDuration = $fleetMission->time_arrival - $fleetMission->time_departure;
+
+        // Process arrival (battle happens)
+        $this->travel($fleetMissionDuration + 1)->seconds();
+        $this->get('/overview');
+
+        // Check for defender wreck field at defender's planet
+        $defenderCoords = $foreignPlanet->getPlanetCoordinates();
+        $defenderWreckField = WreckField::where('galaxy', $defenderCoords->galaxy)
+            ->where('system', $defenderCoords->system)
+            ->where('planet', $defenderCoords->position)
+            ->where('owner_player_id', $foreignPlanet->getPlayer()->getId())
+            ->first();
+
+        // Process return mission
+        $this->travel($fleetMissionDuration + 5)->seconds();
+        $this->get('/overview');
+
+        // Check for attacker wreck field at attacker's planet
+        $attackerCoords = $attacker->getPlanetCoordinates();
+        $attackerWreckField = WreckField::where('galaxy', $attackerCoords->galaxy)
+            ->where('system', $attackerCoords->system)
+            ->where('planet', $attackerCoords->position)
+            ->where('owner_player_id', $attacker->getPlayer()->getId())
+            ->first();
+
+        // Both wreck fields should potentially exist if conditions were met
+        // At minimum, they should be at different coordinates
+        if ($defenderWreckField !== null && $attackerWreckField !== null) {
+            $this->assertNotEquals(
+                $defenderWreckField->id,
+                $attackerWreckField->id,
+                'Attacker and defender wreck fields should be different'
+            );
+
+            $this->assertTrue(
+                $defenderWreckField->galaxy !== $attackerWreckField->galaxy
+                || $defenderWreckField->system !== $attackerWreckField->system
+                || $defenderWreckField->planet !== $attackerWreckField->planet,
+                'Wreck fields should be at different coordinates'
+            );
+        }
+    }
+
+    /**
+     * Test that non-General class does NOT create wreck field at origin planet.
+     *
+     * @throws BindingResolutionException
+     */
+    public function testNonGeneralDoesNotCreateWreckFieldAtOrigin(): void
+    {
+        // Clear all battle reports and wreck fields to ensure test isolation
+        Message::where('battle_report_id', '!=', null)->delete();
+        BattleReport::query()->delete();
+        WreckField::query()->delete();
+
+        // Configure wreck field settings
+        $settingsService = resolve(SettingsService::class);
+        $settingsService->set('debris_field_from_ships', 30);
+        $settingsService->set('wreck_field_min_resources_loss', 150000);
+        $settingsService->set('wreck_field_min_fleet_percentage', 5);
+
+        // Set up: attacker WITHOUT General class
+        $attacker = $this->planetService;
+        $attackerPlayer = $attacker->getPlayer();
+
+        // Set character class to Collector (NOT General)
+        $attackerPlayer->getUser()->character_class = CharacterClass::COLLECTOR->value;
+        $attackerPlayer->getUser()->save();
+
+        // Clear any existing units
+        $attacker->removeUnits($attacker->getShipUnits(), true);
+        $attacker->save();
+        $attacker->reloadPlanet();
+
+        // Set up: Attacker with cruisers
+        $attacker->addUnit('cruiser', 100);
+        $attacker->save();
+
+        // Add deuterium for fleet travel
+        $this->planetAddResources(new Resources(0, 0, 50000, 0));
+
+        // Launch attack mission
+        $units = new UnitCollection();
+        $units->addUnit(ObjectService::getShipObjectByMachineName('cruiser'), 100);
+        $foreignPlanet = $this->sendMissionToOtherPlayerPlanet($units, new Resources(0, 0, 0, 0));
+
+        // Set up: Defender with defenses to destroy some attackers
+        $foreignPlanet->addUnit('rocket_launcher', 500);
+        $foreignPlanet->save();
+
+        // Get the mission
+        $fleetMissionService = resolve(FleetMissionService::class, ['player' => $attacker->getPlayer()]);
+        $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        $fleetMissionDuration = $fleetMission->time_arrival - $fleetMission->time_departure;
+
+        // Process arrival (battle happens)
+        $this->travel($fleetMissionDuration + 1)->seconds();
+        $this->get('/overview');
+
+        // Process return mission
+        $this->travel($fleetMissionDuration + 5)->seconds();
+        $this->get('/overview');
+
+        // Check that NO wreck field exists at attacker planet (not General class)
+        $coords = $attacker->getPlanetCoordinates();
+        $wreckField = WreckField::where('galaxy', $coords->galaxy)
+            ->where('system', $coords->system)
+            ->where('planet', $coords->position)
+            ->where('owner_player_id', $attacker->getPlayer()->getId())
+            ->first();
+        $this->assertNull($wreckField, 'No wreck field should exist at origin planet for non-General class');
+    }
+
+    /**
+     * Test that wreck field respects minimum resource loss threshold.
+     *
+     * @throws BindingResolutionException
+     */
+    public function testWreckFieldRespectsMinimumResourceLoss(): void
+    {
+        // Clear all battle reports and wreck fields to ensure test isolation
+        Message::where('battle_report_id', '!=', null)->delete();
+        BattleReport::query()->delete();
+        WreckField::query()->delete();
+
+        // Configure wreck field settings with HIGH threshold
+        $settingsService = resolve(SettingsService::class);
+        $settingsService->set('debris_field_from_ships', 30);
+        $settingsService->set('wreck_field_min_resources_loss', 10000000); // 10 million - very high
+        $settingsService->set('wreck_field_min_fleet_percentage', 5);
+
+        // Set up: attacker with General class
+        $attacker = $this->planetService;
+        $attackerPlayer = $attacker->getPlayer();
+
+        // Set character class to General
+        $attackerPlayer->getUser()->character_class = CharacterClass::GENERAL->value;
+        $attackerPlayer->getUser()->save();
+
+        // Clear any existing units
+        $attacker->removeUnits($attacker->getShipUnits(), true);
+        $attacker->save();
+        $attacker->reloadPlanet();
+
+        // Set up: Attacker with few cruisers (not enough value for wreck field)
+        $attacker->addUnit('cruiser', 10);
+        $attacker->save();
+
+        // Add deuterium for fleet travel
+        $this->planetAddResources(new Resources(0, 0, 50000, 0));
+
+        // Launch attack mission
+        $units = new UnitCollection();
+        $units->addUnit(ObjectService::getShipObjectByMachineName('cruiser'), 10);
+        $foreignPlanet = $this->sendMissionToOtherPlayerPlanet($units, new Resources(0, 0, 0, 0));
+
+        // Set up: Defender with some defenses
+        $foreignPlanet->addUnit('rocket_launcher', 100);
+        $foreignPlanet->save();
+
+        // Get the mission
+        $fleetMissionService = resolve(FleetMissionService::class, ['player' => $attacker->getPlayer()]);
+        $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        $fleetMissionDuration = $fleetMission->time_arrival - $fleetMission->time_departure;
+
+        // Process arrival and return
+        $this->travel($fleetMissionDuration + 1)->seconds();
+        $this->get('/overview');
+        $this->travel($fleetMissionDuration + 5)->seconds();
+        $this->get('/overview');
+
+        // Check that NO wreck field exists (didn't meet minimum resource loss)
+        $coords = $attacker->getPlanetCoordinates();
+        $wreckField = WreckField::where('galaxy', $coords->galaxy)
+            ->where('system', $coords->system)
+            ->where('planet', $coords->position)
+            ->where('owner_player_id', $attacker->getPlayer()->getId())
+            ->first();
+        $this->assertNull($wreckField, 'No wreck field should exist if minimum resource loss not met');
+    }
+}

--- a/tests/Unit/CrawlerEnergyDisplayTest.php
+++ b/tests/Unit/CrawlerEnergyDisplayTest.php
@@ -25,14 +25,14 @@ class CrawlerEnergyDisplayTest extends UnitTestCase
 
         // Get crawler object
         $object = ObjectService::getObjectById(217); // Crawler ID
-        
+
         // Simulate the energy calculation from ObjectAjaxTrait for 100% production
         $crawlerPercentage = 10 / 10; // Convert to decimal (0-1.5)
         $baseEnergy = 50;
         $energyConsumption = $baseEnergy * $crawlerPercentage;
-        
+
         $energy_difference = floor($energyConsumption);
-        
+
         // Assert that energy consumption is calculated correctly
         $this->assertEquals(50, $energy_difference, 'Crawler should consume 50 energy at 100% production');
     }


### PR DESCRIPTION
## Description
This PR implements the wreck field generation for players with the General class. Wreck fields are created for attacking Generals and transported back with the return mission.

### Type of Change:
- [X] Feature enhancement


## Related Issues
Fixes #1006 

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [X] **Automated Refactoring:** Rector has been run and no outstanding issues remain.
- [X] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [X] **Static Analysis:** Code passes PHPStan static code analysis.
- [X] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [X] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [X] **Documentation:** Documentation has been updated to reflect any changes made.

