### PR TITLE
fix: display actual player class in combat reports

### DIFF
--- a/app/GameMessages/BattleReport.php
+++ b/app/GameMessages/BattleReport.php
@@ -399,6 +399,8 @@ class BattleReport extends GameMessage
             'defender_name' => $defender_name,
             'attacker_class' => ($winner === 'attacker') ? 'undermark' : (($winner === 'draw') ? 'middlemark' : 'overmark'),
             'defender_class' => ($winner === 'defender') ? 'undermark' : (($winner === 'draw') ? 'middlemark' : 'overmark'),
+            'attacker_character_class' => isset($this->battleReportModel->attacker['character_class']) ? $this->battleReportModel->attacker['character_class'] : null,
+            'defender_character_class' => isset($this->battleReportModel->defender['character_class']) ? $this->battleReportModel->defender['character_class'] : null,
             'defender_planet_name' => $planet->getPlanetName(),
             'defender_planet_coords' => $planet->getPlanetCoordinates()->asString(),
             'defender_planet_link' => route('galaxy.index', ['galaxy' => $planet->getPlanetCoordinates()->galaxy, 'system' => $planet->getPlanetCoordinates()->system, 'position' => $planet->getPlanetCoordinates()->position]),

--- a/app/GameMissions/AttackMission.php
+++ b/app/GameMissions/AttackMission.php
@@ -560,6 +560,10 @@ class AttackMission extends GameMission
             'hamill_manoeuvre_triggered' => $battleResult->hamillManoeuvreTriggered,
         ];
 
+        $characterClassService = app(CharacterClassService::class);
+        $attackerCharacterClass = $characterClassService->getCharacterClass($attackPlayer->getUser());
+        $defenderCharacterClass = $characterClassService->getCharacterClass($defenderPlanet->getPlayer()->getUser());
+
         $report->attacker = [
             'player_id' => $attackPlayer->getId(),
             'resource_loss' => $battleResult->attackerResourceLoss->sum(),
@@ -568,6 +572,7 @@ class AttackMission extends GameMission
             'shielding_technology' => $battleResult->attackerShieldLevel,
             'armor_technology' => $battleResult->attackerArmorLevel,
             'planet_id' => $battleResult->attackerPlanetId,
+            'character_class' => $attackerCharacterClass?->getName(),
         ];
 
         // TODO: Enhance battle reports to show individual participating fleets/defenders
@@ -586,6 +591,7 @@ class AttackMission extends GameMission
             'weapon_technology' => $battleResult->defenderWeaponLevel,
             'shielding_technology' => $battleResult->defenderShieldLevel,
             'armor_technology' => $battleResult->defenderArmorLevel,
+            'character_class' => $defenderCharacterClass?->getName(),
         ];
 
         $report->loot = [

--- a/resources/views/ingame/messages/templates/battle_report_full.blade.php
+++ b/resources/views/ingame/messages/templates/battle_report_full.blade.php
@@ -256,7 +256,7 @@
             <br class="clearfloat">
 
             <ul class="common_info fleft">
-                <li class="attackerCharacterClass">@lang('Class'): Collector</li>
+                <li class="attackerCharacterClass">@lang('Class'): {{ $attacker_character_class ?? '' }}</li>
             </ul>
             <br class="clearfloat">
 
@@ -323,7 +323,7 @@
             <br class="clearfloat">
 
             <ul class="common_info fleft">
-                <li class="defenderCharacterClass">@lang('Class'): Collector</li>
+                <li class="defenderCharacterClass">@lang('Class'): {{ $defender_character_class ?? '' }}</li>
             </ul>
 
             <br class="clearfloat">
@@ -532,7 +532,7 @@
                     "4492924": {
                         "ownerName": "{{ $attacker_name }}",
                         "ownerCharacterClassId": 1,
-                        "ownerCharacterClassName": "Collector",
+                        "ownerCharacterClassName": "{{ $attacker_character_class ?? '' }}",
                         "ownerID": 115473,
                         "ownerCoordinates": "2:488:1",
                         "ownerPlanetType": 3,
@@ -604,7 +604,7 @@
                 "member": [{
                     "ownerName": "{{ $defender_name }}",
                     "ownerCharacterClassId": 1,
-                    "ownerCharacterClassName": "Collector",
+                    "ownerCharacterClassName": "{{ $defender_character_class ?? '' }}",
                     "ownerID": 102489,
                     "ownerCoordinates": "2:3:11",
                     "ownerPlanetType": 1,


### PR DESCRIPTION
## Description
This PR fixes the incorrect Collector class display for all players in combat reports and now dynamically displays the correct player class. Aliens/Pirates are left blank after the `Class:` string.

### Type of Change:
- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #1170 

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [X] **Automated Refactoring:** Rector has been run and no outstanding issues remain.
- [X] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [X] **Static Analysis:** Code passes PHPStan static code analysis.
- [X] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [X] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [X] **Documentation:** Documentation has been updated to reflect any changes made.

## Additional Information
Add any additional context, screenshots, or explanations to help reviewers understand your PR. If this change introduces any breaking changes or significant impacts, please detail them here.
