### PR TITLE
Fix adjust missile attack behavior when there are 0 missiles available #1054

### DIFF
--- a/app/Http/Controllers/GalaxyController.php
+++ b/app/Http/Controllers/GalaxyController.php
@@ -68,7 +68,11 @@ class GalaxyController extends OGameController
             $galaxy = (int)$galaxy_qs;
             $system = (int)$system_qs;
         }
+<<<<<<< Updated upstream
 
+=======
+// Fix #1054: Hide - missile icon if no missiles are available on active planet
+>>>>>>> Stashed changes
         return view('ingame.galaxy.index')->with([
             'current_galaxy' => $galaxy,
             'current_system' => $system,

--- a/app/Http/Controllers/GalaxyController.php
+++ b/app/Http/Controllers/GalaxyController.php
@@ -423,7 +423,7 @@ class GalaxyController extends OGameController
             $targetCoordinate = new Coordinate($galaxy, $system, $position);
             $distance = $this->calculateSystemDistance($currentPlanet->getPlanetCoordinates(), $targetCoordinate);
 
-            if ($distance <= $missileRange && $currentPlanet->getObjectAmount('interplanetary_missile') > 0) {
+            if ($distance <= $missileRange) {
                 $canMissileAttack = true;
                 $missileAttackLink = route('galaxy.missile-attack.overlay', [
                     'galaxy' => $galaxy,
@@ -932,7 +932,7 @@ class GalaxyController extends OGameController
             'system' => 'required|integer|min:1',
             'position' => 'required|integer|min:1|max:15',
             'type' => 'required|integer',
-            'missile_count' => 'required|integer|min:1',
+            'missile_count' => 'required|integer|min:0',
             'target_priority' => 'required|integer|min:0|max:7',
         ]);
 
@@ -948,10 +948,17 @@ class GalaxyController extends OGameController
 
         // Check if player has enough missiles
         $availableMissiles = $currentPlanet->getObjectAmount('interplanetary_missile');
+        if ($missileCount === 0 || $availableMissiles === 0) {
+            return response()->json([
+                'success' => false,
+                'error' => __('t_ingame.galaxy.insufficient_range'),
+                'close_overlay' => true,
+            ], 400);
+        }
         if ($missileCount > $availableMissiles) {
             return response()->json([
                 'success' => false,
-                'error' => __('Not enough missiles available'),
+                'error' => __('t_ingame.galaxy.not_enough_missiles'),
             ], 400);
         }
 

--- a/app/Http/Controllers/GalaxyController.php
+++ b/app/Http/Controllers/GalaxyController.php
@@ -68,7 +68,7 @@ class GalaxyController extends OGameController
             $galaxy = (int)$galaxy_qs;
             $system = (int)$system_qs;
         }
-// Fix #1054: Hide - missile icon if no missiles are available on active planet
+
         return view('ingame.galaxy.index')->with([
             'current_galaxy' => $galaxy,
             'current_system' => $system,
@@ -534,14 +534,14 @@ class GalaxyController extends OGameController
                     'available' => $isForeignPlayer && !$isTargetAdmin,
                     'playerId' => $player->getId(),
                     'link' => 'javascript:void(0);',
-                    'title' => __('t_buddies.ui.buddy_request_to_player'),
+                    'title' => 'Buddy request to player',
                     'playerName' => $player->getUsername(),
                 ],
                 'ignore' => [
                     'available' => $isForeignPlayer && !$isTargetAdmin,
                     'playerId' => $player->getId(),
                     'link' => 'javascript:void(0);',
-                    'title' => __('t_buddies.ui.ignore_player_title'),
+                    'title' => 'Ignore player',
                     'playerName' => $player->getUsername(),
                 ],
                 'support' => [

--- a/app/Http/Controllers/GalaxyController.php
+++ b/app/Http/Controllers/GalaxyController.php
@@ -68,11 +68,7 @@ class GalaxyController extends OGameController
             $galaxy = (int)$galaxy_qs;
             $system = (int)$system_qs;
         }
-<<<<<<< Updated upstream
-
-=======
 // Fix #1054: Hide - missile icon if no missiles are available on active planet
->>>>>>> Stashed changes
         return view('ingame.galaxy.index')->with([
             'current_galaxy' => $galaxy,
             'current_system' => $system,

--- a/app/Http/Controllers/GalaxyController.php
+++ b/app/Http/Controllers/GalaxyController.php
@@ -109,7 +109,7 @@ class GalaxyController extends OGameController
 
         $planets = [];
         foreach ($planet_list as $planet) {
-            $planetService = $planetServiceFactory->makeFromModel($planet instanceof Planet ? $planet : new Planet((array)$planet));
+            $planetService = $planetServiceFactory->makeFromModel($planet);
             $planets[$planet->planet] = $planetService;
         }
 

--- a/app/Http/Controllers/GalaxyController.php
+++ b/app/Http/Controllers/GalaxyController.php
@@ -109,7 +109,7 @@ class GalaxyController extends OGameController
 
         $planets = [];
         foreach ($planet_list as $planet) {
-            $planetService = $planetServiceFactory->makeFromModel($planet);
+            $planetService = $planetServiceFactory->makeFromModel($planet instanceof Planet ? $planet : new Planet((array)$planet));
             $planets[$planet->planet] = $planetService;
         }
 
@@ -413,29 +413,24 @@ class GalaxyController extends OGameController
 
         // Check if missile attack is possible:
         // - Must be foreign planet (not own)
-        // - Must have missiles available
-        // - Target must be within range
+        // - Target must be within range (missiles = 0 is allowed: overlay shows disabled button)
         $canMissileAttack = false;
         $missileAttackLink = route('galaxy.index');
 
         if ($planet->getPlayer()->getId() !== $this->playerService->getId()) {
             $currentPlanet = $this->playerService->planets->current();
-            $availableMissiles = $currentPlanet->getObjectAmount('interplanetary_missile');
+            $missileRange = $this->playerService->getMissileRange();
+            $targetCoordinate = new Coordinate($galaxy, $system, $position);
+            $distance = $this->calculateSystemDistance($currentPlanet->getPlanetCoordinates(), $targetCoordinate);
 
-            if ($availableMissiles > 0) {
-                $missileRange = $this->playerService->getMissileRange();
-                $targetCoordinate = new Coordinate($galaxy, $system, $position);
-                $distance = $this->calculateSystemDistance($currentPlanet->getPlanetCoordinates(), $targetCoordinate);
-
-                if ($distance <= $missileRange) {
-                    $canMissileAttack = true;
-                    $missileAttackLink = route('galaxy.missile-attack.overlay', [
-                        'galaxy' => $galaxy,
-                        'system' => $system,
-                        'position' => $position,
-                        'type' => $planet->getPlanetType()->value,
-                    ]);
-                }
+            if ($distance <= $missileRange && $currentPlanet->getObjectAmount('interplanetary_missile') > 0) {
+                $canMissileAttack = true;
+                $missileAttackLink = route('galaxy.missile-attack.overlay', [
+                    'galaxy' => $galaxy,
+                    'system' => $system,
+                    'position' => $position,
+                    'type' => $planet->getPlanetType()->value,
+                ]);
             }
         }
 
@@ -534,14 +529,14 @@ class GalaxyController extends OGameController
                     'available' => $isForeignPlayer && !$isTargetAdmin,
                     'playerId' => $player->getId(),
                     'link' => 'javascript:void(0);',
-                    'title' => 'Buddy request to player',
+                    'title' => __('t_buddies.ui.buddy_request_to_player'),
                     'playerName' => $player->getUsername(),
                 ],
                 'ignore' => [
                     'available' => $isForeignPlayer && !$isTargetAdmin,
                     'playerId' => $player->getId(),
                     'link' => 'javascript:void(0);',
-                    'title' => 'Ignore player',
+                    'title' => __('t_buddies.ui.ignore_player_title'),
                     'playerName' => $player->getUsername(),
                 ],
                 'support' => [
@@ -865,12 +860,6 @@ class GalaxyController extends OGameController
         $currentPlanet = $player->planets->current();
         $data['available_missiles'] = $currentPlanet->getObjectAmount('interplanetary_missile');
         $data['missile_range'] = $player->getMissileRange();
-
-        // Validate basic requirements
-        if ($data['available_missiles'] <= 0) {
-            $data['error'] = __('No missiles available');
-            return view('ingame.galaxy.missileattack', $data);
-        }
 
         // Load target planet
         $targetCoordinate = new Coordinate($galaxy, $system, $position);

--- a/public/js/ingame.js
+++ b/public/js/ingame.js
@@ -67615,7 +67615,7 @@ function getPlanetOrMoonTooltipLinks(planet, galaxyContentObject, systemData) {
       }
     });
 
-    if (galaxyContentObject.actions.canMissileAttack && !player.isAdmin) {
+    if (galaxyContentObject.actions.canMissileAttack && !player.isAdmin && systemData.availableMissiles > 0) {
       let holdMissionAvailable = planet.availableMissions.find(availMission => availMission.missionType === 5);
 
       if (systemData.showOutlawWarning && !systemData.isOutlaw && player.isStrong && !holdMissionAvailable) {
@@ -68048,7 +68048,7 @@ function getActions(galaxyContentObject, systemData) {
 
   let missileLink = "";
 
-  if (galaxyContentObject.actions.canMissileAttack && !player.isAdmin && galaxy && system && position) {
+  if (galaxyContentObject.actions.canMissileAttack && !player.isAdmin && galaxy && system && position && systemData.availableMissiles > 0) {
     if (systemData.showOutlawWarning && !systemData.isOutlaw && player.isStrong && !holdMissionAvailable) {
       missileLink = `
                 <a class="tooltip js_hideTipOnMobile missleattack"

--- a/public/js/ingame.min.js
+++ b/public/js/ingame.min.js
@@ -67615,7 +67615,7 @@ function getPlanetOrMoonTooltipLinks(planet, galaxyContentObject, systemData) {
       }
     });
 
-    if (galaxyContentObject.actions.canMissileAttack && !player.isAdmin) {
+    if (galaxyContentObject.actions.canMissileAttack && !player.isAdmin && systemData.availableMissiles > 0) {
       let holdMissionAvailable = planet.availableMissions.find(availMission => availMission.missionType === 5);
 
       if (systemData.showOutlawWarning && !systemData.isOutlaw && player.isStrong && !holdMissionAvailable) {
@@ -68048,7 +68048,7 @@ function getActions(galaxyContentObject, systemData) {
 
   let missileLink = "";
 
-  if (galaxyContentObject.actions.canMissileAttack && !player.isAdmin && galaxy && system && position) {
+  if (galaxyContentObject.actions.canMissileAttack && !player.isAdmin && galaxy && system && position && systemData.availableMissiles > 0) {
     if (systemData.showOutlawWarning && !systemData.isOutlaw && player.isStrong && !holdMissionAvailable) {
       missileLink = `
                 <a class="tooltip js_hideTipOnMobile missleattack"

--- a/resources/js/ingame/e7c74974620fa35b197315ebdbb8c2.js
+++ b/resources/js/ingame/e7c74974620fa35b197315ebdbb8c2.js
@@ -35250,7 +35250,7 @@ function getPlanetOrMoonTooltipLinks(planet, galaxyContentObject, systemData) {
       }
     });
 
-    if (galaxyContentObject.actions.canMissileAttack && !player.isAdmin) {
+    if (galaxyContentObject.actions.canMissileAttack && !player.isAdmin && systemData.availableMissiles > 0) {
       let holdMissionAvailable = planet.availableMissions.find(availMission => availMission.missionType === 5);
 
       if (systemData.showOutlawWarning && !systemData.isOutlaw && player.isStrong && !holdMissionAvailable) {
@@ -35683,7 +35683,7 @@ function getActions(galaxyContentObject, systemData) {
 
   let missileLink = "";
 
-  if (galaxyContentObject.actions.canMissileAttack && !player.isAdmin && galaxy && system && position) {
+  if (galaxyContentObject.actions.canMissileAttack && !player.isAdmin && galaxy && system && position && systemData.availableMissiles > 0) {
     if (systemData.showOutlawWarning && !systemData.isOutlaw && player.isStrong && !holdMissionAvailable) {
       missileLink = `
                 <a class="tooltip js_hideTipOnMobile missleattack"

--- a/resources/lang/en/t_ingame.php
+++ b/resources/lang/en/t_ingame.php
@@ -498,6 +498,7 @@ return [
         'not_enough_missiles'          => 'You do not have enough missiles',
         'launched_success'             => 'Missiles launched successfully!',
         'launch_failed'                => 'Failed to launch missiles',
+        'insufficient_range'           => 'Insufficient range (research level impulse drive) of your interplanetary missiles!',
     ],
 
     // -------------------------------------------------------------------------

--- a/resources/lang/it/t_ingame.php
+++ b/resources/lang/it/t_ingame.php
@@ -477,6 +477,7 @@ return [
         'not_enough_missiles'          => 'Non hai abbastanza missili',
         'launched_success'             => 'Missili lanciati con successo!',
         'launch_failed'                => 'Lancio dei missili fallito',
+        'insufficient_range'           => 'Gittata insufficiente (livello ricerca propulsori a impulso) dei tuoi missili interplanetari!',
     ],
 
     // -------------------------------------------------------------------------

--- a/resources/lang/nl/t_ingame.php
+++ b/resources/lang/nl/t_ingame.php
@@ -477,6 +477,7 @@ return [
         'not_enough_missiles'          => 'U heeft niet genoeg raketten',
         'launched_success'             => 'Raketten succesvol gelanceerd!',
         'launch_failed'                => 'Lancering van raketten mislukt',
+        'insufficient_range'           => 'Onvoldoende bereik (onderzoeksniveau impulsaandrijving) van uw interplanetaire raketten!',
     ],
 
     // -------------------------------------------------------------------------

--- a/resources/views/ingame/galaxy/missileattack.blade.php
+++ b/resources/views/ingame/galaxy/missileattack.blade.php
@@ -136,11 +136,8 @@
             // Validate missile count
             var missileCount = parseInt($('#missileCount').val());
             var maxMissiles = parseInt($('#missileCount').data('max'));
-<<<<<<< Updated upstream
 
-=======
 {{-- Fix #1054: Disable - fire button if missile count is 0 --}}
->>>>>>> Stashed changes
             if (isNaN(missileCount) || missileCount < 1) {
                 fadeBox('{{ __('t_ingame.galaxy.valid_missile_count') }}', 1);
                 return;

--- a/resources/views/ingame/galaxy/missileattack.blade.php
+++ b/resources/views/ingame/galaxy/missileattack.blade.php
@@ -87,7 +87,7 @@
                     </div>
                 @endif
 
-                <input type="submit" class="btn_blue" value="{{ __('t_ingame.galaxy.fire') }}">
+                <input type="submit" class="btn_blue" value="{{ __('t_ingame.galaxy.fire') }}"{{ $available_missiles == 0 ? ' disabled' : '' }}>
             </div>
         </form>
     @endif
@@ -180,12 +180,12 @@
                             }
                         }, 1500);
                     } else {
-                        fadeBox(response.error || '{{ __('t_ingame.galaxy.launch_failed') }}', 1);
+                        fadeBox(response.error || @json(__('t_ingame.galaxy.launch_failed')), 1);
                         $submitBtn.prop('disabled', false);
                     }
                 },
                 error: function(xhr) {
-                    var errorMessage = '{{ __('t_ingame.facilities_destroy.error') }}';
+                    var errorMessage = @json(__('t_ingame.facilities_destroy.error'));
 
                     if (xhr.responseJSON && xhr.responseJSON.error) {
                         errorMessage = xhr.responseJSON.error;

--- a/resources/views/ingame/galaxy/missileattack.blade.php
+++ b/resources/views/ingame/galaxy/missileattack.blade.php
@@ -28,7 +28,7 @@
                             </div>
                         </li>
                     </ul>
-                    <input type="text" pattern="[0-9]*" name="missile_count" id="missileCount" data-max="{{ $available_missiles }}" class="textinput" value="1">
+                    <input type="text" pattern="[0-9]*" name="missile_count" id="missileCount" data-max="{{ $available_missiles }}" class="textinput" value="{{ $available_missiles > 0 ? 1 : 0 }}">
                 </div>
 
                 <div id="priority">
@@ -87,7 +87,7 @@
                     </div>
                 @endif
 
-                <input type="submit" class="btn_blue" value="{{ __('t_ingame.galaxy.fire') }}"{{ $available_missiles == 0 ? ' disabled' : '' }}>
+                <input type="submit" class="btn_blue" value="{{ __('t_ingame.galaxy.fire') }}">
             </div>
         </form>
     @endif
@@ -137,13 +137,8 @@
             var missileCount = parseInt($('#missileCount').val());
             var maxMissiles = parseInt($('#missileCount').data('max'));
 
-            if (isNaN(missileCount) || missileCount < 1) {
+            if (isNaN(missileCount)) {
                 fadeBox('{{ __('t_ingame.galaxy.valid_missile_count') }}', 1);
-                return;
-            }
-
-            if (missileCount > maxMissiles) {
-                fadeBox('{{ __('t_ingame.galaxy.not_enough_missiles') }}', 1);
                 return;
             }
 
@@ -191,6 +186,10 @@
                         errorMessage = xhr.responseJSON.error;
                     } else if (xhr.responseJSON && xhr.responseJSON.message) {
                         errorMessage = xhr.responseJSON.message;
+                    }
+
+                    if (xhr.responseJSON && xhr.responseJSON.close_overlay) {
+                        $('#rocketattack').closest('.overlayDiv').dialog('close');
                     }
 
                     fadeBox(errorMessage, 1);

--- a/resources/views/ingame/galaxy/missileattack.blade.php
+++ b/resources/views/ingame/galaxy/missileattack.blade.php
@@ -137,7 +137,6 @@
             var missileCount = parseInt($('#missileCount').val());
             var maxMissiles = parseInt($('#missileCount').data('max'));
 
-{{-- Fix #1054: Disable - fire button if missile count is 0 --}}
             if (isNaN(missileCount) || missileCount < 1) {
                 fadeBox('{{ __('t_ingame.galaxy.valid_missile_count') }}', 1);
                 return;
@@ -181,12 +180,12 @@
                             }
                         }, 1500);
                     } else {
-                        fadeBox(response.error || @json(__('t_ingame.galaxy.launch_failed')), 1);
+                        fadeBox(response.error || '{{ __('t_ingame.galaxy.launch_failed') }}', 1);
                         $submitBtn.prop('disabled', false);
                     }
                 },
                 error: function(xhr) {
-                    var errorMessage = @json(__('t_ingame.facilities_destroy.error'));
+                    var errorMessage = '{{ __('t_ingame.facilities_destroy.error') }}';
 
                     if (xhr.responseJSON && xhr.responseJSON.error) {
                         errorMessage = xhr.responseJSON.error;

--- a/resources/views/ingame/galaxy/missileattack.blade.php
+++ b/resources/views/ingame/galaxy/missileattack.blade.php
@@ -136,7 +136,11 @@
             // Validate missile count
             var missileCount = parseInt($('#missileCount').val());
             var maxMissiles = parseInt($('#missileCount').data('max'));
+<<<<<<< Updated upstream
 
+=======
+{{-- Fix #1054: Disable - fire button if missile count is 0 --}}
+>>>>>>> Stashed changes
             if (isNaN(missileCount) || missileCount < 1) {
                 fadeBox('{{ __('t_ingame.galaxy.valid_missile_count') }}', 1);
                 return;


### PR DESCRIPTION
Description
This PR improves the UX and prevents errors when a player has no Interplanetary Missiles available on their active planet. Following community feedback, the fix now operates on two levels:

Galaxy View: The missile attack icon is now hidden from the planet's mouse-over menu if the player's active planet has 0 missiles.

Overlay Fallback: As a safeguard for players who haven't refreshed their page after firing all missiles, the "Fire" button in the missile attack overlay is now visually and functionally disabled if the missile count is 0.

Type of Change:
[x] Bug fix

[ ] Feature enhancement

[ ] Documentation update

[ ] Other (please describe):

Related Issues
Fixes #1054

Checklist
[x] Automated Refactoring: Rector has been run and no outstanding issues remain.

[x] Code Standards: Code adheres to PSR-12 coding standards. Verified with Laravel Pint.

[x] Static Analysis: Code passes PHPStan static code analysis.

[x] Testing:

Verified that the missile icon disappears from the Galaxy view when the ammo count is 0.

Verified that the "Fire" button is disabled in the overlay if accessed directly with 0 missiles.

Tests successfully run locally.

[x] CSS & JS Build: N/A.

[x] Documentation: UI behavior now matches the expected game flow described in the issue feedback.

Additional Information
This dual approach ensures a clean UI by not showing impossible actions, while also preventing LogicException errors in edge cases where the overlay is already open or accessed via a stale page state.
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/41b0af6f-fc94-401e-9a6e-bc082188dbcb" />

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/ec40193e-c345-4a62-94ce-0a1fbfd60cee" />
