### PR TITLE
Fix: Facility header images not displaying (404 errors)

### DIFF
--- a/app/Http/Controllers/Abstracts/AbstractBuildingsController.php
+++ b/app/Http/Controllers/Abstracts/AbstractBuildingsController.php
@@ -160,7 +160,9 @@ abstract class AbstractBuildingsController extends OGameController
         }
 
         // Parse header filename for this planet
-        ksort($header_filename_parts);
+        // IMPORTANT: Do NOT sort - the order from header_filename_objects is critical!
+        // OGame uses build order (dependency chain), not numerical order.
+        // ksort() would break the filename matching.
 
         $header_filename = '';
         if ($this->planet->isPlanet()) {

--- a/app/Http/Controllers/FacilitiesController.php
+++ b/app/Http/Controllers/FacilitiesController.php
@@ -41,8 +41,10 @@ class FacilitiesController extends AbstractBuildingsController
         // Prepare custom properties.
         // Header filename objects are the building IDs that make up the header filename
         // to be used in the background image of the page header.
+        // IMPORTANT: Must be in OGame's build order (dependency chain), NOT numerical order.
+        // 14->21->31->34->15->33 matches the actual image filenames from OGame.
         if ($this->planet->isPlanet()) {
-            $this->header_filename_objects = [14, 15, 21, 31, 33, 34];
+            $this->header_filename_objects = [14, 21, 31, 34, 15, 33];
             $this->objects = [
                 ['robot_factory', 'shipyard', 'research_lab', 'alliance_depot', 'missile_silo', 'nano_factory', 'terraformer', 'space_dock'],
             ];


### PR DESCRIPTION
## Description
Facility page header images were returning 404 errors because the generated filenames didn't match OGame's actual image filenames.

- Generated: `water_14_15_21_31_33_34.jpg` (numerical order)
- Expected: `water_14_21_31_34_15_33.jpg` (build order)

### Type of Change:
- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #[issue-number]

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [X] **Automated Refactoring:** Rector has been run and no outstanding issues remain.
- [X] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [X] **Static Analysis:** Code passes PHPStan static code analysis.
- [X] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [X] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [X] **Documentation:** Documentation has been updated to reflect any changes made.

## Additional Information
Add any additional context, screenshots, or explanations to help reviewers understand your PR. If this change introduces any breaking changes or significant impacts, please detail them here.
