### PR TITLE
fix: use dynamic coordinates in CoordinateDistanceCalculatorTest 

### DIFF
--- a/tests/Unit/CoordinateDistanceCalculatorTest.php
+++ b/tests/Unit/CoordinateDistanceCalculatorTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit;
 
+use Illuminate\Support\Facades\DB;
 use OGame\Models\Planet;
 use OGame\Models\Planet\Coordinate;
 use OGame\Models\User;
@@ -14,11 +15,23 @@ class CoordinateDistanceCalculatorTest extends TestCase
     private CoordinateDistanceCalculator $calculator;
     private SettingsService $settingsService;
 
+    /** @var array<int, int> Planet IDs created during tests, deleted in tearDown. */
+    private array $createdPlanetIds = [];
+
     protected function setUp(): void
     {
         parent::setUp();
         $this->settingsService = app(SettingsService::class);
         $this->calculator = new CoordinateDistanceCalculator($this->settingsService);
+    }
+
+    protected function tearDown(): void
+    {
+        if (!empty($this->createdPlanetIds)) {
+            Planet::whereIn('id', $this->createdPlanetIds)->delete();
+        }
+
+        parent::tearDown();
     }
 
     /**
@@ -64,18 +77,40 @@ class CoordinateDistanceCalculatorTest extends TestCase
         // Create a user
         $user = User::factory()->create();
 
-        // Create planets in systems 1, 3, and 5 (leaving 2, 4, 6, 7, 8, 9, 10 empty)
-        Planet::factory()->create(['user_id' => $user->id, 'galaxy' => 9, 'system' => 1, 'planet' => 1]);
-        Planet::factory()->create(['user_id' => $user->id, 'galaxy' => 9, 'system' => 3, 'planet' => 1]);
-        Planet::factory()->create(['user_id' => $user->id, 'galaxy' => 9, 'system' => 5, 'planet' => 1]);
+        // Find a starting system across all 9 galaxies where 10 consecutive systems are all empty,
+        // to avoid unique constraint violations with planets created by other tests.
+        $galaxy = null;
+        $startSystem = null;
+        for ($g = 1; $g <= 9 && $galaxy === null; $g++) {
+            for ($start = 1; $start <= 490; $start++) {
+                $existingCount = DB::table('planets')
+                    ->where('galaxy', $g)
+                    ->whereBetween('system', [$start, $start + 9])
+                    ->count();
+                if ($existingCount === 0) {
+                    $galaxy = $g;
+                    $startSystem = $start;
+                    break;
+                }
+            }
+        }
 
-        $from = new Coordinate(9, 1, 1);
-        $to = new Coordinate(9, 10, 1);
+        if ($galaxy === null || $startSystem === null) {
+            $this->fail('Could not find 10 consecutive empty systems in any galaxy for testing.');
+        }
+
+        // Create planets in systems startSystem, startSystem+2, startSystem+4 (leaving others empty)
+        $p1 = Planet::factory()->create(['user_id' => $user->id, 'galaxy' => $galaxy, 'system' => $startSystem, 'planet' => 1]);
+        $p2 = Planet::factory()->create(['user_id' => $user->id, 'galaxy' => $galaxy, 'system' => $startSystem + 2, 'planet' => 1]);
+        $p3 = Planet::factory()->create(['user_id' => $user->id, 'galaxy' => $galaxy, 'system' => $startSystem + 4, 'planet' => 1]);
+        $this->createdPlanetIds = [$p1->id, $p2->id, $p3->id];
+
+        $from = new Coordinate($galaxy, $startSystem, 1);
+        $to = new Coordinate($galaxy, $startSystem + 9, 1);
 
         $result = $this->calculator->getNumEmptySystems($from, $to);
 
-        // Systems 1-10: occupied are 1, 3, 5 = 3 occupied
-        // Total systems = 10 - 1 + 1 = 10
+        // Systems startSystem to startSystem+9: 3 occupied (startSystem, startSystem+2, startSystem+4), 10 total
         // Empty = 10 - 3 = 7
         $this->assertEquals(7, $result);
     }


### PR DESCRIPTION
## Description
This PR changes `CoordinateDistanceCalculatorTest` to query the database for 10 free systems throughout all 9 galaxies instead of the previous hardcoded coordinates. The test now also cleans up after itself via `teardDown()` method to ensure no subsequent test pollution.

### Type of Change:
- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #1265 

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [X] **Automated Refactoring:** Rector has been run and no outstanding issues remain.
- [X] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [X] **Static Analysis:** Code passes PHPStan static code analysis.
- [X] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [X] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.

