### PR TITLE
Wrap defender ships in array in battle report

### DIFF
--- a/resources/views/ingame/messages/templates/battle_report_full.blade.php
+++ b/resources/views/ingame/messages/templates/battle_report_full.blade.php
@@ -638,11 +638,11 @@
                         "lossesInThisRound": null,
                         "statistic": {"hits": 0, "absorbedDamage": 0, "fullStrength": 0},
                         "losses": null,
-                        "ships": {
+                        "ships": [{
 @foreach ($defender_units_start->units as $unit)
                             "{{ $unit->unitObject->id }}": {{ $unit->amount }},
 @endforeach
-                        }
+                        }]
                     },
                     // Actual rounds starting from round 1.
 @foreach ($rounds as $round)


### PR DESCRIPTION
Description
This PR corrects the JSON structure for defender ships in the battle report template. Previously, the ships data was emitted as a single object, which caused inconsistencies with the frontend expectations and limited the ability to display multiple ship entries per defender.

Changes made:

Modified resources/views/ingame/messages/templates/battle_report_full.blade.php.

Changed the output of the defender ships from an object { ... } to an array containing that object [{ ... }].

Purpose:
This change ensures the backend output aligns with the expected frontend data format. It resolves issues where the ship count at the "start" of the round would display incorrectly or fail to render properly when multiple ship types or entries were present for a defender.

Type of Change:
[x] Bug fix

[ ] Feature enhancement

[ ] Documentation update

[ ] Other (please describe):

Related Issues
Fixes #1052

Checklist
[x] Automated Refactoring: Rector has been run.

[x] Code Standards: Verified with Laravel Pint (PSR-12).

[x] Static Analysis: PHPStan passed.

[x] Testing:

Confirmed that the "start" round now correctly displays the initial ship count.

Verified JSON output format in the battle report template.

[x] Documentation: The report template now accurately reflects the required data structure.

Additional Information
By wrapping the ships object in an array, we ensure future-proofing for cases where a defender might have varied ship entries or when the frontend iterates over the ship list.

**First Round :**
<img width="1394" height="649" alt="image" src="https://github.com/user-attachments/assets/b71d3e95-8863-4f84-82fd-3b9db3041182" />
**Second Round :**
<img width="1369" height="655" alt="image" src="https://github.com/user-attachments/assets/c221cb7a-64f3-40a7-97cd-bb6f0103089e" />
