### PR TITLE
fix: flaky FleedSpeedTypeTest

### DIFF
--- a/tests/Feature/FleetSpeedTypeTest.php
+++ b/tests/Feature/FleetSpeedTypeTest.php
@@ -120,6 +120,8 @@ class FleetSpeedTypeTest extends AccountTestCase
     {
         $settingsService = resolve(SettingsService::class);
         $settingsService->set('fleet_speed_war', 1);
+        $settingsService->set('ignore_empty_systems_on', 0);
+        $settingsService->set('ignore_inactive_systems_on', 0);
 
         $this->playerSetResearchLevel('combustion_drive', 10);
         $this->planetAddUnit('light_fighter', 1);


### PR DESCRIPTION
## Description
This PR fixes the flaky `FleedSpeedTypeTest` by explicitly resetting `ignore_empty_systems_on` and `ignore_inactive_systems_on` to `0` at the start of the test, establishing its preconditions rather than relying on database state left by other tests.

### Type of Change:
- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #1247 

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [X] **Automated Refactoring:** Rector has been run and no outstanding issues remain.
- [X] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [X] **Static Analysis:** Code passes PHPStan static code analysis.
- [X] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [X] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [X] **Documentation:** Documentation has been updated to reflect any changes made.