### PR TITLE
fix: prevent wrong object types from entering build queues

### DIFF
--- a/app/Http/Controllers/Abstracts/AbstractUnitsController.php
+++ b/app/Http/Controllers/Abstracts/AbstractUnitsController.php
@@ -153,7 +153,14 @@ abstract class AbstractUnitsController extends OGameController
         $building_id = $request->input('technologyId');
         $amount = $request->input('amount');
 
-        $this->queue->add($player->planets->current(), $building_id, $amount);
+        try {
+            $this->queue->add($player->planets->current(), $building_id, $amount);
+        } catch (Exception $e) {
+            return response()->json([
+                'success' => false,
+                'message' => $e->getMessage(),
+            ]);
+        }
 
         return response()->json([
             'status' => 'success',

--- a/app/Http/Controllers/ResearchController.php
+++ b/app/Http/Controllers/ResearchController.php
@@ -176,7 +176,15 @@ class ResearchController extends OGameController
         }
 
         $building_id = $request->input('technologyId');
-        $this->queue->add($player, $player->planets->current(), $building_id);
+
+        try {
+            $this->queue->add($player, $player->planets->current(), $building_id);
+        } catch (Exception $e) {
+            return response()->json([
+                'success' => false,
+                'message' => $e->getMessage(),
+            ]);
+        }
 
         return response()->json([
             'status' => 'success',

--- a/app/Services/BuildingQueueService.php
+++ b/app/Services/BuildingQueueService.php
@@ -80,6 +80,11 @@ class BuildingQueueService
         // Check if user satisfies requirements to build this object.
         $building = ObjectService::getObjectById($building_id);
 
+        // Only buildings and stations can be added to the building queue.
+        if ($building->type !== GameObjectType::Building && $building->type !== GameObjectType::Station) {
+            throw new Exception('Only buildings and stations can be added to the building queue.');
+        }
+
         // Check if building can be built on this planet type (planet or moon).
         $correct_planet_type = ObjectService::objectValidPlanetType($building->machine_name, $planet);
         if (!$correct_planet_type) {
@@ -114,7 +119,7 @@ class BuildingQueueService
 
         // Check if planet has enough fields for this building (only for buildings that consume fields)
         // Ships, defense units, and certain other objects don't consume planet fields
-        if (($building->type === GameObjectType::Building || $building->type === GameObjectType::Station) && $building->consumesPlanetField) {
+        if ($building->consumesPlanetField) {
             $currentBuildingCount = $planet->getBuildingCount();
             $maxFields = $planet->getPlanetFieldMax();
 

--- a/app/Services/PlanetService.php
+++ b/app/Services/PlanetService.php
@@ -6,6 +6,7 @@ use Exception;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use OGame\Factories\PlanetServiceFactory;
 use OGame\Factories\PlayerServiceFactory;
 use OGame\GameObjects\Models\Abstracts\GameObject;
@@ -1440,8 +1441,19 @@ class PlanetService
                 // Check if this is a downgrade
                 $is_downgrade = $item->is_downgrade ?? false;
 
-                // Update building level
-                $this->setObjectLevel($item->object_id, $item->object_level_target, $save_planet);
+                // Update building level. If the object type is invalid (e.g. a research object somehow
+                // ended up in the building queue due to a prior bug), skip it gracefully. The item is
+                // already marked processed above, so it will not be retried on the next page load.
+                try {
+                    $this->setObjectLevel($item->object_id, $item->object_level_target, $save_planet);
+                } catch (RuntimeException $e) {
+                    Log::error('Building queue item skipped due to invalid object type.', [
+                        'planet_id' => $this->getPlanetId(),
+                        'object_id' => $item->object_id,
+                        'object_level_target' => $item->object_level_target,
+                        'error' => $e->getMessage(),
+                    ]);
+                }
 
                 // Update production/storage stats for subsequent resource calculations
                 $this->updateResourceProductionStats(false);
@@ -1486,6 +1498,11 @@ class PlanetService
     public function setObjectLevel(int $object_id, int $level, bool $save_planet = true): void
     {
         $object = ObjectService::getObjectById($object_id);
+
+        if ($object->type !== GameObjectType::Building && $object->type !== GameObjectType::Station) {
+            throw new RuntimeException('setObjectLevel() can only be used for buildings and stations, not: ' . $object->machine_name);
+        }
+
         $this->planet->{$object->machine_name} = $level;
         if ($save_planet) {
             $this->save();

--- a/app/Services/ResearchQueueService.php
+++ b/app/Services/ResearchQueueService.php
@@ -5,6 +5,7 @@ namespace OGame\Services;
 use Exception;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Date;
+use OGame\GameObjects\Models\Enums\GameObjectType;
 use OGame\Models\ResearchQueue;
 use OGame\Models\Resources;
 use OGame\ViewModels\Queue\ResearchQueueListViewModel;
@@ -117,7 +118,12 @@ class ResearchQueueService
             throw new Exception('Maximum number of items already in queue.');
         }
 
-        $object = ObjectService::getResearchObjectById($research_object_id);
+        $object = ObjectService::getObjectById($research_object_id);
+
+        // Only research objects can be added to the research queue.
+        if ($object->type !== GameObjectType::Research) {
+            throw new Exception('Only research objects can be added to the research queue.');
+        }
 
         // @TODO: add checks that current logged in user is owner of planet
         // and is able to add this object to the research queue.

--- a/app/Services/UnitQueueService.php
+++ b/app/Services/UnitQueueService.php
@@ -6,6 +6,7 @@ use Exception;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Date;
+use OGame\GameObjects\Models\Enums\GameObjectType;
 use OGame\Models\UnitQueue;
 use OGame\ViewModels\Queue\UnitQueueListViewModel;
 use OGame\ViewModels\Queue\UnitQueueViewModel;
@@ -165,7 +166,12 @@ class UnitQueueService
             return;
         }
 
-        $object = ObjectService::getUnitObjectById($object_id);
+        $object = ObjectService::getObjectById($object_id);
+
+        // Only ships and defense units can be added to the unit queue.
+        if ($object->type !== GameObjectType::Ship && $object->type !== GameObjectType::Defense) {
+            throw new Exception('Only ships and defense units can be added to the unit queue.');
+        }
 
         // Check if user satisifes requirements to build this object.
         $requirements_met = ObjectService::objectRequirementsMet($object->machine_name, $planet);

--- a/tests/Feature/BuildQueueTest.php
+++ b/tests/Feature/BuildQueueTest.php
@@ -639,4 +639,41 @@ class BuildQueueTest extends AccountTestCase
             "Starting: $starting_metal, Current: $current_metal"
         );
     }
+
+    /**
+     * Verify that adding a research object to the building queue is rejected.
+     * This is a regression test for a bug where plasma_technology (id=122) could be
+     * added to building_queues via a crafted HTTP request, then written to the planets
+     * table causing "Unknown column 'plasma_technology' in 'field list'" SQL errors.
+     *
+     * @throws Exception
+     */
+    public function testBuildQueueRejectsResearchObject(): void
+    {
+        // Get the plasma_technology research object (id=122).
+        $researchObject = ObjectService::getObjectByMachineName('plasma_technology');
+
+        // Attempt to add plasma_technology to the building queue via the resources endpoint.
+        $response = $this->post('/resources/add-buildrequest', [
+            '_token' => csrf_token(),
+            'technologyId' => $researchObject->id,
+        ]);
+
+        // The response should indicate failure, not success.
+        $response->assertStatus(200);
+        $responseData = $response->json();
+        $this->assertFalse($responseData['success'], 'Adding a research object to the building queue should be rejected.');
+
+        // Verify that no building queue entry was created for the research object.
+        $queueEntry = BuildingQueue::where('planet_id', $this->planetService->getPlanetId())
+            ->where('object_id', $researchObject->id)
+            ->first();
+        $this->assertNull($queueEntry, 'A building queue entry should not have been created for a research object.');
+
+        // Verify that the planet model does not have plasma_technology set as a dirty attribute.
+        // Travel forward in time to trigger planet update.
+        $this->travel(1)->hours();
+        $response = $this->get('/resources');
+        $response->assertStatus(200);
+    }
 }

--- a/tests/Feature/ResearchQueueTest.php
+++ b/tests/Feature/ResearchQueueTest.php
@@ -4,7 +4,9 @@ namespace Tests\Feature;
 
 use Exception;
 use Illuminate\Contracts\Container\BindingResolutionException;
+use OGame\Models\ResearchQueue;
 use OGame\Models\Resources;
+use OGame\Services\ObjectService;
 use OGame\Services\SettingsService;
 use Tests\AccountTestCase;
 
@@ -329,5 +331,34 @@ class ResearchQueueTest extends AccountTestCase
         $response = $this->get('/research');
         $response->assertStatus(200);
         $this->assertObjectLevelOnPage($response, 'hyperspace_drive', 21, 'Hyperspace Drive is not at level 21 after research time has passed.');
+    }
+
+    /**
+     * Verify that adding a building object to the research queue is rejected.
+     * Only research-type objects should be accepted by the research queue.
+     *
+     * @throws Exception
+     */
+    public function testResearchQueueRejectsBuildingObject(): void
+    {
+        // Get a building object (metal_mine).
+        $buildingObject = ObjectService::getObjectByMachineName('metal_mine');
+
+        // Attempt to add the building to the research queue via the research endpoint.
+        $response = $this->post('/research/add-buildrequest', [
+            '_token' => csrf_token(),
+            'technologyId' => $buildingObject->id,
+        ]);
+
+        // The response should indicate failure, not success.
+        $response->assertStatus(200);
+        $responseData = $response->json();
+        $this->assertFalse($responseData['success'], 'Adding a building object to the research queue should be rejected.');
+
+        // Verify that no research queue entry was created for the building object.
+        $queueEntry = ResearchQueue::where('planet_id', $this->planetService->getPlanetId())
+            ->where('object_id', $buildingObject->id)
+            ->first();
+        $this->assertNull($queueEntry, 'A research queue entry should not have been created for a building object.');
     }
 }

--- a/tests/Feature/UnitQueueTest.php
+++ b/tests/Feature/UnitQueueTest.php
@@ -4,6 +4,8 @@ namespace Tests\Feature;
 
 use Exception;
 use OGame\Models\Resources;
+use OGame\Models\UnitQueue;
+use OGame\Services\ObjectService;
 use OGame\Services\SettingsService;
 use Tests\AccountTestCase;
 
@@ -557,5 +559,35 @@ class UnitQueueTest extends AccountTestCase
         // Verify ship is in queue
         $response = $this->get('/shipyard');
         $response->assertStatus(200);
+    }
+
+    /**
+     * Verify that adding a research object to the unit queue is rejected.
+     * Only ship and defense objects should be accepted by the unit queue.
+     *
+     * @throws Exception
+     */
+    public function testUnitQueueRejectsResearchObject(): void
+    {
+        // Get a research object (plasma_technology).
+        $researchObject = ObjectService::getObjectByMachineName('plasma_technology');
+
+        // Attempt to add the research object to the unit queue via the shipyard endpoint.
+        $response = $this->post('/shipyard/add-buildrequest', [
+            '_token' => csrf_token(),
+            'technologyId' => $researchObject->id,
+            'amount' => 1,
+        ]);
+
+        // The response should indicate failure, not success.
+        $response->assertStatus(200);
+        $responseData = $response->json();
+        $this->assertFalse($responseData['success'], 'Adding a research object to the unit queue should be rejected.');
+
+        // Verify that no unit queue entry was created for the research object.
+        $queueEntry = UnitQueue::where('planet_id', $this->planetService->getPlanetId())
+            ->where('object_id', $researchObject->id)
+            ->first();
+        $this->assertNull($queueEntry, 'A unit queue entry should not have been created for a research object.');
     }
 }


### PR DESCRIPTION
## Description
This PR fixes an issue by which a research object could end up in the building queue. It also contains a fix to unblock affected players without manual database intervention.

A crafted HTTP request could insert a research object ID (e.g. `plasma_technology`) into `building_queues`. When the queue timer expired, `setObjectLevel()` would write the attribute to the `Planet` Eloquent model and `save()` would attempt `UPDATE planets SET plasma_technology = 1`, hitting an "Unknown column" SQL error. Because the queue item was never marked as processed, every subsequent page load re-triggered the error, leaving the player permanently stuck.                                                                                                                                               

### Changes

**`BuildingQueueService`**: added an explicit type guard rejecting any object that isn't a `Building` or `Station`.                                                                                         
  
**`PlanetService::setObjectLevel()`**: added the same guard as a backstop, so even a corrupt entry already in the database cannot write a bad attribute to the planet model.                                
                                                            
**`PlanetService::updateBuildingQueue()`**: wraps `setObjectLevel()` in a try/catch so any corrupt entries that exist in production are skipped and marked processed rather than retried on every page load. This unblocks affected players on next login without a manual DB fix.
                                                                                                                                                                                                               
**`ResearchQueueService` and `UnitQueueService`**: these were already incidentally safe because they used type-specific object lookups (`getResearchObjectById`, `getUnitObjectById`) that happen to throw on a type mismatch. That safety was a side effect of implementation detail. Switched both to `getObjectById` + an explicit type guard to make the contract clear and consistent across all three queues.                                                                                                                                                                                                      
                                                            
**Controllers**: `ResearchController` and `AbstractUnitsController` lacked try/catch on `addBuildRequest()`, so a rejected queue add would surface as a 500. Both now return a structured JSON failure.     
  
**Tests**: regression tests added to `BuildQueueTest`, `ResearchQueueTest`, and `UnitQueueTest` verifying that each queue rejects the wrong object type and creates no queue entry.                          

### Type of Change:
- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #1272

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [X] **Automated Refactoring:** Rector has been run and no outstanding issues remain.
- [X] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [X] **Static Analysis:** Code passes PHPStan static code analysis.
- [X] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [X] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [X] **Documentation:** Documentation has been updated to reflect any changes made.