### PR TITLE
fix: Dark Matter halving UI for unit queue #1136

### DIFF
--- a/resources/views/ingame/shared/buildqueue/unit-active.blade.php
+++ b/resources/views/ingame/shared/buildqueue/unit-active.blade.php
@@ -37,19 +37,17 @@
         </tr>
         <tr class="data">
             <td colspan="2">
+                @php
+                    $halvingService = app(\OGame\Services\HalvingService::class);
+                    $halvingCost = $halvingService->calculateHalvingCost($build_active->time_countdown, 'unit');
+                @endphp
                 <a class="build-faster dark_highlight tooltipLeft js_hideTipOnMobile ship tpd-hideOnClickOutside"
-                   title="" href="javascript:void(0);"
-                   rel="#page=componentOnly&amp;component=itemactions&amp;action=buyAndActivate&amp;itemUuid=75accaa0d1bc22b78d83b89cd437bdccd6a58887&amp;asJson=1">
-                    <div class="                                                build-finish-img
-                                            " alt="                                                Complete
-                                            "></div>
-                    <span class="build-txt">
-                                                                                            Complete
-                                                                                    </span>
-                    <span class="dm_cost ">
-                                                                                                    Costs:
-                                                                                                        5,250 DM
-                                                                                            </span>
+                   title="Reduces construction time by 50% of the total construction time."
+                   href="javascript:void(0);"
+                   rel="{{ route('shipyard.halveunit') }}?queue_item_id={{ $build_active->id }}">
+                    <div class="build-faster-img" alt="Halve time"></div>
+                    <span class="build-txt">Halve time</span>
+                    <span class="dm_cost">Costs: {{ number_format($halvingCost) }} DM</span>
                 </a>
             </td>
         </tr>
@@ -57,8 +55,8 @@
     </table>
 
     <script type="text/javascript">
-        var questionbuilding = 'Do\u0020you\u0020want\u0020to\u0020reduce\u0020the\u0020construction\u0020time\u0020of\u0020the\u0020current\u0020construction\u0020project\u0020by\u002050\u0025\u0020of\u0020the\u0020total\u0020construction\u0020time\u0020\u00287m\u002010s\u0029\u0020for\u0020\u003Cspan\u0020style\u003D\u0022font\u002Dweight\u003A\u0020bold\u003B\u0022\u003E750\u0020Dark\u0020Matter\u003C\/span\u003E\u003F';
-        var pricebuilding = 750;
+        var questionship = 'Do you want to reduce the construction time of the current shipyard production by 50% of the total construction time for <span style="font-weight: bold;">{{ number_format($halvingCost) }} Dark Matter</span>?';
+        var priceship = {{ $halvingCost }};
         var referrerPage = $.deparam.querystring().page;
         new CountdownTimer('unitCountdown', {{ $build_active->time_countdown }}, '{{ url()->current() }}', null, true, 3)
         new CountdownTimerUnit('shipyardCountdownUnit', {{ $build_active->time_countdown_object_next }}, {{ $build_active->object_amount_remaining }}, {{ $build_active->object->id }}, {{ $build_active->time_countdown_per_object }}, null, 3)


### PR DESCRIPTION
## Description
This PR updates the unit-active queue view to use the correct Dark Matter halving flow that's already implemented and working for buildings and research, with proper cost calculation based on remaining construction time.

### Type of Change:
- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #1136

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [x] **Code Standards:** Blade template adheres to existing code style conventions. No PSR-12/Rector/PHPStan changes needed (file is Blade template, not PHP class).
- [x] **Testing:** Existing test `HalvingIntegrationTest::testUnitHalvingEndToEnd` covers the `/ajax/shipyard/halve-unit` endpoint and validates the halving flow works correctly.
- [x] **Automated Refactoring:** No PHP class files modified; Rector not applicable.
- [x] **Static Analysis:** No PHP class files modified; PHPStan not applicable.
- [x] **CSS & JS Build:** No CSS or JS source files modified; build not needed.
- [x] **Documentation:** Bug fix only; no public API changes requiring documentation updates.

## Additional Information
