### PR TITLE
Add message notification for Space Dock automatic repairs

### DIFF
--- a/app/Console/Commands/Scheduler/CleanupWreckFields.php
+++ b/app/Console/Commands/Scheduler/CleanupWreckFields.php
@@ -4,8 +4,11 @@ namespace OGame\Console\Commands\Scheduler;
 
 use Illuminate\Console\Command;
 use OGame\Factories\PlanetServiceFactory;
+use OGame\Factories\PlayerServiceFactory;
+use OGame\GameMessages\WreckFieldRepairCompleted;
 use OGame\Models\Planet\Coordinate;
 use OGame\Models\WreckField;
+use OGame\Services\MessageService;
 use OGame\Services\ObjectService;
 
 class CleanupWreckFields extends Command
@@ -156,6 +159,15 @@ class CleanupWreckFields extends Command
 
         if ($totalDeployed > 0) {
             $this->info("Auto-deployed {$totalDeployed} ships from wreck field at {$wreckField->galaxy}:{$wreckField->system}:{$wreckField->planet}");
+
+            // Send message to player about auto-deployment
+            $playerServiceFactory = resolve(PlayerServiceFactory::class);
+            $playerService = $playerServiceFactory->make($wreckField->owner_player_id);
+            $messageService = resolve(MessageService::class, ['player' => $playerService]);
+            $messageService->sendSystemMessageToPlayer($playerService, WreckFieldRepairCompleted::class, [
+                'planet' => '[planet]' . $planet->getPlanetId() . '[/planet]',
+                'ship_count' => (string) $totalDeployed,
+            ]);
         }
     }
 }

--- a/app/Factories/GameMessageFactory.php
+++ b/app/Factories/GameMessageFactory.php
@@ -33,19 +33,20 @@ use OGame\GameMessages\FleetDeployment;
 use OGame\GameMessages\FleetDeploymentWithResources;
 use OGame\GameMessages\FleetLostContact;
 use OGame\GameMessages\MissileAttackReport;
+use OGame\GameMessages\MissileDefenseReport;
 use OGame\GameMessages\MoonDestroyed;
 use OGame\GameMessages\MoonDestructionCatastrophic;
 use OGame\GameMessages\MoonDestructionFailure;
 use OGame\GameMessages\MoonDestructionMissionFailed;
 use OGame\GameMessages\MoonDestructionRepelled;
 use OGame\GameMessages\MoonDestructionSuccess;
-use OGame\GameMessages\MissileDefenseReport;
 use OGame\GameMessages\PlanetRelocationSuccess;
 use OGame\GameMessages\ReturnOfFleet;
 use OGame\GameMessages\ReturnOfFleetWithResources;
 use OGame\GameMessages\TransportArrived;
 use OGame\GameMessages\TransportReceived;
 use OGame\GameMessages\WelcomeMessage;
+use OGame\GameMessages\WreckFieldRepairCompleted;
 use OGame\Models\Message;
 use RuntimeException;
 
@@ -113,6 +114,9 @@ class GameMessageFactory
         'moon_destroyed' => MoonDestroyed::class,
         'moon_destruction_mission_failed' => MoonDestructionMissionFailed::class,
         'moon_destruction_repelled' => MoonDestructionRepelled::class,
+
+        // Wreck field messages
+        'wreck_field_repair_completed' => WreckFieldRepairCompleted::class,
     ];
 
     /**

--- a/app/GameMessages/WreckFieldRepairCompleted.php
+++ b/app/GameMessages/WreckFieldRepairCompleted.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace OGame\GameMessages;
+
+use OGame\GameMessages\Abstracts\GameMessage;
+
+class WreckFieldRepairCompleted extends GameMessage
+{
+    protected function initialize(): void
+    {
+        $this->key = 'wreck_field_repair_completed';
+        $this->params = [
+            'planet',
+            'ship_count',
+        ];
+        $this->tab = 'economy';
+        $this->subtab = 'economy';
+    }
+}

--- a/resources/lang/en/t_messages.php
+++ b/resources/lang/en/t_messages.php
@@ -453,4 +453,13 @@ Application message:
         'subject' => 'Moon :moon_name [:moon_coords] has been destroyed!',
         'body' => 'Your moon :moon_name at :moon_coords has been destroyed by a Deathstar fleet belonging to :attacker_name!',
     ],
+
+    // ------------------------
+    // Wreck field repair completed
+    'wreck_field_repair_completed' => [
+        'from' => 'System Message',
+        'subject' => 'Repair completed',
+        'body' => 'Your repair request on planet :planet has been completed.
+:ship_count ships have been put back into service.',
+    ],
 ];

--- a/tests/Console/CleanupWreckFieldsCommandTest.php
+++ b/tests/Console/CleanupWreckFieldsCommandTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Console;
 
 use OGame\Factories\PlanetServiceFactory;
+use OGame\Models\Message;
 use OGame\Models\Planet;
 use OGame\Models\User;
 use OGame\Models\WreckField;
@@ -302,5 +303,72 @@ class CleanupWreckFieldsCommandTest extends TestCase
 
         $this->assertNotNull($wreckFieldAfter, 'Repairing wreck field should not be deleted if less than 72 hours');
         $this->assertEquals('repairing', $wreckFieldAfter->status);
+    }
+
+    public function test_auto_deployment_sends_message_to_player(): void
+    {
+        // Create a wreck field that started repairs more than 72 hours ago
+        $wreckField = new WreckField();
+        $wreckField->galaxy = $this->planet->galaxy;
+        $wreckField->system = $this->planet->system;
+        $wreckField->planet = $this->planet->planet;
+        $wreckField->owner_player_id = $this->user->id;
+        $wreckField->status = 'repairing';
+        $wreckField->created_at = now()->subHours(80);
+        $wreckField->expires_at = now()->addHours(10);
+        $wreckField->repair_started_at = now()->subHours(73); // More than 72 hours ago
+        $wreckField->repair_completed_at = now()->subHours(73)->addMinutes(30); // 30 min repair time
+        $wreckField->space_dock_level = 5;
+        $wreckField->ship_data = [
+            ['machine_name' => 'light_fighter', 'quantity' => 100, 'repair_progress' => 0]
+        ];
+        $wreckField->save();
+
+        // Run the command
+        $this->artisan('ogamex:scheduler:cleanup-wreckfields');
+
+        // Verify the message was sent to the player
+        $message = Message::where('user_id', $this->user->id)
+            ->where('key', 'wreck_field_repair_completed')
+            ->first();
+
+        $this->assertNotNull($message, 'Message should be sent to player when ships are auto-deployed');
+        $this->assertEquals('wreck_field_repair_completed', $message->key);
+        $this->assertArrayHasKey('planet', $message->params);
+        $this->assertArrayHasKey('ship_count', $message->params);
+
+        // Verify the ship count is correct (35 or 36 for level 5 = 35.7% cap)
+        $expectedShips = (int) floor(100 * 0.357);
+        $this->assertEquals((string) $expectedShips, $message->params['ship_count']);
+    }
+
+    public function test_auto_deployment_does_not_send_message_for_recent_repairs(): void
+    {
+        // Create a wreck field that started repairs less than 72 hours ago
+        $wreckField = new WreckField();
+        $wreckField->galaxy = $this->planet->galaxy;
+        $wreckField->system = $this->planet->system;
+        $wreckField->planet = $this->planet->planet;
+        $wreckField->owner_player_id = $this->user->id;
+        $wreckField->status = 'repairing';
+        $wreckField->created_at = now()->subHours(10);
+        $wreckField->expires_at = now()->addHours(62);
+        $wreckField->repair_started_at = now()->subHours(10); // Only 10 hours ago
+        $wreckField->repair_completed_at = now()->subHours(9)->addMinutes(30);
+        $wreckField->space_dock_level = 5;
+        $wreckField->ship_data = [
+            ['machine_name' => 'light_fighter', 'quantity' => 100, 'repair_progress' => 0]
+        ];
+        $wreckField->save();
+
+        // Run the command
+        $this->artisan('ogamex:scheduler:cleanup-wreckfields');
+
+        // Verify no message was sent
+        $message = Message::where('user_id', $this->user->id)
+            ->where('key', 'wreck_field_repair_completed')
+            ->first();
+
+        $this->assertNull($message, 'No message should be sent for repairs that started less than 72 hours ago');
     }
 }


### PR DESCRIPTION
## Description
Add message notification when space dock automatically returns ships after 72 hours.

When a wreck field repair has been in progress for more than 72 hours without manual collection, the `ogamex:scheduler:cleanup-wreckfields` command now automatically deploys the repaired ships to the planet and sends a "Repair completed" system message to the player.

### Type of Change:
- [X] Bug fix
- [X] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #1187

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [X] **Automated Refactoring:** Rector has been run and no outstanding issues remain.
- [X] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [X] **Static Analysis:** Code passes PHPStan static code analysis.
- [X] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [X] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [X] **Documentation:** Documentation has been updated to reflect any changes made.