### PR TITLE
fix: correct expedition target display to Deep space

### DIFF
--- a/app/Http/Controllers/FleetController.php
+++ b/app/Http/Controllers/FleetController.php
@@ -301,14 +301,8 @@ class FleetController extends OGameController
             $targetCoordinates = $targetPlanet->getPlanetCoordinates();
         } else {
             $targetPlayerId = 99999;
-            // Position 16 is the expedition/deep space position
-            if ($position === UniverseConstants::EXPEDITION_POSITION) {
-                $targetPlanetName = 'Deep space';
-                $targetPlayerName = 'Deep space';
-            } else {
-                $targetPlanetName = '?';
-                $targetPlayerName = 'Deep space';
-            }
+            $targetPlanetName = 'Deep space';
+            $targetPlayerName = 'Deep space';
             $targetCoordinates = new Coordinate($galaxy, $system, $position);
             $targetInhabited = false;
         }


### PR DESCRIPTION
## Description
This PR fixes a small error when selecting expeditions as the mission type. It now shows the correct string `Deep space` as the target instead of the previous `?`.

### Type of Change:
- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #1279 

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [X] **Automated Refactoring:** Rector has been run and no outstanding issues remain.
- [X] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [X] **Static Analysis:** Code passes PHPStan static code analysis.
- [X] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [X] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [X] **Documentation:** Documentation has been updated to reflect any changes made.