### PR TITLE
fix: Display Moon Destruction in fleet widget instead of Destroy

### DIFF
--- a/app/GameMissions/MoonDestructionMission.php
+++ b/app/GameMissions/MoonDestructionMission.php
@@ -67,7 +67,7 @@ class MoonDestructionMission extends GameMission
         }
 
         if ($deathstarCount === 0) {
-            return new MissionPossibleStatus(false, __('Destroy mission requires at least one Deathstar.'));
+            return new MissionPossibleStatus(false, __('Moon Destruction requires at least one Deathstar.'));
         }
 
         // If target player is in vacation mode, the mission is not possible.


### PR DESCRIPTION
## Description
This PR fixes the Moon Destruction display in the fleet widget and changes the error messages accordingly.

### Type of Change:
- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #1343 

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [X] **Automated Refactoring:** Rector has been run and no outstanding issues remain.
- [X] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [X] **Static Analysis:** Code passes PHPStan static code analysis.
- [X] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [X] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [X] **Documentation:** Documentation has been updated to reflect any changes made.