### PR TITLE
fix: Prevent Terraformer from being demolished

### DIFF
--- a/app/Services/ObjectService.php
+++ b/app/Services/ObjectService.php
@@ -947,6 +947,11 @@ class ObjectService
                 return false;
             }
 
+            // Special case: Terraformer cannot be downgraded once built
+            if ($machine_name === 'terraformer') {
+                return false;
+            }
+
             // Special case: Missile Silo cannot be downgraded if it contains missiles
             if ($machine_name === 'missile_silo') {
                 $ipm_count = $planet->getObjectAmount('interplanetary_missile');

--- a/tests/Unit/ObjectServiceTest.php
+++ b/tests/Unit/ObjectServiceTest.php
@@ -142,6 +142,19 @@ class ObjectServiceTest extends UnitTestCase
     }
 
     /**
+     * Test canDowngradeBuilding returns false for Terraformer (permanent building).
+     */
+    public function testCanDowngradeBuildingTerraformerIsPermanent(): void
+    {
+        $this->createAndSetPlanetModel([
+            'terraformer' => 1,
+        ]);
+
+        $can_downgrade = ObjectService::canDowngradeBuilding('terraformer', $this->planetService);
+        $this->assertFalse($can_downgrade);
+    }
+
+    /**
      * Test getRecursiveRequirements returns all prerequisites for a technology.
      * Example: shielding_technology requires research_lab level 6 and energy_technology level 3.
      */


### PR DESCRIPTION
## Description
This PR hides the tear down button for terraformers and introduces a test to prevent a future regression.

### Type of Change:
- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #1160 

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [x] **Automated Refactoring:** Rector has been run and no outstanding issues remain.
- [X] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [X] **Static Analysis:** Code passes PHPStan static code analysis.
- [X] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [X] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [X] **Documentation:** Documentation has been updated to reflect any changes made.

## Additional Information
Add any additional context, screenshots, or explanations to help reviewers understand your PR. If this change introduces any breaking changes or significant impacts, please detail them here.
