### PR TITLE
fix: ACS Defend recall during hold time and arrival messages

### DIFF
--- a/app/Http/Controllers/FleetEventsController.php
+++ b/app/Http/Controllers/FleetEventsController.php
@@ -207,6 +207,7 @@ class FleetEventsController extends OGameController
             // Planet from service
             $eventRowViewModel = new FleetEventRowViewModel();
             $eventRowViewModel->id = $row->id;
+            $eventRowViewModel->real_mission_id = $row->id;
             $eventRowViewModel->mission_type = $row->mission_type;
             $eventRowViewModel->mission_label = $fleetMissionService->missionTypeToLabel($row->mission_type);
             // For ACS Defend missions (type 5), show physical arrival time (when fleet actually arrives)
@@ -299,7 +300,8 @@ class FleetEventsController extends OGameController
                 // ACS Defend missions (type 5) should be recallable during hold time
                 // Expeditions (type 15) should NOT be recallable during hold time
                 $waitEndRow->is_recallable = ($friendlyStatus === FleetMissionStatus::Friendly && $row->mission_type === 5);
-                $waitEndRow->id = $row->id + 888888; // Add large number to avoid conflicts
+                $waitEndRow->id = $row->id + 888888; // Add large number to avoid DOM ID conflicts
+                $waitEndRow->real_mission_id = $row->id;
                 $waitEndRow->mission_type = $eventRowViewModel->mission_type;
                 $waitEndRow->mission_label = $fleetMissionService->missionTypeToLabel($eventRowViewModel->mission_type);
                 // For ACS Defend, time_arrival already includes hold time (return departure time)
@@ -336,7 +338,8 @@ class FleetEventsController extends OGameController
                 $returnTripRow = new FleetEventRowViewModel();
                 $returnTripRow->is_return_trip = true;
                 $returnTripRow->is_recallable = false;
-                $returnTripRow->id = $row->id + 999999; // Add a large number to avoid id conflicts
+                $returnTripRow->id = $row->id + 999999; // Add a large number to avoid DOM ID conflicts
+                $returnTripRow->real_mission_id = $row->id;
                 $returnTripRow->mission_type = $eventRowViewModel->mission_type;
                 $returnTripRow->mission_label = $fleetMissionService->missionTypeToLabel($eventRowViewModel->mission_type);
                 $returnTripRow->mission_time_arrival = $returnDepartureTime + $oneWayDuration;

--- a/app/ViewModels/FleetEventRowViewModel.php
+++ b/app/ViewModels/FleetEventRowViewModel.php
@@ -10,6 +10,7 @@ use OGame\Models\Resources;
 class FleetEventRowViewModel
 {
     public int $id;
+    public ?int $real_mission_id = null;
     public int $mission_type;
     public string $mission_label;
     public int $mission_time_arrival;

--- a/resources/views/ingame/fleetevents/eventrow.blade.php
+++ b/resources/views/ingame/fleetevents/eventrow.blade.php
@@ -239,7 +239,7 @@
         <td class="sendMail">
             @if ($fleet_event_row->is_recallable)
                 <span class="reversal reversal_time" ref="{{ $fleet_event_row->id }}">
-                    <a class="icon_link tooltipHTML recallFleet" data-fleet-id="{{ $fleet_event_row->id }}"
+                    <a class="icon_link tooltipHTML recallFleet" data-fleet-id="{{ $fleet_event_row->real_mission_id }}"
                        title="Recall:| {{ \Carbon\Carbon::parse($fleet_event_row->active_recall_time)->format('d.m.Y') }}<br>
                                             {{ \Carbon\Carbon::parse($fleet_event_row->active_recall_time)->format('H:i:s') }}">
                         <img src="/img/icons/89624964d4b06356842188dba05b1b.gif" height="16" width="16"/>


### PR DESCRIPTION
## Description

This PR mainly fixes the ACS Defend recall bug, but adresses another message bug, in which the ACS Defend arrival message was sent at some point during the ACS Defend hold time and not when it actually arrived.

- **Fleet widget recall HTTP 500**: The recall button in the fleet events widget used a synthetic DOM ID (`real_id + 888888`). For mission IDs above 111,111 this overflowed past 999,999, causing the controller to subtract the wrong offset and fetch a non-existent mission, resulting in a 500 error. Fixed by adding a `real_mission_id` property to `FleetEventRowViewModel` and using it for `data-fleet-id` so the real mission ID is always sent.

- **`cancelMission()` hold-time detection**: The hold-time boundary check used `time_arrival + time_holding`, which double-counts the hold for ACS Defend since `time_arrival` already equals `physical_arrival + time_holding`. This created a phantom recall window after the hold expired that could produce duplicate return missions. Fixed to block recall as soon as `time_arrival < now`.

- **Arrival messages sent too late or not at all**: `getArrivedMissionsByPlanetIds()` only queried missions where `time_arrival <= now`, but for ACS Defend that means the hold has fully expired. Arrival messages were therefore delayed by the entire hold duration in normal flow, and skipped entirely when the fleet was recalled (because `cancel()` sets `processed = 1`, permanently excluding it from the query). Fixed by also matching ACS Defend missions where physical arrival has passed, and by sending arrival messages inside `cancelMission()` when recalling during hold time before any page load has done so.

- Fixed `getFleetMissionById()` return type to `FleetMission|null` and added null guard in `updateMission()`.

### Type of Change:
- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #1222 

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [X] **Automated Refactoring:** Rector has been run and no outstanding issues remain.
- [X] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [X] **Static Analysis:** Code passes PHPStan static code analysis.
- [X] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [X] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [X] **Documentation:** Documentation has been updated to reflect any changes made.
