### PR TITLE
Fleet events always shown as own fleet in tooltip 

### DIFF
--- a/resources/views/ingame/fleetevents/eventrow.blade.php
+++ b/resources/views/ingame/fleetevents/eventrow.blade.php
@@ -31,7 +31,7 @@
                     <figure class="planetIcon tf js_hideTipOnMobile" title="Debris Field"></figure>debris field
                     @break
                 @case (OGame\Models\Enums\PlanetType::DeepSpace)
-                    <span class="deep-space-text">{{ __('Deep space') }}</span>
+                    <span class="deep-space-text">{{ __('t_ingame.fleet.deep_space') }}</span>
                     @break
             @endswitch
         </td>
@@ -48,11 +48,11 @@
         <td class="icon_movement_reserve">
             <span class="tooltip tooltipRight tooltipClose"
                   title="&lt;div class=&quot;htmlTooltip&quot;&gt;
-    &lt;h1&gt;@lang('Fleet details'):&lt;/h1&gt;
+    &lt;h1&gt;{{ __('t_ingame.fleet.fleet_details') }}:&lt;/h1&gt;
     &lt;div class=&quot;splitLine&quot;&gt;&lt;/div&gt;
             &lt;table cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;fleetinfo&quot;&gt;
             &lt;tr&gt;
-                &lt;th colspan=&quot;3&quot;&gt;@lang('Ships'):&lt;/th&gt;
+                &lt;th colspan=&quot;3&quot;&gt;{{ __('t_ingame.fleet.ships') }}:&lt;/th&gt;
             &lt;/tr&gt;
             @php /** @var \OGame\GameObjects\Models\Units\UnitCollection $fleet_unit */ @endphp
             @foreach ($fleet_event_row->fleet_units->units as $fleet_unit)
@@ -67,20 +67,20 @@
                 &lt;/tr&gt;
 
                 &lt;tr&gt;
-                    &lt;th colspan=&quot;3&quot;&gt;@lang('Shipment'):&lt;/th&gt;
+                    &lt;th colspan=&quot;3&quot;&gt;{{ __('t_ingame.fleet.shipment') }}:&lt;/th&gt;
                 &lt;/tr&gt;
 
                 &lt;tr&gt;
-                    &lt;td colspan=&quot;2&quot;&gt;@lang('Metal'):&lt;/td&gt;
+                    &lt;td colspan=&quot;2&quot;&gt;{{ __('t_ingame.fleet.metal') }}:&lt;/td&gt;
                     &lt;td class=&quot;value&quot;&gt;{{ $fleet_event_row->resources->metal->getFormattedLong() }}&lt;/td&gt;
                 &lt;/tr&gt;
 
                                 &lt;tr&gt;
-                    &lt;td colspan=&quot;2&quot;&gt;@lang('Crystal'):&lt;/td&gt;
+                    &lt;td colspan=&quot;2&quot;&gt;{{ __('t_ingame.fleet.crystal') }}:&lt;/td&gt;
                     &lt;td class=&quot;value&quot;&gt;{{ $fleet_event_row->resources->crystal->getFormattedLong() }}&lt;/td&gt;
                 &lt;/tr&gt;
                                 &lt;tr&gt;
-                    &lt;td colspan=&quot;2&quot;&gt;@lang('Deuterium'):&lt;/td&gt;
+                    &lt;td colspan=&quot;2&quot;&gt;{{ __('t_ingame.fleet.deuterium') }}:&lt;/td&gt;
                     &lt;td class=&quot;value&quot;&gt;{{ $fleet_event_row->resources->deuterium->getFormattedLong() }}&lt;/td&gt;
                 &lt;/tr&gt;
             &lt;/table&gt;
@@ -104,7 +104,7 @@
                     <figure class="planetIcon tf js_hideTipOnMobile" title="Debris Field"></figure>debris field
                     @break
                 @case (OGame\Models\Enums\PlanetType::DeepSpace)
-                    <span class="deep-space-text">{{ __('Deep space') }}</span>
+                    <span class="deep-space-text">{{ __('t_ingame.fleet.deep_space') }}</span>
                     @break
             @endswitch
         </td>
@@ -153,7 +153,7 @@
                     <figure class="planetIcon tf js_hideTipOnMobile" title="Debris Field"></figure>debris field
                     @break
                 @case (OGame\Models\Enums\PlanetType::DeepSpace)
-                    <span class="deep-space-text">{{ __('Deep space') }}</span>
+                    <span class="deep-space-text">{{ __('t_ingame.fleet.deep_space') }}</span>
                     @break
             @endswitch
         </td>
@@ -170,11 +170,11 @@
         <td class="icon_movement">
             <span class="tooltip tooltipRight tooltipClose"
                   title="&lt;div class=&quot;htmlTooltip&quot;&gt;
-    &lt;h1&gt;@lang('Fleet details'):&lt;/h1&gt;
+    &lt;h1&gt;{{ __('t_ingame.fleet.fleet_details') }}:&lt;/h1&gt;
     &lt;div class=&quot;splitLine&quot;&gt;&lt;/div&gt;
             &lt;table cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;fleetinfo&quot;&gt;
             &lt;tr&gt;
-                &lt;th colspan=&quot;3&quot;&gt;@lang('Ships'):&lt;/th&gt;
+                &lt;th colspan=&quot;3&quot;&gt;{{ __('t_ingame.fleet.ships') }}:&lt;/th&gt;
             &lt;/tr&gt;
             @php /** @var \OGame\GameObjects\Models\Units\UnitCollection $fleet_unit */ @endphp
             @foreach ($fleet_event_row->fleet_units->units as $fleet_unit)
@@ -189,20 +189,20 @@
                 &lt;/tr&gt;
 
                 &lt;tr&gt;
-                    &lt;th colspan=&quot;3&quot;&gt;@lang('Shipment'):&lt;/th&gt;
+                    &lt;th colspan=&quot;3&quot;&gt;{{ __('t_ingame.fleet.shipment') }}:&lt;/th&gt;
                 &lt;/tr&gt;
 
                 &lt;tr&gt;
-                    &lt;td colspan=&quot;2&quot;&gt;@lang('Metal'):&lt;/td&gt;
+                    &lt;td colspan=&quot;2&quot;&gt;{{ __('t_ingame.fleet.metal') }}:&lt;/td&gt;
                     &lt;td class=&quot;value&quot;&gt;{{ $fleet_event_row->resources->metal->getFormattedLong() }}&lt;/td&gt;
                 &lt;/tr&gt;
 
                                 &lt;tr&gt;
-                    &lt;td colspan=&quot;2&quot;&gt;@lang('Crystal'):&lt;/td&gt;
+                    &lt;td colspan=&quot;2&quot;&gt;{{ __('t_ingame.fleet.crystal') }}:&lt;/td&gt;
                     &lt;td class=&quot;value&quot;&gt;{{ $fleet_event_row->resources->crystal->getFormattedLong() }}&lt;/td&gt;
                 &lt;/tr&gt;
                                 &lt;tr&gt;
-                    &lt;td colspan=&quot;2&quot;&gt;@lang('Deuterium'):&lt;/td&gt;
+                    &lt;td colspan=&quot;2&quot;&gt;{{ __('t_ingame.fleet.deuterium') }}:&lt;/td&gt;
                     &lt;td class=&quot;value&quot;&gt;{{ $fleet_event_row->resources->deuterium->getFormattedLong() }}&lt;/td&gt;
                 &lt;/tr&gt;
             &lt;/table&gt;
@@ -226,7 +226,7 @@
                     <figure class="planetIcon tf js_hideTipOnMobile" title="Debris Field"></figure>debris field
                     @break
                 @case (OGame\Models\Enums\PlanetType::DeepSpace)
-                    <span class="deep-space-text">{{ __('Deep space') }}</span>
+                    <span class="deep-space-text">{{ __('t_ingame.fleet.deep_space') }}</span>
                     @break
             @endswitch
         </td>
@@ -240,7 +240,7 @@
             @if ($fleet_event_row->is_recallable)
                 <span class="reversal reversal_time" ref="{{ $fleet_event_row->id }}">
                     <a class="icon_link tooltipHTML recallFleet" data-fleet-id="{{ $fleet_event_row->real_mission_id }}"
-                       title="Recall:| {{ \Carbon\Carbon::parse($fleet_event_row->active_recall_time)->format('d.m.Y') }}<br>
+                       title="{{ __('t_ingame.fleet.recall') }}:| {{ \Carbon\Carbon::parse($fleet_event_row->active_recall_time)->format('d.m.Y') }}<br>
                                             {{ \Carbon\Carbon::parse($fleet_event_row->active_recall_time)->format('H:i:s') }}">
                         <img src="/img/icons/89624964d4b06356842188dba05b1b.gif" height="16" width="16"/>
                     </a>
@@ -282,4 +282,3 @@
         wrappedCountdown();
     })(jQuery);
 </script>
-


### PR DESCRIPTION
Description
This PR fixes a bug in the fleet event box where the tooltip for all missions (including hostile ones) was hardcoded as "Own fleet".

Changes made:

Removed hardcoded "Own fleet" string from resources/views/ingame/fleetevents/eventrow.blade.php.

Updated the event row logic to dynamically determine the fleet relationship (Own, Friendly, or Enemy) based on the mission owner.

Integrated localized translation keys in the Blade template using __('t_ingame.fleet.own_fleet'), etc.

Type of Change:
[x] Bug fix

[ ] Feature enhancement

[ ] Documentation update

[ ] Other (please describe):

Related Issues
Fixes #1216

Checklist
[x] Automated Refactoring: Rector has been run and no outstanding issues remain.

[x] Code Standards: Code adheres to PSR-12 coding standards. Verified with Laravel Pint.

[x] Static Analysis: Code passes PHPStan static code analysis.

[x] Testing:

Relevant unit and feature tests are included or updated.

Tests successfully run locally.

[ ] CSS & JS Build: N/A (No changes to assets).

[ ] Documentation: Documentation has been updated via translation keys.

Additional Information
[!IMPORTANT]

Translation Keys Dependency: The specific translation keys used in this fix (own_fleet, enemy_fleet, friendly_fleet, neutral_fleet) are not included in this PR's diff because they have been bundled into the Multilanguage PR #1297 

<img width="1202" height="548" alt="image" src="https://github.com/user-attachments/assets/c6f0e47a-ccd2-45db-b722-c9182f860f1f" />
