### PR TITLE
Fix facilities page header background-image not displaying

### DIFF
--- a/resources/views/ingame/facilities/index.blade.php
+++ b/resources/views/ingame/facilities/index.blade.php
@@ -12,7 +12,7 @@
         <div id="facilities">
             <div class="c-left"></div>
             <div class="c-right"></div>
-            <header data-anchor="technologyDetails" data-technologydetails-size="large" style="background-image:url({{ asset('img/headers/facilities/' . $header_filename) }}.jpg);">
+            <header data-anchor="technologyDetails" data-technologydetails-size="large" style="background-image:url('{{ asset('img/headers/facilities/' . $header_filename . '.jpg') }}');">
                 <h2>Facilities - {{ $planet_name }}</h2>
                 @if (isset($jump_gate_level) && $jump_gate_level > 0)
                     <div id="slot01" class="slot">

--- a/tests/Feature/FacilitiesHeaderTest.php
+++ b/tests/Feature/FacilitiesHeaderTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\AccountTestCase;
+
+/**
+ * Test that Facilities page header functionality works as expected.
+ */
+class FacilitiesHeaderTest extends AccountTestCase
+{
+    /**
+     * Test that the facilities page loads successfully and contains a header element.
+     *
+     * @return void
+     */
+    public function testFacilitiesPageHasHeaderElement(): void
+    {
+        $response = $this->get('/facilities');
+
+        $response->assertStatus(200);
+        $response->assertSee('Facilities - ');
+    }
+
+    /**
+     * Test that the facilities page contains a header with background-image.
+     * This catches issues where the header_filename is not generated correctly.
+     *
+     * @return void
+     */
+    public function testFacilitiesPageHeaderHasBackgroundImage(): void
+    {
+        $response = $this->get('/facilities');
+
+        $response->assertStatus(200);
+
+        // Get the response content
+        $content = $response->getContent();
+        if ($content === false) {
+            $content = '';
+        }
+
+        // Verify the header element exists with a background-image style
+        $this->assertMatchesRegularExpression(
+            '/<header[^>]*style=["\'][^"\']*background-image:\s*url\([^)]+\)/',
+            $content,
+            'The facilities page should have a header element with a valid background-image CSS url() function'
+        );
+    }
+
+    /**
+     * Test that the header filename follows the expected pattern.
+     * The header filename should match the pattern: {biome}_{building_ids}.jpg
+     *
+     * @return void
+     */
+    public function testFacilitiesPageHeaderFilenamePattern(): void
+    {
+        $response = $this->get('/facilities');
+
+        $response->assertStatus(200);
+
+        // Get the response content
+        $content = $response->getContent();
+        if ($content === false) {
+            $content = '';
+        }
+
+        // Verify the header image path follows the expected pattern
+        // Pattern: /img/headers/facilities/{biome}_{optional_building_ids}.jpg
+        // Where biome is: dry, desert, normal, ice, etc.
+        // And building_ids (if present) are: _14, _15, _21, _31, _33, _34 in ascending order
+        $this->assertMatchesRegularExpression(
+            '#/img/headers/facilities/(dry|desert|normal|ice|water|gas)(?:_(?:14|15|21|31|33|34))*\.jpg#',
+            $content,
+            'The header image filename should follow the pattern: {biome}_{optional_building_ids}.jpg'
+        );
+    }
+
+    /**
+     * Test that the header filename includes building IDs when buildings are present.
+     *
+     * @return void
+     */
+    public function testFacilitiesPageHeaderIncludesBuildingIds(): void
+    {
+        // Build some facilities that should appear in the header
+        $this->planetSetObjectLevel('robot_factory', 1);  // ID 14
+        $this->planetSetObjectLevel('shipyard', 1);        // ID 15
+        $this->planetSetObjectLevel('research_lab', 1);    // ID 21
+
+        $response = $this->get('/facilities');
+
+        $response->assertStatus(200);
+
+        // Get the response content
+        $content = $response->getContent();
+        if ($content === false) {
+            $content = '';
+        }
+
+        // The header should include building IDs 14, 15, 21 (sorted: 14_15_21)
+        $this->assertMatchesRegularExpression(
+            '#/img/headers/facilities/(dry|desert|normal|ice|water|gas)_14_15_21\.jpg#',
+            $content,
+            'The header image filename should include building IDs 14, 15, and 21'
+        );
+    }
+
+    /**
+     * Test that the header filename does NOT include extra closing parenthesis.
+     * This specifically tests for the bug where the CSS url() function had
+     * incorrect syntax like: url(/path).jpg); instead of url('/path.jpg');
+     *
+     * @return void
+     */
+    public function testFacilitiesPageHeaderCssUrlSyntaxIsValid(): void
+    {
+        $response = $this->get('/facilities');
+
+        $response->assertStatus(200);
+
+        // Get the response content
+        $content = $response->getContent();
+        if ($content === false) {
+            $content = '';
+        }
+
+        // The broken syntax would produce: url(/img/headers/facilities/...).jpg);
+        // We should NOT find this pattern
+        $this->assertDoesNotMatchRegularExpression(
+            '#url\([^)]+\)\.jpg\);#',
+            $content,
+            'The header background-image should not have the broken CSS url() syntax'
+        );
+
+        // The correct syntax should produce: url('/img/headers/facilities/....jpg');
+        // or: url(/img/headers/facilities/....jpg);
+        $this->assertMatchesRegularExpression(
+            "#url\(['\"]?/img/headers/facilities/[^'\"]+\.jpg['\"]?\)#",
+            $content,
+            'The header background-image should have valid CSS url() syntax'
+        );
+    }
+}


### PR DESCRIPTION
## Description  
This PR fixes a syntax error in `resources/views/ingame/facilities/index.blade.php`. The `)` before `.jpg` was closing the `url() `function prematurely, making the rest of the CSS invalid and the browser ignoring the background image entirely.

I have also added a couple feature tests to prevent regressions in the future.

### Type of Change:
- [X] Bug fix
- [X] Feature enhancement

## Related Issues
Fixes #1103 

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [X] **Automated Refactoring:** Rector has been run and no outstanding issues remain.
- [X] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [X] **Static Analysis:** Code passes PHPStan static code analysis.
- [X] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [X] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [X] **Documentation:** Documentation has been updated to reflect any changes made.

