### PR TITLE
fix(expedition): Implement debris field creation for expedition battles

### DIFF
--- a/app/GameMissions/ExpeditionMission.php
+++ b/app/GameMissions/ExpeditionMission.php
@@ -708,7 +708,7 @@ class ExpeditionMission extends GameMission
 
         // Create debris field for expedition battles at position 16 (deep space)
         // Expedition battles create debris fields that can only be collected by Pathfinders (Discoverer class)
-        $expeditionCoords = new \OGame\Models\Planet\Coordinate($mission->galaxy_to, $mission->system_to, 16);
+        $expeditionCoords = new Coordinate($mission->galaxy_to, $mission->system_to, 16);
         $debrisFieldService = resolve(DebrisFieldService::class);
         $debrisFieldService->loadOrCreateForCoordinates($expeditionCoords);
 


### PR DESCRIPTION
## Description

This PR fixes a bug where expedition combat did not create debris fields. Now expedition battles properly generate debris fields at position 16 (deep space) that can be harvested according to character class restrictions.

**Key Changes:**

- Added debris field creation for expedition battles in `ExpeditionMission.php`
- Implemented 10% debris rate (instead of standard 30%) for expeditions
- Debris fields are created at position 16 (deep space coordinates)
- Only Discoverer class players can see expedition debris fields in galaxy view
- Only Pathfinder ships can harvest expedition debris (not Recyclers)
- Recyclers can still only harvest regular debris at positions 1-15

### Type of Change:

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues

Fixes #1115

## Checklist

Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [x] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [x] **Static Analysis:** Code passes PHPStan static code analysis.
- [x] **Testing:**
  - [x] Relevant unit and feature tests are included or updated.
  - [x] Tests successfully run locally.
- [x] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [x] **Documentation:** Documentation has been updated to reflect any changes made.

## Additional Information
