### PR TITLE
fix: ACS Defend duplication bug and add feature tests

### DIFF
--- a/app/GameMissions/AcsDefendMission.php
+++ b/app/GameMissions/AcsDefendMission.php
@@ -83,7 +83,9 @@ class AcsDefendMission extends GameMission
         // via FleetMissionService::sendAcsDefendArrivalMessages()
         // This method is called after the hold time expires to create the return mission
 
-        // Create and start the return mission
+        // Create and start the return mission.
+        // Unit counts on the mission record may have been updated by battle processing if the fleet
+        // was attacked during hold time, so getFleetUnits() returns the correct post-battle survivors.
         $this->startReturn($mission, $this->fleetMissionService->getResources($mission), $this->fleetMissionService->getFleetUnits($mission));
 
         // Mark the arrival mission as processed


### PR DESCRIPTION
## Description
This PR fixes a game breaking bug that let players dupe ships/resources with ACS Defend missions.

Cause:

`AttackMission::processArrival() `called `startReturn()` for surviving ACS defend fleets immediately after battle. This created a return mission record in the database with `time_departure = hold_end_time`, which had two consequences:

1. Immediate widget duplication: `getActiveFleetMissionsForCurrentPlayer()` shows all unprocessed missions. The premature return mission was immediately visible as a second fleet slot with no recall button, while the original outbound mission was still holding at the target planet. 
2. Recall doubles ships: `cancel()` creates a return mission for the player when they recall a fleet. With the battle-created return mission already in the DB, both missions would eventually process and add ships to the planet independently.

Instead of calling `startReturn()` from `AttackMission`, the surviving fleet's outbound mission record is updated in-place with the post-battle unit counts and proportionally adjusted resources. The fleet continues holding at the target planet as normal. The single return mission is created exactly once, either by:

- `AcsDefendMission::processArrival()` when hold time expires (normal flow), or
- `GameMission::cancel()` when the player recalls the fleet

This means one fleet in → one fleet out, regardless of whether a battle occurred during the hold.


### Type of Change:
- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #1224 

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [ ] **Automated Refactoring:** Rector has been run and no outstanding issues remain.
- [ ] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [ ] **Static Analysis:** Code passes PHPStan static code analysis.
- [ ] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [ ] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [ ] **Documentation:** Documentation has been updated to reflect any changes made.

## Additional Information
Add any additional context, screenshots, or explanations to help reviewers understand your PR. If this change introduces any breaking changes or significant impacts, please detail them here.
