### PR TITLE
fix(scrapyard): parse locale-formatted ship counts correctly

### DIFF
--- a/resources/views/ingame/merchant/scrap.blade.php
+++ b/resources/views/ingame/merchant/scrap.blade.php
@@ -370,7 +370,7 @@
             });
 
             $validInputs.each(function() {
-                var val = parseInt($(this).val().replace(/,/g, '')) || 0;
+                var val = parseInt($(this).val().replace(/[,.]/g, '')) || 0;
 
                 if (val > 0) {
                     hasSelection = true;
@@ -426,7 +426,7 @@
                 }
 
                 var $input = $(this);
-                var val = parseInt($input.val().replace(/,/g, '')) || 0;
+                var val = parseInt($input.val().replace(/[,.]/g, '')) || 0;
 
                 if (val <= 0) {
                     return; // Skip empty inputs
@@ -449,7 +449,7 @@
 
             // Now validate ONLY the target input against remaining storage
             if (targetInput) {
-                var val = parseInt(targetInput.val().replace(/,/g, '')) || 0;
+                var val = parseInt(targetInput.val().replace(/[,.]/g, '')) || 0;
 
                 if (val > 0) {
                     var itemId = targetInput.attr('data-item-id');
@@ -552,7 +552,7 @@
 
             // Only collect from inputs with IDs (cloned inputs don't have IDs)
             $('.ship_amount[id]').each(function() {
-                var val = parseInt($(this).val().replace(/,/g, '')) || 0;
+                var val = parseInt($(this).val().replace(/[,.]/g, '')) || 0;
                 if (val > 0) {
                     var id = $(this).attr('name').replace('am', '');
                     items[id] = val;


### PR DESCRIPTION
## Description
This PR fixes a bug where ship counts were formatted using the browser's locale (`toLocaleString()`). In European locales this produces `300.000` instead of `300,000`. The input parser only stripped commas, so `parseInt("300.000")` returned `300` instead of `300000`.

### Type of Change:
- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #1273 

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [X] **Automated Refactoring:** Rector has been run and no outstanding issues remain.
- [X] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [X] **Static Analysis:** Code passes PHPStan static code analysis.
- [X] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [X] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [X] **Documentation:** Documentation has been updated to reflect any changes made.