### PR TITLE
fix: flaky FleetDispatchMoonDestructionTest

### DIFF
--- a/tests/AccountTestCase.php
+++ b/tests/AccountTestCase.php
@@ -5,6 +5,7 @@ namespace Tests;
 use Carbon\Carbon;
 use Exception;
 use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Illuminate\Testing\TestResponse;
@@ -31,6 +32,14 @@ abstract class AccountTestCase extends TestCase
     protected int $userPlanetAmount = 2;
 
     protected int $currentPlanetId = 0;
+
+    /**
+     * Default computer technology level for newly created users.
+     * Tests that require a different level can override this property.
+     *
+     * @var int
+     */
+    protected int $defaultComputerTechnologyLevel = 5;
 
     /**
      * Test user main planet.
@@ -62,7 +71,7 @@ abstract class AccountTestCase extends TestCase
         parent::setUp();
 
         // Set default test time to 2024-01-01 00:00:00 to ensure all tests have the same starting point.
-        $this->travelTo(Carbon::create(2024, 1, 1, 0, 0, 0));
+        $this->travelTo(Date::create(2024, 1, 1, 0, 0, 0));
 
         // Set default server settings for all tests.
         $settingsService = resolve(SettingsService::class);
@@ -84,9 +93,6 @@ abstract class AccountTestCase extends TestCase
 
         // Create a new user and login so we can access ingame features.
         $this->createAndLoginUser();
-
-        // We should now automatically be logged in. Retrieve meta fields to verify.
-        $this->retrieveMetaFields();
     }
 
     /**
@@ -142,6 +148,28 @@ abstract class AccountTestCase extends TestCase
 
         // Check if we are authenticated after registration.
         $this->assertAuthenticated();
+
+        // Update currentUserId and planetService to reflect the new user.
+        $this->retrieveMetaFields();
+
+        // Set default computer technology level for newly created users.
+        $this->setDefaultComputerTechnology();
+    }
+
+    /**
+     * Set default computer technology level for newly created users.
+     * Tests that require a different level can override $defaultComputerTechnologyLevel.
+     *
+     * @return void
+     */
+    protected function setDefaultComputerTechnology(): void
+    {
+        if ($this->defaultComputerTechnologyLevel === 0) {
+            // Skip setting if level is 0 (default game behavior).
+            return;
+        }
+
+        $this->playerSetResearchLevel('computer_technology', $this->defaultComputerTechnologyLevel);
     }
 
     /**
@@ -940,6 +968,6 @@ abstract class AccountTestCase extends TestCase
      */
     protected function resetTestTime(): void
     {
-        Carbon::setTestNow($this->defaultTestTime);
+        $this->travelTo($this->defaultTestTime);
     }
 }

--- a/tests/Feature/ResearchQueueCancelTest.php
+++ b/tests/Feature/ResearchQueueCancelTest.php
@@ -12,6 +12,8 @@ use Tests\AccountTestCase;
  */
 class ResearchQueueCancelTest extends AccountTestCase
 {
+    protected int $defaultComputerTechnologyLevel = 0;
+
     /**
      * Verify that when adding more than one of the same technology to the research queue, that cancellation
      * of the first research in the queue will cancel all research of that type in the queue.


### PR DESCRIPTION
## Description
This PR fixes two test failures related to fleet slot allocation and stale planet service references.

The moon destruction test was failing because it needed to send multiple fleets at once, but newly created test players only had 1 fleet slot. All new test players now automatically start at Computer Technology level 5 but the Research Queue Cancel test expects to start at level 0 and practice canceling a research upgrade. I have added an opt out for this test to revert to Computer Technology level 0.

Additionally, tests that switch players during execution now correctly update the test's user context, fixing issues where tests operated on stale player data after switching users.

### Type of Change:
- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #1246 

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [X] **Automated Refactoring:** Rector has been run and no outstanding issues remain.
- [X] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [X] **Static Analysis:** Code passes PHPStan static code analysis.
- [X] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [X] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [X] **Documentation:** Documentation has been updated to reflect any changes made.