### PR TITLE
fix: add processChangepassword() and translation keys

### DIFF
--- a/app/Http/Controllers/OptionsController.php
+++ b/app/Http/Controllers/OptionsController.php
@@ -5,6 +5,7 @@ namespace OGame\Http\Controllers;
 use Exception;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\View\View;
 use OGame\Services\PlayerService;
 
@@ -104,6 +105,43 @@ class OptionsController extends OGameController
     }
 
     /**
+     * Process password change request.
+     *
+     * @param Request $request
+     * @param PlayerService $player
+     * @return array<string,string>|null
+     */
+    public function processChangePassword(Request $request, PlayerService $player): array|null
+    {
+        $currentPassword = $request->input('db_password');
+
+        // Only process if the password section was submitted
+        if (empty($currentPassword)) {
+            return null;
+        }
+
+        $newPassword = $request->input('newpass1');
+        $confirmPassword = $request->input('newpass2');
+
+        if (!Hash::check($currentPassword, $player->getUser()->password)) {
+            return ['error' => __('t_ingame.options.msg_password_incorrect')];
+        }
+
+        if ($newPassword !== $confirmPassword) {
+            return ['error' => __('t_ingame.options.msg_password_mismatch')];
+        }
+
+        $length = strlen($newPassword);
+        if ($length < 4 || $length > 128) {
+            return ['error' => __('t_ingame.options.msg_password_length_invalid')];
+        }
+
+        $player->getUser()->forceFill(['password' => Hash::make($newPassword)])->save();
+
+        return ['success' => __('t_ingame.options.msg_settings_saved')];
+    }
+
+    /**
      * Process espionage probes amount save request.
      *
      * @param Request $request
@@ -150,6 +188,7 @@ class OptionsController extends OGameController
         // Define change handlers.
         $change_handlers = [
             'processChangeUsername',
+            'processChangePassword',
             'processVacationMode',
             'processEspionageProbesAmount'
         ];

--- a/resources/lang/en/t_ingame.php
+++ b/resources/lang/en/t_ingame.php
@@ -998,11 +998,11 @@ return [
         'password_strength_medium'                  => 'Medium',
         'password_strength_high'                    => 'High',
         'password_properties_title'                 => 'The password should contain the following properties',
-        'password_min_max'                          => 'min. 4 characters, max. 20 characters',
+        'password_min_max'                          => 'min. 4 characters, max. 128 characters',
         'password_mixed_case'                       => 'Upper and lower case',
         'password_special_chars'                    => 'Special characters (e.g. !?:_., )',
         'password_numbers'                          => 'Numbers',
-        'password_length_hint'                      => 'Your password needs to have at least <strong>4 characters</strong> and may not be longer than <strong>20 characters</strong>.',
+        'password_length_hint'                      => 'Your password needs to have at least <strong>4 characters</strong> and may not be longer than <strong>128 characters</strong>.',
 
         // Tab 1 – Email
         'section_email'                             => 'Email address',
@@ -1115,6 +1115,9 @@ return [
 
         // Controller messages
         'msg_settings_saved'                        => 'Settings saved',
+        'msg_password_incorrect'                    => 'The current password you entered is incorrect.',
+        'msg_password_mismatch'                     => 'The new passwords do not match.',
+        'msg_password_length_invalid'               => 'The new password must be between 4 and 128 characters.',
         'msg_vacation_activated'                    => 'Vacation mode has been activated. It will protect you from new attacks for a minimum of 48 hours.',
         'msg_vacation_deactivated'                  => 'Vacation mode has been deactivated.',
         'msg_vacation_min_duration'                 => 'You can only deactivate vacation mode after the minimum duration of 48 hours has passed.',

--- a/resources/lang/it/t_ingame.php
+++ b/resources/lang/it/t_ingame.php
@@ -973,11 +973,11 @@ return [
         'password_strength_medium'              => 'Media',
         'password_strength_high'                => 'Alta',
         'password_properties_title'             => 'La password dovrebbe contenere le seguenti proprietà',
-        'password_min_max'                      => 'min. 4 caratteri, max. 20 caratteri',
+        'password_min_max'                      => 'min. 4 caratteri, max. 128 caratteri',
         'password_mixed_case'                   => 'Lettere maiuscole e minuscole',
         'password_special_chars'                => 'Caratteri speciali (es. !?:_., )',
         'password_numbers'                      => 'Numeri',
-        'password_length_hint'                  => 'La tua password deve avere almeno <strong>4 caratteri</strong> e non può essere più lunga di <strong>20 caratteri</strong>.',
+        'password_length_hint'                  => 'La tua password deve avere almeno <strong>4 caratteri</strong> e non può essere più lunga di <strong>128 caratteri</strong>.',
 
         'section_email'                         => 'Indirizzo email',
         'current_email'                         => 'Indirizzo email attuale:',
@@ -1077,6 +1077,9 @@ return [
 
         // Messaggi controller
         'msg_settings_saved'                    => 'Impostazioni salvate',
+        'msg_password_incorrect'                => 'La password attuale inserita non è corretta.',
+        'msg_password_mismatch'                 => 'Le nuove password non coincidono.',
+        'msg_password_length_invalid'           => 'La nuova password deve essere compresa tra 4 e 128 caratteri.',
         'msg_vacation_activated'                => 'Modalità vacanza attivata. Ti proteggerà dai nuovi attacchi per un minimo di 48 ore.',
         'msg_vacation_deactivated'              => 'Modalità vacanza disattivata.',
         'msg_vacation_min_duration'             => 'Puoi disattivare la modalità vacanza solo dopo che è trascorsa la durata minima di 48 ore.',

--- a/resources/lang/nl/t_ingame.php
+++ b/resources/lang/nl/t_ingame.php
@@ -973,11 +973,11 @@ return [
         'password_strength_medium'              => 'Gemiddeld',
         'password_strength_high'                => 'Hoog',
         'password_properties_title'             => 'Het wachtwoord moet de volgende eigenschappen bevatten',
-        'password_min_max'                      => 'min. 4 tekens, max. 20 tekens',
+        'password_min_max'                      => 'min. 4 tekens, max. 128 tekens',
         'password_mixed_case'                   => 'Hoofd- en kleine letters',
         'password_special_chars'                => 'Speciale tekens (bijv. !?:_., )',
         'password_numbers'                      => 'Cijfers',
-        'password_length_hint'                  => 'Je wachtwoord moet minimaal <strong>4 tekens</strong> hebben en mag niet langer zijn dan <strong>20 tekens</strong>.',
+        'password_length_hint'                  => 'Je wachtwoord moet minimaal <strong>4 tekens</strong> hebben en mag niet langer zijn dan <strong>128 tekens</strong>.',
 
         'section_email'                         => 'E-mailadres',
         'current_email'                         => 'Huidig e-mailadres:',
@@ -1077,6 +1077,9 @@ return [
 
         // Controllerberichten
         'msg_settings_saved'                    => 'Instellingen opgeslagen',
+        'msg_password_incorrect'                => 'Het huidige wachtwoord dat je hebt ingevoerd is onjuist.',
+        'msg_password_mismatch'                 => 'De nieuwe wachtwoorden komen niet overeen.',
+        'msg_password_length_invalid'           => 'Het nieuwe wachtwoord moet tussen 4 en 128 tekens lang zijn.',
         'msg_vacation_activated'                => 'Vakantiemodus geactiveerd. Je wordt minimaal 48 uur beschermd tegen nieuwe aanvallen.',
         'msg_vacation_deactivated'              => 'Vakantiemodus gedeactiveerd.',
         'msg_vacation_min_duration'             => 'Je kunt de vakantiemodus pas deactiveren nadat de minimale duur van 48 uur is verstreken.',

--- a/resources/views/ingame/options/index.blade.php
+++ b/resources/views/ingame/options/index.blade.php
@@ -96,19 +96,19 @@
                                             <div class="fieldwrapper">
                                                 <label class="styled textBeefy">{{ __('t_ingame.options.old_password') }}</label>
                                                 <div class="thefield">
-                                                    <input class="textInput w200" type="password" value="" size="20" name="db_password" maxlength="20">
+                                                    <input class="textInput w200" type="password" value="" size="20" name="db_password" maxlength="128">
                                                 </div>
                                             </div>
                                             <div class="fieldwrapper">
                                                 <label class="styled textBeefy">{{ __('t_ingame.options.new_password') }}</label>
                                                 <div class="thefield">
-                                                    <input class="textInput w200 validate[optional,custom[pwMinSize],custom[pwMaxSize]]" type="password" maxlength="20" size="20" name="newpass1" id="newpass1">
+                                                    <input class="textInput w200 validate[optional,custom[pwMinSize],custom[pwMaxSize]]" type="password" maxlength="128" size="20" name="newpass1" id="newpass1">
                                                 </div>
                                             </div>
                                             <div class="fieldwrapper">
                                                 <label class="styled textBeefy">{{ __('t_ingame.options.repeat_password') }}</label>
                                                 <div class="thefield">
-                                                    <input class="textInput w200" type="password" maxlength="20" size="20" name="newpass2">
+                                                    <input class="textInput w200" type="password" maxlength="128" size="20" name="newpass2">
                                                 </div>
                                             </div>
                                             <div class="pw_check">
@@ -549,7 +549,7 @@
     <script type="text/javascript">
         $(document).ready(function () {
             passwordMinLength = 4;
-            passwordMaxLength = 20;
+            passwordMaxLength = 128;
             customSorting = 5;
             openGroup = 0;
             selectedTab = 0;

--- a/resources/views/outgame/layouts/main.blade.php
+++ b/resources/views/outgame/layouts/main.blade.php
@@ -191,7 +191,7 @@
                                onKeyDown="hideLoginErrorBox();"
                                id="passwordLogin"
                                name="password"
-                               maxlength="20"
+                               maxlength="128"
                         />
                     </div>
                 </div>
@@ -258,7 +258,7 @@
                                name="password"
                                autocomplete="new-password"
                                value="{{ old('password') }}"
-                               maxlength="20"
+                               maxlength="128"
                         />
                     </div>
 


### PR DESCRIPTION
## Description
This PR makes the password changeable for users, adds translation keys, and extends the hardcoded max length for passwords from 20 characters to 128 characters.

### Type of Change:
- [X] Bug fix
- [X] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #1318

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [X] **Automated Refactoring:** Rector has been run and no outstanding issues remain.
- [X] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [X] **Static Analysis:** Code passes PHPStan static code analysis.
- [X] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [x] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [X] **Documentation:** Documentation has been updated to reflect any changes made.
