### PR TITLE
Fix: add fusion reactor (12) to resources header objects

### DIFF
--- a/app/Http/Controllers/ResourcesController.php
+++ b/app/Http/Controllers/ResourcesController.php
@@ -48,7 +48,7 @@ class ResourcesController extends AbstractBuildingsController
         // Header filename objects are the building IDs that make up the header filename
         // to be used in the background image of the page header.
         if ($this->planet->isPlanet()) {
-            $this->header_filename_objects = [1, 2, 3, 4, 212];
+            $this->header_filename_objects = [1, 2, 3, 4, 12, 212];
         } elseif ($this->planet->isMoon()) {
             $this->header_filename_objects = [41, 42, 43];
         }


### PR DESCRIPTION
## Description
Luckily, all the fusion reacter header images are present and only needed to be enabled.

### Type of Change:
- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #1156 

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [X] **Automated Refactoring:** Rector has been run and no outstanding issues remain.
- [X] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [X] **Static Analysis:** Code passes PHPStan static code analysis.
- [x] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [X] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [x] **Documentation:** Documentation has been updated to reflect any changes made.

## Additional Information
Add any additional context, screenshots, or explanations to help reviewers understand your PR. If this change introduces any breaking changes or significant impacts, please detail them here.
