### PR TITLE
feat: enforce alliance_combat_system_on setting for ACS missions

### DIFF
--- a/app/GameMissions/AcsDefendMission.php
+++ b/app/GameMissions/AcsDefendMission.php
@@ -34,6 +34,11 @@ class AcsDefendMission extends GameMission
             return $parentCheck;
         }
 
+        // ACS is disabled on this server.
+        if (!$this->settings->allianceCombatSystemOn()) {
+            return new MissionPossibleStatus(false, __('ACS is disabled on this server.'));
+        }
+
         // ACS Defend mission is only possible for planets and moons.
         if (!in_array($targetType, [PlanetType::Planet, PlanetType::Moon])) {
             return new MissionPossibleStatus(false);

--- a/app/Http/Controllers/FleetController.php
+++ b/app/Http/Controllers/FleetController.php
@@ -361,7 +361,7 @@ class FleetController extends OGameController
         // ACS Attack (type 2) is enabled when the player has selected a union, Attack (type 1) is possible,
         // and the fleet can reach the target within the union's max delay time at 100% speed.
         $unionId = (int)request()->input('union');
-        if ($unionId > 0 && in_array(1, $enabledMissions, true)) {
+        if ($settingsService->allianceCombatSystemOn() && $unionId > 0 && in_array(1, $enabledMissions, true)) {
             $union = FleetUnion::find($unionId);
             if ($union !== null
                 && $union->galaxy_to === $targetCoordinates->galaxy
@@ -800,8 +800,12 @@ class FleetController extends OGameController
      * @param FleetUnionService $fleetUnionService
      * @return JsonResponse
      */
-    public function createUnion(PlayerService $player, FleetUnionService $fleetUnionService, MessageService $messageService): JsonResponse
+    public function createUnion(PlayerService $player, FleetUnionService $fleetUnionService, MessageService $messageService, SettingsService $settingsService): JsonResponse
     {
+        if (!$settingsService->allianceCombatSystemOn()) {
+            return response()->json(['error' => __('ACS is disabled on this server.')], 403);
+        }
+
         $validated = request()->validate([
             'fleet_mission_id' => 'nullable|integer|exists:fleet_missions,id',
             'fleetID' => 'nullable|integer|exists:fleet_missions,id',
@@ -991,8 +995,12 @@ class FleetController extends OGameController
      * @param FleetUnionService $fleetUnionService
      * @return JsonResponse
      */
-    public function joinUnion(PlayerService $player, FleetUnionService $fleetUnionService): JsonResponse
+    public function joinUnion(PlayerService $player, FleetUnionService $fleetUnionService, SettingsService $settingsService): JsonResponse
     {
+        if (!$settingsService->allianceCombatSystemOn()) {
+            return response()->json(['error' => __('ACS is disabled on this server.')], 403);
+        }
+
         $validated = request()->validate([
             'fleet_mission_id' => 'required|integer|exists:fleet_missions,id',
             'union_id' => 'required|integer|exists:fleet_unions,id',

--- a/tests/Feature/FleetDispatch/FleetDispatchAcsAttackTest.php
+++ b/tests/Feature/FleetDispatch/FleetDispatchAcsAttackTest.php
@@ -1264,4 +1264,102 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
             'Union time_arrival must be updated to reflect the latest fleet arrival'
         );
     }
+
+    /**
+     * Verify that union creation is blocked when ACS is disabled by server settings.
+     */
+    public function testAcsDisabledBlocksUnionCreation(): void
+    {
+        $this->basicSetup();
+        $this->createTargetPlayer();
+
+        $unitCollection = new UnitCollection();
+        $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 10);
+        $this->dispatchFleet($this->targetPlanet->getPlanetCoordinates(), $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet);
+
+        $fleetMissionService = resolve(FleetMissionService::class);
+        $mission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+
+        $settingsService = resolve(SettingsService::class);
+        $settingsService->set('alliance_combat_system_on', 0);
+
+        $response = $this->post('/ajax/fleet/union/create', [
+            'fleetID' => $mission->id,
+            'groupname' => 'TestUnion',
+            '_token' => csrf_token(),
+        ]);
+        $response->assertStatus(403);
+
+        $settingsService->set('alliance_combat_system_on', 1);
+
+        // Mission should still be type 1 (not converted to ACS Attack)
+        $mission->refresh();
+        $this->assertEquals(1, $mission->mission_type, 'Mission should remain type 1 when union creation is blocked by ACS setting.');
+    }
+
+    /**
+     * Verify that joining a union is blocked when ACS is disabled by server settings.
+     */
+    public function testAcsDisabledBlocksUnionJoining(): void
+    {
+        $this->basicSetup();
+
+        $settingsService = resolve(SettingsService::class);
+        $settingsService->set('alliance_combat_system_on', 0);
+
+        $response = $this->post('/ajax/fleet/union/join', [
+            'fleet_mission_id' => 999999,
+            'union_id' => 999999,
+            '_token' => csrf_token(),
+        ]);
+        $response->assertStatus(403);
+
+        $settingsService->set('alliance_combat_system_on', 1);
+    }
+
+    /**
+     * Verify that ACS Attack (type 2) is not offered in mission options when ACS is disabled.
+     */
+    public function testAcsDisabledHidesAcsAttackFromCheckTarget(): void
+    {
+        $this->basicSetup();
+        $this->createTargetPlayer();
+
+        // Send attack and create a union while ACS is on
+        $unitCollection = new UnitCollection();
+        $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 10);
+        $this->dispatchFleet($this->targetPlanet->getPlanetCoordinates(), $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet);
+
+        $fleetMissionService = resolve(FleetMissionService::class);
+        $mission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+
+        $this->post('/ajax/fleet/union/create', [
+            'fleetID' => $mission->id,
+            'groupname' => 'TestUnion',
+            '_token' => csrf_token(),
+        ]);
+        $mission->refresh();
+        $unionId = $mission->union_id;
+
+        // Disable ACS
+        $settingsService = resolve(SettingsService::class);
+        $settingsService->set('alliance_combat_system_on', 0);
+
+        $lightFighterObj = ObjectService::getUnitObjectByMachineName('light_fighter');
+        $response = $this->post('/ajax/fleet/dispatch/check-target', [
+            'galaxy' => $this->targetPlanet->getPlanetCoordinates()->galaxy,
+            'system' => $this->targetPlanet->getPlanetCoordinates()->system,
+            'position' => $this->targetPlanet->getPlanetCoordinates()->position,
+            'type' => PlanetType::Planet->value,
+            'mission' => 1,
+            'union' => $unionId,
+            '_token' => csrf_token(),
+            'am' . $lightFighterObj->id => 5,
+        ]);
+
+        $settingsService->set('alliance_combat_system_on', 1);
+
+        $response->assertStatus(200);
+        $response->assertJson(['orders' => [2 => false]]);
+    }
 }

--- a/tests/Feature/FleetDispatch/FleetDispatchAcsDefendTest.php
+++ b/tests/Feature/FleetDispatch/FleetDispatchAcsDefendTest.php
@@ -1213,6 +1213,50 @@ class FleetDispatchAcsDefendTest extends FleetDispatchTestCase
     }
 
     /**
+     * Verify that ACS Defend dispatch is blocked when ACS is disabled by server settings.
+     *
+     * Uses planet slot 7 (distinct from the planet 8 used by createBuddyPlayer) to avoid
+     * coordinate collisions when the planet allocator wraps around in large test suite runs.
+     */
+    public function testAcsDisabledBlocksAcsDefendDispatch(): void
+    {
+        $this->basicSetup();
+
+        // Create a buddy inline at planet slot 7 to avoid colliding with the planet 8
+        // coordinate used by createBuddyPlayer() in this class and FleetDispatchMultiDefenderBattleTest.
+        $buddyUser = User::factory()->create();
+        self::$allCreatedBuddyUserIds[] = $buddyUser->id;
+
+        $buddyPlanet = Planet::factory()->create([
+            'user_id' => $buddyUser->id,
+            'galaxy' => $this->planetService->getPlanetCoordinates()->galaxy,
+            'system' => min(499, $this->planetService->getPlanetCoordinates()->system + 5),
+            'planet' => 7,
+        ]);
+
+        $planetServiceFactory = resolve(PlanetServiceFactory::class);
+        $buddyPlayerService = resolve(PlayerService::class, ['player_id' => $buddyUser->id]);
+        $acsBlockBuddyPlanet = $planetServiceFactory->makeForPlayer($buddyPlayerService, $buddyPlanet->id);
+
+        $buddyService = resolve(BuddyService::class);
+        $request = $buddyService->sendRequest($this->currentUserId, $buddyUser->id);
+        $buddyService->acceptRequest($request->id, $buddyUser->id);
+
+        $settingsService = resolve(SettingsService::class);
+        $settingsService->set('alliance_combat_system_on', 0);
+
+        $unitCollection = new UnitCollection();
+        $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 2);
+        $this->dispatchFleet($acsBlockBuddyPlanet->getPlanetCoordinates(), $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet, 0, false);
+
+        $settingsService->set('alliance_combat_system_on', 1);
+
+        // Ships should still be on planet (mission was rejected)
+        $response = $this->get('/shipyard');
+        $this->assertObjectLevelOnPage($response, 'light_fighter', 5, 'Ships should not have been dispatched when ACS is disabled.');
+    }
+
+    /**
      * Create a player that is neither buddy nor alliance member.
      *
      * @return User The non-affiliated user


### PR DESCRIPTION
## Description
This PR makes the ACS enabled setting in server settings functional and adds two feature tests to prevent regressions in the future.

### Type of Change:
- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #1299 

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [X] **Automated Refactoring:** Rector has been run and no outstanding issues remain.
- [X] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [X] **Static Analysis:** Code passes PHPStan static code analysis.
- [X] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [X] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [X] **Documentation:** Documentation has been updated to reflect any changes made.
