### PR TITLE
[FIX] Deathstar missing rapid fire against new ships

### DIFF
--- a/app/GameObjects/MilitaryShipObjects.php
+++ b/app/GameObjects/MilitaryShipObjects.php
@@ -252,6 +252,8 @@ class MilitaryShipObjects
             new GameObjectRapidfire('ion_cannon', 100),
             new GameObjectRapidfire('gauss_cannon', 50),
             new GameObjectRapidfire('battlecruiser', 15),
+            new GameObjectRapidfire('pathfinder', 30),
+            new GameObjectRapidfire('reaper', 10),
             new GameObjectRapidfire('crawler', 250),
         ];
         $deathstar->properties = new GameObjectProperties($deathstar, 9000000, 50000, 200000, 100, 1000000, 1);


### PR DESCRIPTION
Add two GameObjectRapidfire entries to MilitaryShipObjects.php for the Death Star's rapidfire list: 'pathfinder' with value 30 and 'reaper' with value 10. This updates the Death Star's counters against those ship types for combat/balance purposes.

## Description
Please include a summary of the changes made to OGameX and their purpose. Clearly describe what this PR does and why it is necessary.

### Type of Change:
- [ ] Bug fix
- [ x ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #1213 

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [ ] **Automated Refactoring:** Rector has been run and no outstanding issues remain.
- [ ] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [ ] **Static Analysis:** Code passes PHPStan static code analysis.
- [ ] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [ ] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [ ] **Documentation:** Documentation has been updated to reflect any changes made.

## Additional Information
<img width="1090" height="817" alt="image" src="https://github.com/user-attachments/assets/ef517f3f-9747-4fbf-9b1c-2dff9a8b3d28" />
