### PR TITLE
fix: expedition merchant and black hole outcomes

### DIFF
--- a/app/GameMissions/ExpeditionMission.php
+++ b/app/GameMissions/ExpeditionMission.php
@@ -937,13 +937,17 @@ class ExpeditionMission extends GameMission
             return ExpeditionOutcomeType::Failed;
         }
 
-        // Pick a random number between 1 and total weight
-        $random = random_int(1, (int)$totalWeight);
+        // Scale weights to integers (multiply by 10) to avoid precision loss
+        // from casting float totals to int for random_int(). Without this,
+        // outcomes with small fractional weights (e.g. merchant 0.4, black_hole 0.2)
+        // can fall into sub-integer gaps in the cumulative range and become unreachable.
+        $scaledTotal = (int)round($totalWeight * 10);
+        $random = random_int(1, $scaledTotal);
 
         // Find which outcome was selected
         $currentWeight = 0;
         foreach ($weightedOutcomes as $weighted) {
-            $currentWeight += $weighted['weight'];
+            $currentWeight += (int)round($weighted['weight'] * 10);
             if ($random <= $currentWeight) {
                 return $weighted['outcome'];
             }

--- a/app/Http/Controllers/Admin/ServerSettingsController.php
+++ b/app/Http/Controllers/Admin/ServerSettingsController.php
@@ -128,16 +128,16 @@ class ServerSettingsController extends OGameController
         $settingsService->set('expedition_reward_multiplier_ships', request('expedition_reward_multiplier_ships', 1.0));
         $settingsService->set('expedition_reward_multiplier_dark_matter', request('expedition_reward_multiplier_dark_matter', 1.0));
         $settingsService->set('expedition_reward_multiplier_items', request('expedition_reward_multiplier_items', 1.0));
-        $settingsService->set('expedition_weight_ships', request('expedition_weight_ships', 22));
-        $settingsService->set('expedition_weight_resources', request('expedition_weight_resources', 32.5));
-        $settingsService->set('expedition_weight_delay', request('expedition_weight_delay', 7));
-        $settingsService->set('expedition_weight_speedup', request('expedition_weight_speedup', 2));
-        $settingsService->set('expedition_weight_nothing', request('expedition_weight_nothing', 26.5));
-        $settingsService->set('expedition_weight_black_hole', request('expedition_weight_black_hole', 0.3));
-        $settingsService->set('expedition_weight_pirates', request('expedition_weight_pirates', 0));
-        $settingsService->set('expedition_weight_aliens', request('expedition_weight_aliens', 0));
-        $settingsService->set('expedition_weight_dark_matter', request('expedition_weight_dark_matter', 9));
-        $settingsService->set('expedition_weight_merchant', request('expedition_weight_merchant', 0.7));
+        $settingsService->set('expedition_weight_ships', request('expedition_weight_ships', 17));
+        $settingsService->set('expedition_weight_resources', request('expedition_weight_resources', 35));
+        $settingsService->set('expedition_weight_delay', request('expedition_weight_delay', 7.5));
+        $settingsService->set('expedition_weight_speedup', request('expedition_weight_speedup', 2.75));
+        $settingsService->set('expedition_weight_nothing', request('expedition_weight_nothing', 25));
+        $settingsService->set('expedition_weight_black_hole', request('expedition_weight_black_hole', 0.2));
+        $settingsService->set('expedition_weight_pirates', request('expedition_weight_pirates', 3));
+        $settingsService->set('expedition_weight_aliens', request('expedition_weight_aliens', 1.5));
+        $settingsService->set('expedition_weight_dark_matter', request('expedition_weight_dark_matter', 7.5));
+        $settingsService->set('expedition_weight_merchant', request('expedition_weight_merchant', 0.4));
         $settingsService->set('expedition_weight_items', request('expedition_weight_items', 0));
 
         $settingsService->set('hamill_manoeuvre_chance', max(1, (int)request('hamill_probability', 1000)));

--- a/app/Services/SettingsService.php
+++ b/app/Services/SettingsService.php
@@ -565,7 +565,7 @@ class SettingsService
      */
     public function expeditionWeightShips(): float
     {
-        return (float)$this->get('expedition_weight_ships', '22');
+        return (float)$this->get('expedition_weight_ships', '17');
     }
 
     /**
@@ -575,7 +575,7 @@ class SettingsService
      */
     public function expeditionWeightResources(): float
     {
-        return (float)$this->get('expedition_weight_resources', '32.5');
+        return (float)$this->get('expedition_weight_resources', '35');
     }
 
     /**
@@ -585,7 +585,7 @@ class SettingsService
      */
     public function expeditionWeightDelay(): float
     {
-        return (float)$this->get('expedition_weight_delay', '7');
+        return (float)$this->get('expedition_weight_delay', '7.5');
     }
 
     /**
@@ -595,7 +595,7 @@ class SettingsService
      */
     public function expeditionWeightSpeedup(): float
     {
-        return (float)$this->get('expedition_weight_speedup', '2');
+        return (float)$this->get('expedition_weight_speedup', '2.75');
     }
 
     /**
@@ -605,7 +605,7 @@ class SettingsService
      */
     public function expeditionWeightNothing(): float
     {
-        return (float)$this->get('expedition_weight_nothing', '26.5');
+        return (float)$this->get('expedition_weight_nothing', '25');
     }
 
     /**
@@ -615,7 +615,7 @@ class SettingsService
      */
     public function expeditionWeightBlackHole(): float
     {
-        return (float)$this->get('expedition_weight_black_hole', '0.3');
+        return (float)$this->get('expedition_weight_black_hole', '0.2');
     }
 
     /**
@@ -645,7 +645,7 @@ class SettingsService
      */
     public function expeditionWeightDarkMatter(): float
     {
-        return (float)$this->get('expedition_weight_dark_matter', '9');
+        return (float)$this->get('expedition_weight_dark_matter', '7.5');
     }
 
     /**
@@ -655,7 +655,7 @@ class SettingsService
      */
     public function expeditionWeightMerchant(): float
     {
-        return (float)$this->get('expedition_weight_merchant', '0.7');
+        return (float)$this->get('expedition_weight_merchant', '0.4');
     }
 
     /**

--- a/database/migrations/2026_03_29_000000_fix_expedition_weight_redistribution.php
+++ b/database/migrations/2026_03_29_000000_fix_expedition_weight_redistribution.php
@@ -1,0 +1,57 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * Revert the redistributed weights back to official OGame percentages.
+     * When pirates, aliens, and items were originally disabled (weight 0), their
+     * combined 5% was redistributed across other outcomes. Now that pirates and
+     * aliens are enabled, the redistribution must be removed to avoid inflated totals.
+     */
+    public function up(): void
+    {
+        $weights = [
+            'expedition_weight_ships' => '17',          // was 17.9 (official: 17%)
+            'expedition_weight_resources' => '35',      // was 36.8 (official: 35%)
+            'expedition_weight_delay' => '7.5',         // was 7.9 (official: 7.5%)
+            'expedition_weight_speedup' => '2.75',      // was 2.9 (official: 2.75%)
+            'expedition_weight_nothing' => '25',        // was 26.3 (official: 25%)
+            'expedition_weight_dark_matter' => '7.5',   // was 7.9 (official: 7.5%)
+        ];
+
+        foreach ($weights as $key => $value) {
+            DB::table('settings')->where('key', $key)->update([
+                'value' => $value,
+                'updated_at' => now(),
+            ]);
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * Restore the redistributed weights.
+     */
+    public function down(): void
+    {
+        $weights = [
+            'expedition_weight_ships' => '17.9',
+            'expedition_weight_resources' => '36.8',
+            'expedition_weight_delay' => '7.9',
+            'expedition_weight_speedup' => '2.9',
+            'expedition_weight_nothing' => '26.3',
+            'expedition_weight_dark_matter' => '7.9',
+        ];
+
+        foreach ($weights as $key => $value) {
+            DB::table('settings')->where('key', $key)->update([
+                'value' => $value,
+                'updated_at' => now(),
+            ]);
+        }
+    }
+};

--- a/tests/Feature/FleetDispatch/FleetDispatchExpeditionTest.php
+++ b/tests/Feature/FleetDispatch/FleetDispatchExpeditionTest.php
@@ -957,16 +957,16 @@ class FleetDispatchExpeditionTest extends FleetDispatchTestCase
 
         // Ensure all weights are initialized with their defaults if not already set
         $defaultWeights = [
-            'expedition_weight_ships' => '22',
-            'expedition_weight_resources' => '32.5',
-            'expedition_weight_delay' => '7',
-            'expedition_weight_speedup' => '2',
-            'expedition_weight_nothing' => '26.5',
-            'expedition_weight_black_hole' => '0.3',
-            'expedition_weight_dark_matter' => '9',
-            'expedition_weight_merchant' => '0.7',
-            'expedition_weight_pirates' => '0',
-            'expedition_weight_aliens' => '0',
+            'expedition_weight_ships' => '17',
+            'expedition_weight_resources' => '35',
+            'expedition_weight_delay' => '7.5',
+            'expedition_weight_speedup' => '2.75',
+            'expedition_weight_nothing' => '25',
+            'expedition_weight_black_hole' => '0.2',
+            'expedition_weight_dark_matter' => '7.5',
+            'expedition_weight_merchant' => '0.4',
+            'expedition_weight_pirates' => '3',
+            'expedition_weight_aliens' => '1.5',
         ];
 
         foreach ($defaultWeights as $key => $defaultValue) {


### PR DESCRIPTION
## Description
This PR fixes an issue in which `selectRandomOutcome() `cast the float weight total to `int` for `random_int()`, truncating the upper bound. Outcomes with small fractional weights (merchant 0.4, black hole 0.2) fell into sub-integer gaps in the cumulative range and could never be selected. 

### Type of Change:
- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #1332 

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [X] **Automated Refactoring:** Rector has been run and no outstanding issues remain.
- [X] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [X] **Static Analysis:** Code passes PHPStan static code analysis.
- [X] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [X] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [X] **Documentation:** Documentation has been updated to reflect any changes made.