### PR TITLE
chore: comment out lifeform and food features from UI

### DIFF
--- a/resources/views/ingame/fleet/index.blade.php
+++ b/resources/views/ingame/fleet/index.blade.php
@@ -182,7 +182,7 @@
             var LOOT_PRIO_METAL = 2;
             var LOOT_PRIO_CRYSTAL = 3;
             var LOOT_PRIO_DEUTERIUM = 4;
-            var LOOT_PRIO_FOOD = 1;
+            // var LOOT_PRIO_FOOD = 1;
 
             var missions = {
                 "MISSION_NONE": 0,
@@ -266,11 +266,11 @@
 
             var holdingTime = 1;
             var expeditionTime = 0;
-            var lifeformEnabled = true;
+            // var lifeformEnabled = true;
             var metalOnPlanet = {{ $planet->metal()->getRounded() }};
             var crystalOnPlanet = {{ $planet->crystal()->getRounded() }};
             var deuteriumOnPlanet = {{ $planet->deuterium()->getRounded() }};
-            var foodOnPlanet = 0;
+            // var foodOnPlanet = 0;
 
             var fleetCount = {{ $fleetSlotsInUse }};
             var maxFleetCount = {{ $fleetSlotsMax }};
@@ -363,7 +363,7 @@
                 "LOCA_ALL_METAL": "Metal",
                 "LOCA_ALL_CRYSTAL": "Crystal",
                 "LOCA_ALL_DEUTERIUM": "Deuterium",
-                "LOCA_ALL_FOOD": "Food",
+                // "LOCA_ALL_FOOD": "Food",
                 "LOCA_FLEET_LOAD_ROOM": "cargo bay",
                 "LOCA_FLEET_CARGO_SPACE": "Available space \/ Max. cargo space",
                 "LOCA_FLEET_SEND": "Send fleet",
@@ -383,7 +383,7 @@
                 "LOCA_INACTIVE_SYSTEMS": "Inactive Systems",
                 "LOCA_NETWORK_ON": "On",
                 "LOCA_NETWORK_OFF": "Off",
-                "LOCA_LOOT_FOOD": "Plunder food",
+                // "LOCA_LOOT_FOOD": "Plunder food",
                 "LOCA_BASHING_SYSTEM_LIMIT_REACHED_ATTACK_MISSIONS_DISABLED": "Attack missions have been deactivated as a result of too many attacks on the target."
             };
             var locadyn = {
@@ -467,7 +467,7 @@
                 "bonuses": {
                     "recycleAttackerFleet": 0,
                     "moonChanceIncrease": 0,
-                    "lifeformProtection": 0,
+                    // "lifeformProtection": 0,
                     "spaceDockExtender": 0,
                     "denCapacity": {"metal": 0, "crystal": 0, "deuterium": 0},
                     "characterClassBooster": {"1": 0, "2": 0, "3": 0}
@@ -1257,7 +1257,7 @@ The &amp;#96;tactical retreat&amp;#96; option ends with 500,000 points.">
                                         <input name="prioMetal" type="hidden" value="2">
                                         <input name="prioCrystal" type="hidden" value="3">
                                         <input name="prioDeuterium" type="hidden" value="4">
-                                        <input name="prioFood" type="hidden" value="1">
+                                        <!-- <input name="prioFood" type="hidden" value="1"> -->
 
                                     </div>
                                     <div class="missionHeader">@lang('Briefing:')</div>
@@ -1379,7 +1379,7 @@ The &amp;#96;tactical retreat&amp;#96; option ends with 500,000 points.">
                                                     </a>
                                                 </div>
                                             </div>
-                                            <div class="res_wrap border3px">
+                                            <!-- <div class="res_wrap border3px">
                                                 <div class="resourceIcon food tooltip" title="Food"></div>
                                                 <div class="res">
                                                     <input type="text" pattern="[0-9,.]*"
@@ -1403,7 +1403,7 @@ The &amp;#96;tactical retreat&amp;#96; option ends with 500,000 points.">
                                                 <script>
 
                                                 </script>
-                                            </div>
+                                            </div> -->
                                             <div id="loadAllResources">
                                                 <div class="allResourcesWrap ipiHintable"
                                                      data-ipi-hint="ipiFleetCargoLoadAll">

--- a/resources/views/ingame/layouts/main.blade.php
+++ b/resources/views/ingame/layouts/main.blade.php
@@ -241,7 +241,7 @@
                     </span>
                     </div>
                 </div>
-                <div class="resource_tile population">
+                <!-- <div class="resource_tile population">
                     <div id="population_box" class="population tooltipHTML resource ipiHintable tpd-hideOnClickOutside"
                          title="Population|<table class=&quot;resourceTooltip&quot;><tr><th>Available:</th><td><span class=&quot;overmark&quot;>100</span></td></tr><tr><th>Living Space
 </th><td><span class=&quot;overmark&quot;>0</span></td></tr><tr><th>Satisfied</th><td><span class=&quot;undermark&quot;>0</span></td></tr><tr><th>Hungry</th><td><span class=&quot;overmark&quot;>0</span></td></tr><tr><th>Growth rate</th><td><span class=&quot;&quot;>±0</span></td></tr><tr><th>Bunker Space
@@ -261,7 +261,7 @@
                         <span id="resources_food" data-raw="0" class="overmark">0</span>
                     </span>
                     </div>
-                </div>
+                </div> -->
                 <div class="resource_tile darkmatter">
                     <div id="darkmatter_box" class="darkmatter tooltipHTML resource ipiHintable tpd-hideOnClickOutside"
                          title="@lang('Dark Matter')|<table class=&quot;resourceTooltip&quot;><tr><th>Available:</th><td><span class=&quot;&quot;>{!! $resources['darkmatter']['amount_formatted'] !!}</span></td></tr></table>"
@@ -278,13 +278,13 @@
             </div>
         </div>
         <div id="commandercomponent" class="">
-            <div id="lifeform" class="fleft">
+            <!-- <div id="lifeform" class="fleft">
                 <a href="#TODO_page=ingame&amp;component=lfsettings" class="tooltipHTML js_hideTipOnMobile ipiHintable"
                    title="Lifeform|No lifeforms
 " data-ipi-hint="ipiLifeformSettings">
                     <div class="resourceIcon population"></div>
                 </a>
-            </div>
+            </div> -->
             <div id="characterclass" class="fleft">
                 @php
                     $userClass = $currentPlayer->getUser()->getCharacterClassEnum();
@@ -1329,28 +1329,28 @@ However, the Space Dock's engineers think that some of the remains can be salvag
 
                 reloadResources({
                     "resources": {
-                        "population": {
-                            "amount": 100,
-                            "storage": 0,
-                            "safeCapacity": 0,
-                            "growthRate": 0,
-                            "capableToFeed": 0,
-                            "needFood": 0,
-                            "singleFoodConsumption": 0,
-                            "tooltip": "@lang('Population')|<table class=\"resourceTooltip\"><tr><th>@lang('Available'):<\/th><td><span class=\"overmark\">100<\/span><\/td><\/tr><tr><th>@lang('Living Space')\n<\/th><td><span class=\"overmark\">0<\/span><\/td><\/tr><tr><th>@lang('Satisfied')<\/th><td><span class=\"undermark\">0<\/span><\/td><\/tr><tr><th>@lang('Hungry')<\/th><td><span class=\"overmark\">0<\/span><\/td><\/tr><tr><th>@lang('Growth rate')<\/th><td><span class=\"\">\u00b10<\/span><\/td><\/tr><tr><th>@lang('Bunker Space')\n<\/th><td><span class=\"middlemark\">100<\/span><\/td><\/tr><\/table>",
-                            "classesListItem": ""
-                        },
-                        "food": {
-                            "amount": 0,
-                            "storage": 0,
-                            "capableToFeed": 0,
-                            "production": 0,
-                            "consumption": 0,
-                            "timeTillFoodRunsOut": 0,
-                            "vacationMode": "",
-                            "tooltip": "@lang('Food')|<table class=\"resourceTooltip\"><tr><th>@lang('Available'):<\/th><td><span class=\"overmark\">0<\/span><\/td><\/tr><tr><th>@lang('Storage capacity')<\/th><td><span class=\"overmark\">0<\/span><\/td><\/tr><tr><th>@lang('Overproduction')<\/th><td><span class=\"undermark\">0<\/span><\/td><\/tr><tr><th>@lang('Consumption')<\/th><td><span class=\"overmark\">0<\/span><\/td><\/tr><tr><th>@lang('Consumed in')<\/th><td><span class=\"overmark timeTillFoodRunsOut\">~<\/span><\/td><\/tr><\/table>",
-                            "classesListItem": ""
-                        },
+                        // "population": {
+                        //     "amount": 100,
+                        //     "storage": 0,
+                        //     "safeCapacity": 0,
+                        //     "growthRate": 0,
+                        //     "capableToFeed": 0,
+                        //     "needFood": 0,
+                        //     "singleFoodConsumption": 0,
+                        //     "tooltip": "@lang('Population')|<table class=\"resourceTooltip\"><tr><th>@lang('Available'):<\/th><td><span class=\"overmark\">100<\/span><\/td><\/tr><tr><th>@lang('Living Space')\n<\/th><td><span class=\"overmark\">0<\/span><\/td><\/tr><tr><th>@lang('Satisfied')<\/th><td><span class=\"undermark\">0<\/span><\/td><\/tr><tr><th>@lang('Hungry')<\/th><td><span class=\"overmark\">0<\/span><\/td><\/tr><tr><th>@lang('Growth rate')<\/th><td><span class=\"\">\u00b10<\/span><\/td><\/tr><tr><th>@lang('Bunker Space')\n<\/th><td><span class=\"middlemark\">100<\/span><\/td><\/tr><\/table>",
+                        //     "classesListItem": ""
+                        // },
+                        // "food": {
+                        //     "amount": 0,
+                        //     "storage": 0,
+                        //     "capableToFeed": 0,
+                        //     "production": 0,
+                        //     "consumption": 0,
+                        //     "timeTillFoodRunsOut": 0,
+                        //     "vacationMode": "",
+                        //     "tooltip": "@lang('Food')|<table class=\"resourceTooltip\"><tr><th>@lang('Available'):<\/th><td><span class=\"overmark\">0<\/span><\/td><\/tr><tr><th>@lang('Storage capacity')<\/th><td><span class=\"overmark\">0<\/span><\/td><\/tr><tr><th>@lang('Overproduction')<\/th><td><span class=\"undermark\">0<\/span><\/td><\/tr><tr><th>@lang('Consumption')<\/th><td><span class=\"overmark\">0<\/span><\/td><\/tr><tr><th>@lang('Consumed in')<\/th><td><span class=\"overmark timeTillFoodRunsOut\">~<\/span><\/td><\/tr><\/table>",
+                        //     "classesListItem": ""
+                        // },
                         "metal": {
                             "amount": {!! $resources['metal']['amount'] !!},
                             "storage": {!! $resources['metal']['storage'] !!},
@@ -1714,7 +1714,7 @@ However, the Space Dock's engineers think that some of the remains can be salvag
                                     <a href="{{ $urlToPlanetWithUpdatedParam }}"
                                        data-link="{{ $urlToPlanetWithUpdatedParam }}"
                                        title="<b>{{ $planet->getPlanetName() }} [{{ $planet->getPlanetCoordinates()->asString() }}]</b><br/>
-                                        @lang('Lifeform'): Humans<br/>
+                                        {{-- @lang('Lifeform'): Humans<br/> --}}
                                         {{ OGame\Facades\AppUtil::formatNumber($planet->getPlanetDiameter()) }}km ({{ $planet->getBuildingCount() }}/{{ $planet->getPlanetFieldMax() }})<br>
                                         {{ $planet->getPlanetTempMin() }} to {{ $planet->getPlanetTempMax() }}°C<br/>
                                         <a href=&quot;{{ route('overview.index') }}?cp={{ $planet->getPlanetId() }}&quot;>@lang('Overview')</a><br/>

--- a/resources/views/ingame/messages/templates/battle_report_full.blade.php
+++ b/resources/views/ingame/messages/templates/battle_report_full.blade.php
@@ -332,10 +332,10 @@
                 <li class="defenderWeapon">@lang('Weapons'): {{ $defender_weapons }}%</li>
                 <li class="defenderShield">@lang('Shields'): {{ $defender_shields }}%</li>
                 <li class="defenderCover">@lang('Armour'): {{ $defender_armor }}%</li>
-                <li class="resource_list_el_small">
+                <!-- <li class="resource_list_el_small">
                     <div class="resourceIconSmall population"></div>
                     <span class="res_value tooltipCustom overmark" data-tooltip-title="0">0</span>
-                </li>
+                </li> -->
             </ul>
             <br class="clearfloat">
 
@@ -525,7 +525,7 @@
 @endforeach
             ],
             // End combat rounds --------------------------------------------------------------------
-            "lifeformEnabled": true,
+            // "lifeformEnabled": true,
             "isExpedition": false,
             "attackerJSON": {
                 "member": {


### PR DESCRIPTION
## Description  
This PR removes all lifeform related icons and mentions from the UI:

- Hide food and population resource displays from resource bar
- Remove lifeform navigation icon
- Comment out food input fields and variables in fleet dispatch
- Remove lifeform references from battle reports and tooltips

It is possible that the spacing of the remaining resources needs to be tuned but I don't have any reference as to how they should be arranged.

### Type of Change:
- [ ] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [X] Other (please describe):

## Related Issues
Fixes #228 

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [X] **Automated Refactoring:** Rector has been run and no outstanding issues remain.
- [X] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [X] **Static Analysis:** Code passes PHPStan static code analysis.
- [X] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [X] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [X] **Documentation:** Documentation has been updated to reflect any changes made.

## Additional Information
Commented out instead of straight up deleting so that it can be utilized in the future if the scope changes or people want to work on it in their own forks.
