### PR TITLE
feat: Add acs attack loot distribution

### DIFF
--- a/app/GameMissions/AttackMission.php
+++ b/app/GameMissions/AttackMission.php
@@ -12,7 +12,6 @@ use OGame\GameMissions\BattleEngine\PhpBattleEngine;
 use OGame\GameMissions\BattleEngine\RustBattleEngine;
 use OGame\GameMissions\BattleEngine\Services\LootService;
 use OGame\GameMissions\Models\MissionPossibleStatus;
-use OGame\GameObjects\Models\Enums\GameObjectType;
 use OGame\GameObjects\Models\Units\UnitCollection;
 use OGame\Models\BattleReport;
 use OGame\Models\Enums\PlanetType;
@@ -227,10 +226,6 @@ class AttackMission extends GameMission
                     // Fleet survived - create return mission with survivors
                     $fleetOwner = $this->playerServiceFactory->make($fleetResult->playerId);
 
-                    // TODO: Calculate per-fleet loot share (proportional to surviving cargo capacity)
-                    // and surviving cargo (mission resources proportional to cargo survival rate).
-                    // Currently lootShare and survivingCargo are zero — loot/cargo distribution
-                    // across multiple ACS fleets is slated for a future PR.
                     // TODO: Include Reaper-collected debris share for multi-attacker battles.
                     // Currently Reaper debris collection only works for single-attacker path.
                     $totalResources = new Resources(

--- a/app/GameMissions/AttackMission.php
+++ b/app/GameMissions/AttackMission.php
@@ -310,6 +310,22 @@ class AttackMission extends GameMission
             }
         }
 
+        // For single-attacker battles, loot and carried resources already occupy part of the
+        // surviving fleet cargo. Cap automatic Reaper collection to only the remaining free
+        // space so excess debris stays in the debris field instead of disappearing.
+        if (count($battleResult->attackerFleetResults) === 1 && $attackerCollectedDebris->sum() > 0) {
+            $singleFleetResult = $battleResult->attackerFleetResults[0];
+            $remainingCargoCapacity = $battleResult->attackerUnitsResult->getTotalCargoCapacity($attackerPlayer);
+            $availableForCollectedDebris = max(
+                0,
+                (int)($remainingCargoCapacity - $singleFleetResult->survivingCargo->sum() - $singleFleetResult->lootShare->sum())
+            );
+
+            if ($attackerCollectedDebris->sum() > $availableForCollectedDebris) {
+                $attackerCollectedDebris = LootService::distributeLoot($attackerCollectedDebris, $availableForCollectedDebris);
+            }
+        }
+
         // Calculate remaining debris after attacker collection
         $debrisAfterAttackerCollection = new Resources(
             $battleResult->debris->metal->get() - $attackerCollectedDebris->metal->get(),
@@ -478,40 +494,19 @@ class AttackMission extends GameMission
             $mission->save();
 
             // Create and start the return mission (if single attacker has remaining units).
-            $originalCargoCapacity = $battleResult->attackerUnitsStart->getTotalCargoCapacity($attackerPlayer);
             $remainingCargoCapacity = $battleResult->attackerUnitsResult->getTotalCargoCapacity($attackerPlayer);
-
-            // Handle edge case: if original capacity is 0, survival rate is 0
-            $survivalRate = $originalCargoCapacity > 0
-                ? $remainingCargoCapacity / $originalCargoCapacity
-                : 0;
-
-            // Calculate resources remaining on surviving ships
-            $remainingResources = new Resources(
-                max(0, (int)($mission->metal * $survivalRate)),
-                max(0, (int)($mission->crystal * $survivalRate)),
-                max(0, (int)($mission->deuterium * $survivalRate)),
-                0
-            );
-
-            // Calculate loot remaining on surviving ships
-            // Loot is also subject to the survival rate (if cargo ships carrying loot are destroyed, loot is lost)
-            $remainingLoot = new Resources(
-                max(0, (int)($battleResult->loot->metal->get() * $survivalRate)),
-                max(0, (int)($battleResult->loot->crystal->get() * $survivalRate)),
-                max(0, (int)($battleResult->loot->deuterium->get() * $survivalRate)),
-                0
-            );
+            $singleFleetResult = $battleResult->attackerFleetResults[0];
 
             // Total resources = remaining mission resources + remaining loot + collected debris (from attacker Reapers)
             $totalResources = new Resources(
-                $remainingResources->metal->get() + $remainingLoot->metal->get() + $attackerCollectedDebris->metal->get(),
-                $remainingResources->crystal->get() + $remainingLoot->crystal->get() + $attackerCollectedDebris->crystal->get(),
-                $remainingResources->deuterium->get() + $remainingLoot->deuterium->get() + $attackerCollectedDebris->deuterium->get(),
+                $singleFleetResult->survivingCargo->metal->get() + $singleFleetResult->lootShare->metal->get() + $attackerCollectedDebris->metal->get(),
+                $singleFleetResult->survivingCargo->crystal->get() + $singleFleetResult->lootShare->crystal->get() + $attackerCollectedDebris->crystal->get(),
+                $singleFleetResult->survivingCargo->deuterium->get() + $singleFleetResult->lootShare->deuterium->get() + $attackerCollectedDebris->deuterium->get(),
                 0
             );
 
-            // Ensure total doesn't exceed remaining capacity
+            // Defensive cap only: loot and carried cargo are already normalized before we reach
+            // this point, so only edge-case rounding should ever hit this.
             if ($totalResources->sum() > $remainingCargoCapacity) {
                 $totalResources = LootService::distributeLoot($totalResources, $remainingCargoCapacity);
             }

--- a/app/GameMissions/BattleEngine/BattleEngine.php
+++ b/app/GameMissions/BattleEngine/BattleEngine.php
@@ -227,6 +227,9 @@ abstract class BattleEngine
             $result->loot = new Resources(0, 0, 0, 0);
         }
 
+        // Distribute loot and surviving cargo proportionally among each attacker fleet.
+        $this->distributeResources($result);
+
         // Calculate debris.
         // Only permanently lost defenses contribute to debris (destroyed - repaired).
         $permanentlyLostDefenderUnits = clone $result->defenderUnitsLost;
@@ -259,6 +262,92 @@ abstract class BattleEngine
      * @return array<BattleResultRound>
      */
     abstract protected function fightBattleRounds(BattleResult $result): array;
+
+    /**
+     * Populate survivingCargo and lootShare for each attacker fleet result.
+     *
+     * For multi-attacker battles, loot is allocated proportionally to each fleet's
+     * surviving cargo capacity. Carried resources survive at the same rate as cargo
+     * capacity (proportional to the fraction of ships that survived). Each fleet's
+     * loot share is further capped by the space remaining after surviving cargo is
+     * accounted for.
+     *
+     * Single-attacker battles are handled separately in AttackMission::processArrival()
+     * using the original single-fleet path, so this method is a no-op in that case.
+     *
+     * @param BattleResult $result
+     * @return void
+     */
+    private function distributeResources(BattleResult $result): void
+    {
+        if (count($this->attackers) <= 1) {
+            return;
+        }
+
+        // Index attacker fleets by fleet mission ID for efficient lookup.
+        $attackersByMissionId = [];
+        foreach ($this->attackers as $attacker) {
+            $attackersByMissionId[$attacker->fleetMissionId] = $attacker;
+        }
+
+        // Step 1: Compute per-fleet surviving cargo capacity and surviving carried resources.
+        $survivingCapacityByFleet = []; // fleetMissionId => int
+        $totalSurvivingCapacity = 0;
+
+        foreach ($result->attackerFleetResults as $fleetResult) {
+            $attacker = $attackersByMissionId[$fleetResult->fleetMissionId] ?? null;
+            if ($attacker === null || $fleetResult->completelyDestroyed) {
+                $survivingCapacityByFleet[$fleetResult->fleetMissionId] = 0;
+                $fleetResult->survivingCargo = new Resources(0, 0, 0, 0);
+                continue;
+            }
+
+            $originalCapacity = $attacker->getSurvivingCargoCapacity($attacker->units);
+            $survivingCapacity = $attacker->getSurvivingCargoCapacity($fleetResult->unitsResult);
+
+            $survivingCapacityByFleet[$fleetResult->fleetMissionId] = $survivingCapacity;
+            $totalSurvivingCapacity += $survivingCapacity;
+
+            // Carried resources survive at the same rate as cargo capacity.
+            $survivalRate = $originalCapacity > 0 ? $survivingCapacity / $originalCapacity : 0.0;
+            $fleetResult->survivingCargo = new Resources(
+                max(0, (int)($attacker->cargoResources->metal->get() * $survivalRate)),
+                max(0, (int)($attacker->cargoResources->crystal->get() * $survivalRate)),
+                max(0, (int)($attacker->cargoResources->deuterium->get() * $survivalRate)),
+                0
+            );
+        }
+
+        // Step 2: Distribute loot proportionally by surviving cargo capacity.
+        if ($totalSurvivingCapacity <= 0 || $result->loot->sum() <= 0) {
+            return;
+        }
+
+        foreach ($result->attackerFleetResults as $fleetResult) {
+            $survivingCapacity = $survivingCapacityByFleet[$fleetResult->fleetMissionId] ?? 0;
+            if ($survivingCapacity <= 0) {
+                continue;
+            }
+
+            $fraction = $survivingCapacity / $totalSurvivingCapacity;
+
+            // Raw proportional share of each resource type.
+            $lootShare = new Resources(
+                max(0, (int)($result->loot->metal->get() * $fraction)),
+                max(0, (int)($result->loot->crystal->get() * $fraction)),
+                max(0, (int)($result->loot->deuterium->get() * $fraction)),
+                0
+            );
+
+            // Cap to space remaining after surviving carried cargo is accounted for.
+            $availableForLoot = max(0, (int)($survivingCapacity - $fleetResult->survivingCargo->sum()));
+            if ($lootShare->sum() > $availableForLoot) {
+                $lootShare = LootService::distributeLoot($lootShare, $availableForLoot);
+            }
+
+            $fleetResult->lootShare = $lootShare;
+        }
+    }
 
     /**
      * Calculate the debris field based on the units lost in the battle.

--- a/app/GameMissions/BattleEngine/BattleEngine.php
+++ b/app/GameMissions/BattleEngine/BattleEngine.php
@@ -33,11 +33,6 @@ use OGame\Services\WreckFieldService;
 abstract class BattleEngine
 {
     /**
-     * @var LootService The service used to calculate the loot gained from a battle.
-     */
-    private LootService $lootService;
-
-    /**
      * @var int The percentage of loot that is gained from a battle.
      * Base is 50%, but Discoverer class gets 75% from inactive players.
      */
@@ -63,17 +58,6 @@ abstract class BattleEngine
         // Determine loot percentage based on character class and defender status
         $characterClassService = app(CharacterClassService::class);
         $this->lootPercentage = (int)($characterClassService->getInactiveLootPercentage($primaryAttacker->player->getUser()) * 100);
-
-        // Combine all attacker fleets for loot calculation
-        // TODO: In multi-attacker ACS battles, cargo capacity should be calculated per-fleet
-        // using each fleet owner's tech levels, then summed. Currently uses the initiator's
-        // tech for the combined fleet, which can over- or under-estimate total cargo capacity.
-        $combinedAttackerFleet = new UnitCollection();
-        foreach ($this->attackers as $attacker) {
-            $combinedAttackerFleet->addCollection($attacker->units);
-        }
-
-        $this->lootService = new LootService($combinedAttackerFleet, $primaryAttacker->player, $this->defenderPlanet, $this->lootPercentage);
     }
 
     /**
@@ -222,7 +206,7 @@ abstract class BattleEngine
             // ---
             // Check if the attacker has enough cargo capacity to carry the loot.
             // If not, reduce the loot to the cargo capacity.
-            $result->loot = $this->lootService->calculateLootCapacityConstrained();
+            $result->loot = $this->calculateLootCapacityConstrained();
         } else {
             $result->loot = new Resources(0, 0, 0, 0);
         }
@@ -264,6 +248,42 @@ abstract class BattleEngine
     abstract protected function fightBattleRounds(BattleResult $result): array;
 
     /**
+     * Calculate the battle loot constrained by the total cargo capacity of all attackers.
+     *
+     * For ACS battles, cargo capacity must be summed using each fleet owner's own research
+     * and class modifiers instead of evaluating a combined fleet against the initiator only.
+     *
+     * @return Resources
+     */
+    private function calculateLootCapacityConstrained(): Resources
+    {
+        $resources = $this->defenderPlanet->getResources();
+        $loot = new Resources(
+            max(0, $resources->metal->get()) * ($this->lootPercentage / 100),
+            max(0, $resources->crystal->get()) * ($this->lootPercentage / 100),
+            max(0, $resources->deuterium->get()) * ($this->lootPercentage / 100),
+            0
+        );
+
+        return LootService::distributeLoot($loot, $this->getTotalAttackerCargoCapacity());
+    }
+
+    /**
+     * Sum the cargo capacity of all attacking fleets using each fleet owner's modifiers.
+     *
+     * @return int
+     */
+    private function getTotalAttackerCargoCapacity(): int
+    {
+        $totalCapacity = 0;
+        foreach ($this->attackers as $attacker) {
+            $totalCapacity += $attacker->units->getTotalCargoCapacity($attacker->player);
+        }
+
+        return $totalCapacity;
+    }
+
+    /**
      * Populate survivingCargo and lootShare for each attacker fleet result.
      *
      * For multi-attacker battles, loot is allocated proportionally to each fleet's
@@ -272,18 +292,11 @@ abstract class BattleEngine
      * loot share is further capped by the space remaining after surviving cargo is
      * accounted for.
      *
-     * Single-attacker battles are handled separately in AttackMission::processArrival()
-     * using the original single-fleet path, so this method is a no-op in that case.
-     *
      * @param BattleResult $result
      * @return void
      */
-    private function distributeResources(BattleResult $result): void
+    protected function distributeResources(BattleResult $result): void
     {
-        if (count($this->attackers) <= 1) {
-            return;
-        }
-
         // Index attacker fleets by fleet mission ID for efficient lookup.
         $attackersByMissionId = [];
         foreach ($this->attackers as $attacker) {
@@ -316,37 +329,217 @@ abstract class BattleEngine
                 max(0, (int)($attacker->cargoResources->deuterium->get() * $survivalRate)),
                 0
             );
+
+            $fleetResult->lootShare = new Resources(0, 0, 0, 0);
         }
 
         // Step 2: Distribute loot proportionally by surviving cargo capacity.
         if ($totalSurvivingCapacity <= 0 || $result->loot->sum() <= 0) {
+            $result->loot = $this->sumLootShares($result);
+            return;
+        }
+
+        $remainingLootCapacityByFleet = [];
+        foreach ($result->attackerFleetResults as $fleetResult) {
+            $survivingCapacity = $survivingCapacityByFleet[$fleetResult->fleetMissionId] ?? 0;
+            $remainingLootCapacityByFleet[$fleetResult->fleetMissionId] = max(
+                0,
+                (int)($survivingCapacity - $fleetResult->survivingCargo->sum())
+            );
+        }
+
+        foreach (['metal', 'crystal', 'deuterium'] as $resourceName) {
+            $this->distributeLootResource(
+                (int)$result->loot->{$resourceName}->get(),
+                $resourceName,
+                $result,
+                $survivingCapacityByFleet,
+                $remainingLootCapacityByFleet
+            );
+        }
+
+        // Normalize the battle loot to what was actually assigned to surviving fleets so any
+        // excess that did not fit remains on the defender planet instead of disappearing.
+        $result->loot = $this->sumLootShares($result);
+    }
+
+    /**
+     * Distribute one resource type across attacker fleets proportionally by surviving capacity.
+     *
+     * The allocation is performed in weighted passes so that:
+     * - integer rounding does not silently drop resources;
+     * - fleets never exceed their remaining cargo space;
+     * - leftover resources from capped fleets are redistributed to other eligible fleets.
+     *
+     * @param int $resourceAmount
+     * @param string $resourceName
+     * @param BattleResult $result
+     * @param array<int, int> $survivingCapacityByFleet
+     * @param array<int, int> $remainingLootCapacityByFleet
+     * @return void
+     */
+    private function distributeLootResource(
+        int $resourceAmount,
+        string $resourceName,
+        BattleResult $result,
+        array $survivingCapacityByFleet,
+        array &$remainingLootCapacityByFleet
+    ): void {
+        if ($resourceAmount <= 0) {
+            return;
+        }
+
+        $remainingAmount = $resourceAmount;
+        $initiatorFleetMissionId = $this->getInitiatorFleetMissionId();
+
+        while ($remainingAmount > 0) {
+            $eligibleFleetIds = [];
+            $totalWeight = 0;
+
+            foreach ($result->attackerFleetResults as $fleetResult) {
+                $fleetMissionId = $fleetResult->fleetMissionId;
+                $survivingCapacity = $survivingCapacityByFleet[$fleetMissionId] ?? 0;
+                $remainingCapacity = $remainingLootCapacityByFleet[$fleetMissionId] ?? 0;
+
+                if ($survivingCapacity <= 0 || $remainingCapacity <= 0) {
+                    continue;
+                }
+
+                $eligibleFleetIds[] = $fleetMissionId;
+                $totalWeight += $survivingCapacity;
+            }
+
+            if ($totalWeight <= 0 || count($eligibleFleetIds) === 0) {
+                return;
+            }
+
+            $exactShares = [];
+            $baseShares = [];
+            $allocatedThisPass = 0;
+
+            foreach ($eligibleFleetIds as $fleetMissionId) {
+                $exactShare = ($remainingAmount * $survivingCapacityByFleet[$fleetMissionId]) / $totalWeight;
+                $baseShare = (int) floor($exactShare);
+                $assignedShare = min($baseShare, $remainingLootCapacityByFleet[$fleetMissionId]);
+
+                $exactShares[$fleetMissionId] = $exactShare;
+                $baseShares[$fleetMissionId] = $baseShare;
+
+                if ($assignedShare > 0) {
+                    $this->addLootShareToFleet($result, $fleetMissionId, $resourceName, $assignedShare);
+                    $remainingLootCapacityByFleet[$fleetMissionId] -= $assignedShare;
+                    $allocatedThisPass += $assignedShare;
+                }
+            }
+
+            $remainingAmount -= $allocatedThisPass;
+            if ($remainingAmount <= 0) {
+                return;
+            }
+
+            $rankedFleetIds = $eligibleFleetIds;
+            usort($rankedFleetIds, function (int $left, int $right) use ($exactShares, $baseShares, $survivingCapacityByFleet, $initiatorFleetMissionId): int {
+                $leftIsInitiator = $left === $initiatorFleetMissionId;
+                $rightIsInitiator = $right === $initiatorFleetMissionId;
+                if ($leftIsInitiator !== $rightIsInitiator) {
+                    return $rightIsInitiator <=> $leftIsInitiator;
+                }
+
+                $leftRemainder = $exactShares[$left] - $baseShares[$left];
+                $rightRemainder = $exactShares[$right] - $baseShares[$right];
+
+                if ($leftRemainder !== $rightRemainder) {
+                    return $rightRemainder <=> $leftRemainder;
+                }
+
+                if ($survivingCapacityByFleet[$left] !== $survivingCapacityByFleet[$right]) {
+                    return $survivingCapacityByFleet[$right] <=> $survivingCapacityByFleet[$left];
+                }
+
+                return $left <=> $right;
+            });
+
+            $allocatedExtra = 0;
+            foreach ($rankedFleetIds as $fleetMissionId) {
+                if ($remainingAmount <= 0) {
+                    break;
+                }
+
+                if (($remainingLootCapacityByFleet[$fleetMissionId] ?? 0) <= 0) {
+                    continue;
+                }
+
+                $this->addLootShareToFleet($result, $fleetMissionId, $resourceName, 1);
+                $remainingLootCapacityByFleet[$fleetMissionId] -= 1;
+                $remainingAmount -= 1;
+                $allocatedExtra += 1;
+            }
+
+            if ($allocatedThisPass === 0 && $allocatedExtra === 0) {
+                return;
+            }
+        }
+    }
+
+    /**
+     * Get the fleet mission ID of the ACS initiator.
+     *
+     * @return int
+     */
+    private function getInitiatorFleetMissionId(): int
+    {
+        foreach ($this->attackers as $attacker) {
+            if ($attacker->isInitiator) {
+                return $attacker->fleetMissionId;
+            }
+        }
+
+        return $this->attackers[0]->fleetMissionId;
+    }
+
+    /**
+     * Add an allocated loot amount to the matching fleet result.
+     *
+     * @param BattleResult $result
+     * @param int $fleetMissionId
+     * @param string $resourceName
+     * @param int $amount
+     * @return void
+     */
+    private function addLootShareToFleet(BattleResult $result, int $fleetMissionId, string $resourceName, int $amount): void
+    {
+        if ($amount <= 0) {
             return;
         }
 
         foreach ($result->attackerFleetResults as $fleetResult) {
-            $survivingCapacity = $survivingCapacityByFleet[$fleetResult->fleetMissionId] ?? 0;
-            if ($survivingCapacity <= 0) {
+            if ($fleetResult->fleetMissionId !== $fleetMissionId) {
                 continue;
             }
 
-            $fraction = $survivingCapacity / $totalSurvivingCapacity;
-
-            // Raw proportional share of each resource type.
-            $lootShare = new Resources(
-                max(0, (int)($result->loot->metal->get() * $fraction)),
-                max(0, (int)($result->loot->crystal->get() * $fraction)),
-                max(0, (int)($result->loot->deuterium->get() * $fraction)),
-                0
+            $fleetResult->lootShare->{$resourceName}->set(
+                $fleetResult->lootShare->{$resourceName}->get() + $amount
             );
 
-            // Cap to space remaining after surviving carried cargo is accounted for.
-            $availableForLoot = max(0, (int)($survivingCapacity - $fleetResult->survivingCargo->sum()));
-            if ($lootShare->sum() > $availableForLoot) {
-                $lootShare = LootService::distributeLoot($lootShare, $availableForLoot);
-            }
-
-            $fleetResult->lootShare = $lootShare;
+            return;
         }
+    }
+
+    /**
+     * Sum the loot actually assigned across all attacker fleets.
+     *
+     * @param BattleResult $result
+     * @return Resources
+     */
+    private function sumLootShares(BattleResult $result): Resources
+    {
+        $totalLoot = new Resources(0, 0, 0, 0);
+
+        foreach ($result->attackerFleetResults as $fleetResult) {
+            $totalLoot->add($fleetResult->lootShare);
+        }
+
+        return $totalLoot;
     }
 
     /**

--- a/tests/Feature/FleetDispatch/FleetDispatchAcsAttackTest.php
+++ b/tests/Feature/FleetDispatch/FleetDispatchAcsAttackTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\FleetDispatch;
 
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
+use OGame\Enums\CharacterClass;
 use OGame\Factories\PlanetServiceFactory;
 use OGame\GameMissions\AttackMission;
 use OGame\GameObjects\Models\Units\UnitCollection;
@@ -1517,6 +1518,393 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         $this->assertEquals(0, $allyReturn->crystal);
         // Note: deuterium is not asserted because the mission's deuterium field combines
         // cargo and fuel; fuel is returned with surviving ships (same behaviour as single-attacker).
+    }
+
+    /**
+     * Regression test: ACS loot capacity must sum each fleet's own cargo modifiers.
+     *
+     * Setup:
+     *   Initiator: 1 small cargo, no class bonus          => 5 000 capacity
+     *   Ally:      1 small cargo, Collector class bonus   => 6 250 capacity
+     *   Defender:  22 500 metal                           => 11 250 loot at 50%
+     *
+     * Expected:
+     *   Total occupied return cargo should match the 11 250 combined capacity, with
+     *   a small portion reserved for returned fuel. This proves the battle loot was
+     *   constrained using both fleets' own cargo modifiers instead of 10 000 based
+     *   only on the initiator's stats.
+     */
+    public function testAcsAttackUsesPerFleetCargoModifiersForLootCapacity(): void
+    {
+        $this->basicSetup();
+        $this->createTargetPlayer();
+        $this->createAllyPlayer();
+
+        DB::table('planets')
+            ->where('id', $this->targetPlanet->getPlanetId())
+            ->update(['metal' => 22500, 'crystal' => 0, 'deuterium' => 0]);
+
+        $this->planetAddUnit('small_cargo', 1);
+        $initiatorFleet = new UnitCollection();
+        $initiatorFleet->addUnit(ObjectService::getUnitObjectByMachineName('small_cargo'), 1);
+        $this->dispatchFleet(
+            $this->targetPlanet->getPlanetCoordinates(),
+            $initiatorFleet,
+            new Resources(0, 0, 0, 0),
+            PlanetType::Planet
+        );
+
+        $fleetMissionService = resolve(FleetMissionService::class);
+        $initiatorMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+
+        $this->post('/ajax/fleet/union/create', [
+            'fleetID' => $initiatorMission->id,
+            'groupname' => 'CapacityBonusTest',
+            'unionUsers' => $this->allyUser->username,
+            '_token' => csrf_token(),
+        ]);
+        $initiatorMission->refresh();
+        $unionId = $initiatorMission->union_id;
+
+        $allyPlayer = $this->allyPlanet->getPlayer();
+        $allyPlayer->getUser()->character_class = CharacterClass::COLLECTOR->value;
+        $allyPlayer->getUser()->save();
+
+        $this->allyPlanet->addUnit('small_cargo', 1);
+        $allyFleet = new UnitCollection();
+        $allyFleet->addUnit(ObjectService::getUnitObjectByMachineName('small_cargo'), 1);
+
+        $allyFleetMissionService = resolve(FleetMissionService::class, ['player' => $allyPlayer]);
+        $allyMission = $allyFleetMissionService->createNewFromPlanet(
+            $this->allyPlanet,
+            $this->targetPlanet->getPlanetCoordinates(),
+            PlanetType::Planet,
+            1,
+            $allyFleet,
+            new Resources(0, 0, 0, 0),
+            10,
+            0
+        );
+
+        $fleetUnionService = resolve(FleetUnionService::class);
+        $union = FleetUnion::find($unionId);
+        $fleetUnionService->joinUnion($union, $allyMission);
+
+        $arrivalTime = max($initiatorMission->time_arrival, $allyMission->time_arrival);
+        $this->travelTo(Date::createFromTimestamp($arrivalTime + 10));
+        $this->reloadApplication();
+        $this->get('/overview');
+
+        $initiatorReturn = FleetMission::where('parent_id', $initiatorMission->id)
+            ->where('canceled', 0)
+            ->first();
+        $allyReturn = FleetMission::where('parent_id', $allyMission->id)
+            ->where('canceled', 0)
+            ->first();
+
+        $this->assertNotNull($initiatorReturn, 'Initiator should have a return mission');
+        $this->assertNotNull($allyReturn, 'Ally should have a return mission');
+        $this->assertEquals(
+            11250,
+            $initiatorReturn->metal + $allyReturn->metal + $initiatorReturn->deuterium + $allyReturn->deuterium,
+            'Combined return cargo should use the full 11 250 capacity enabled by per-fleet cargo modifiers'
+        );
+        $this->assertGreaterThan(
+            $initiatorReturn->metal,
+            $allyReturn->metal,
+            'Collector ally should receive the larger share because its fleet has more cargo capacity'
+        );
+    }
+
+    /**
+     * Regression test: integer rounding during ACS loot splitting must not drop loot on the floor.
+     *
+     * Setup:
+     *   Initiator: 1 small cargo
+     *   Ally:      1 small cargo
+     *   Defender:  2 metal, 2 crystal => 1 metal, 1 crystal looted
+     *
+     * Expected:
+     *   The combined return missions still carry exactly 1 metal and 1 crystal,
+     *   and the initiator receives the odd-unit remainder just like original OGame.
+     */
+    public function testAcsAttackPreservesLootWhenSharesRoundDown(): void
+    {
+        $this->basicSetup();
+        $this->createTargetPlayer();
+        $this->createAllyPlayer();
+
+        DB::table('planets')
+            ->where('id', $this->targetPlanet->getPlanetId())
+            ->update(['metal' => 2, 'crystal' => 2, 'deuterium' => 0]);
+
+        $this->planetAddUnit('small_cargo', 1);
+        $initiatorFleet = new UnitCollection();
+        $initiatorFleet->addUnit(ObjectService::getUnitObjectByMachineName('small_cargo'), 1);
+        $this->dispatchFleet(
+            $this->targetPlanet->getPlanetCoordinates(),
+            $initiatorFleet,
+            new Resources(0, 0, 0, 0),
+            PlanetType::Planet
+        );
+
+        $fleetMissionService = resolve(FleetMissionService::class);
+        $initiatorMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+
+        $this->post('/ajax/fleet/union/create', [
+            'fleetID' => $initiatorMission->id,
+            'groupname' => 'RoundingTest',
+            'unionUsers' => $this->allyUser->username,
+            '_token' => csrf_token(),
+        ]);
+        $initiatorMission->refresh();
+        $unionId = $initiatorMission->union_id;
+
+        $this->allyPlanet->addUnit('small_cargo', 1);
+        $allyFleet = new UnitCollection();
+        $allyFleet->addUnit(ObjectService::getUnitObjectByMachineName('small_cargo'), 1);
+
+        $allyFleetMissionService = resolve(FleetMissionService::class, ['player' => $this->allyPlanet->getPlayer()]);
+        $allyMission = $allyFleetMissionService->createNewFromPlanet(
+            $this->allyPlanet,
+            $this->targetPlanet->getPlanetCoordinates(),
+            PlanetType::Planet,
+            1,
+            $allyFleet,
+            new Resources(0, 0, 0, 0),
+            10,
+            0
+        );
+
+        $fleetUnionService = resolve(FleetUnionService::class);
+        $union = FleetUnion::find($unionId);
+        $fleetUnionService->joinUnion($union, $allyMission);
+
+        $arrivalTime = max($initiatorMission->time_arrival, $allyMission->time_arrival);
+        $this->travelTo(Date::createFromTimestamp($arrivalTime + 10));
+        $this->reloadApplication();
+        $this->get('/overview');
+
+        $initiatorReturn = FleetMission::where('parent_id', $initiatorMission->id)
+            ->where('canceled', 0)
+            ->first();
+        $allyReturn = FleetMission::where('parent_id', $allyMission->id)
+            ->where('canceled', 0)
+            ->first();
+
+        $this->assertNotNull($initiatorReturn, 'Initiator should have a return mission');
+        $this->assertNotNull($allyReturn, 'Ally should have a return mission');
+        $this->assertEquals(
+            1,
+            $initiatorReturn->metal + $allyReturn->metal,
+            'Combined returns should preserve the full 1 metal looted from the defender'
+        );
+        $this->assertEquals(1, $initiatorReturn->metal, 'Initiator should receive the odd metal remainder');
+        $this->assertEquals(0, $allyReturn->metal, 'Ally should not receive the odd metal remainder');
+        $this->assertEquals(
+            1,
+            $initiatorReturn->crystal + $allyReturn->crystal,
+            'Combined returns should preserve the full 1 crystal looted from the defender'
+        );
+        $this->assertEquals(1, $initiatorReturn->crystal, 'Initiator should receive the odd crystal remainder');
+        $this->assertEquals(0, $allyReturn->crystal, 'Ally should not receive the odd crystal remainder');
+    }
+
+    /**
+     * Regression test: ACS return missions must not exceed surviving cargo capacity,
+     * and loot that does not fit on one fleet must be redistributed without duplicating resources.
+     *
+     * Setup:
+     *   Initiator: 1 small cargo carrying 4 900 metal (almost full)
+     *   Ally:      1 small cargo carrying 0 metal
+     *   Defender:  2 000 metal => 1 000 metal looted
+     *
+     * Expected:
+     *   Combined return metal = 5 900 exactly (4 900 carried + 1 000 looted)
+     *   Each return mission remains within its fleet cargo capacity.
+     */
+    public function testAcsAttackRedistributesLootWithoutExceedingFleetCapacity(): void
+    {
+        $this->basicSetup();
+        $this->createTargetPlayer();
+        $this->createAllyPlayer();
+
+        DB::table('planets')
+            ->where('id', $this->targetPlanet->getPlanetId())
+            ->update(['metal' => 2000, 'crystal' => 0, 'deuterium' => 0]);
+
+        $this->planetAddResources(new Resources(5000, 0, 0, 0));
+        $this->planetAddUnit('small_cargo', 1);
+        $initiatorFleet = new UnitCollection();
+        $initiatorFleet->addUnit(ObjectService::getUnitObjectByMachineName('small_cargo'), 1);
+        $this->dispatchFleet(
+            $this->targetPlanet->getPlanetCoordinates(),
+            $initiatorFleet,
+            new Resources(4900, 0, 0, 0),
+            PlanetType::Planet
+        );
+
+        $fleetMissionService = resolve(FleetMissionService::class);
+        $initiatorMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+
+        $this->post('/ajax/fleet/union/create', [
+            'fleetID' => $initiatorMission->id,
+            'groupname' => 'CapacityInvariantTest',
+            'unionUsers' => $this->allyUser->username,
+            '_token' => csrf_token(),
+        ]);
+        $initiatorMission->refresh();
+        $unionId = $initiatorMission->union_id;
+
+        $this->allyPlanet->addUnit('small_cargo', 1);
+        $allyFleet = new UnitCollection();
+        $allyFleet->addUnit(ObjectService::getUnitObjectByMachineName('small_cargo'), 1);
+
+        $allyFleetMissionService = resolve(FleetMissionService::class, ['player' => $this->allyPlanet->getPlayer()]);
+        $allyMission = $allyFleetMissionService->createNewFromPlanet(
+            $this->allyPlanet,
+            $this->targetPlanet->getPlanetCoordinates(),
+            PlanetType::Planet,
+            1,
+            $allyFleet,
+            new Resources(0, 0, 0, 0),
+            10,
+            0
+        );
+
+        $fleetUnionService = resolve(FleetUnionService::class);
+        $union = FleetUnion::find($unionId);
+        $fleetUnionService->joinUnion($union, $allyMission);
+
+        $arrivalTime = max($initiatorMission->time_arrival, $allyMission->time_arrival);
+        $this->travelTo(Date::createFromTimestamp($arrivalTime + 10));
+        $this->reloadApplication();
+        $this->get('/overview');
+
+        $initiatorReturn = FleetMission::where('parent_id', $initiatorMission->id)
+            ->where('canceled', 0)
+            ->first();
+        $allyReturn = FleetMission::where('parent_id', $allyMission->id)
+            ->where('canceled', 0)
+            ->first();
+
+        $this->assertNotNull($initiatorReturn, 'Initiator should have a return mission');
+        $this->assertNotNull($allyReturn, 'Ally should have a return mission');
+        $this->assertEquals(
+            5900,
+            $initiatorReturn->metal + $allyReturn->metal,
+            'Combined returns should preserve exactly 4 900 carried metal plus 1 000 looted metal'
+        );
+
+        $initiatorReturnPlayer = resolve(PlayerService::class, ['player_id' => $initiatorReturn->user_id]);
+        $allyReturnPlayer = resolve(PlayerService::class, ['player_id' => $allyReturn->user_id]);
+
+        $initiatorCapacity = $fleetMissionService->getFleetUnits($initiatorReturn)->getTotalCargoCapacity($initiatorReturnPlayer);
+        $allyCapacity = $fleetMissionService->getFleetUnits($allyReturn)->getTotalCargoCapacity($allyReturnPlayer);
+
+        $this->assertLessThanOrEqual(
+            $initiatorCapacity,
+            $initiatorReturn->metal + $initiatorReturn->crystal + $initiatorReturn->deuterium,
+            'Initiator return must not exceed the surviving fleet cargo capacity'
+        );
+        $this->assertLessThanOrEqual(
+            $allyCapacity,
+            $allyReturn->metal + $allyReturn->crystal + $allyReturn->deuterium,
+            'Ally return must not exceed the surviving fleet cargo capacity'
+        );
+    }
+
+    /**
+     * Regression test: when the ACS group lacks enough free cargo space for all possible loot,
+     * only the actually transportable amount should be deducted and the remainder must stay on
+     * the defender planet.
+     */
+    public function testAcsAttackLeavesUncarriedLootOnDefenderPlanet(): void
+    {
+        $this->basicSetup();
+        $this->createTargetPlayer();
+        $this->createAllyPlayer();
+
+        DB::table('planets')
+            ->where('id', $this->targetPlanet->getPlanetId())
+            ->update(['metal' => 12000, 'crystal' => 0, 'deuterium' => 0]);
+
+        $this->planetAddResources(new Resources(5000, 0, 0, 0));
+        $this->planetAddUnit('small_cargo', 1);
+        $initiatorFleet = new UnitCollection();
+        $initiatorFleet->addUnit(ObjectService::getUnitObjectByMachineName('small_cargo'), 1);
+        $this->dispatchFleet(
+            $this->targetPlanet->getPlanetCoordinates(),
+            $initiatorFleet,
+            new Resources(4900, 0, 0, 0),
+            PlanetType::Planet
+        );
+
+        $fleetMissionService = resolve(FleetMissionService::class);
+        $initiatorMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+
+        $this->post('/ajax/fleet/union/create', [
+            'fleetID' => $initiatorMission->id,
+            'groupname' => 'LeaveLootTest',
+            'unionUsers' => $this->allyUser->username,
+            '_token' => csrf_token(),
+        ]);
+        $initiatorMission->refresh();
+        $unionId = $initiatorMission->union_id;
+
+        $this->allyPlanet->addUnit('small_cargo', 1);
+        $allyFleet = new UnitCollection();
+        $allyFleet->addUnit(ObjectService::getUnitObjectByMachineName('small_cargo'), 1);
+
+        $allyFleetMissionService = resolve(FleetMissionService::class, ['player' => $this->allyPlanet->getPlayer()]);
+        $allyMission = $allyFleetMissionService->createNewFromPlanet(
+            $this->allyPlanet,
+            $this->targetPlanet->getPlanetCoordinates(),
+            PlanetType::Planet,
+            1,
+            $allyFleet,
+            new Resources(0, 0, 0, 0),
+            10,
+            0
+        );
+
+        $fleetUnionService = resolve(FleetUnionService::class);
+        $union = FleetUnion::find($unionId);
+        $fleetUnionService->joinUnion($union, $allyMission);
+
+        $arrivalTime = max($initiatorMission->time_arrival, $allyMission->time_arrival);
+        $this->travelTo(Date::createFromTimestamp($arrivalTime + 10));
+        $this->reloadApplication();
+        $this->get('/overview');
+
+        $initiatorReturn = FleetMission::where('parent_id', $initiatorMission->id)
+            ->where('canceled', 0)
+            ->first();
+        $allyReturn = FleetMission::where('parent_id', $allyMission->id)
+            ->where('canceled', 0)
+            ->first();
+
+        $this->assertNotNull($initiatorReturn, 'Initiator should have a return mission');
+        $this->assertNotNull($allyReturn, 'Ally should have a return mission');
+
+        $actualLootTaken = ($initiatorReturn->metal + $allyReturn->metal) - 4900;
+        $this->assertGreaterThan(0, $actualLootTaken, 'Attackers should still bring home some loot');
+        $this->assertLessThan(
+            6000,
+            $actualLootTaken,
+            'Actual loot should be lower than the theoretical 6 000 because free cargo space is limited'
+        );
+
+        $planetServiceFactory = resolve(PlanetServiceFactory::class);
+        $refreshedTargetPlanet = $planetServiceFactory->makeForPlayer(
+            $this->targetPlanet->getPlayer(),
+            $this->targetPlanet->getPlanetId()
+        );
+        $this->assertEquals(
+            12000 - $actualLootTaken,
+            $refreshedTargetPlanet->getResources()->metal->get(),
+            'Any loot that does not fit on the ACS return fleets must remain on the defender planet'
+        );
     }
 
     /**

--- a/tests/Feature/FleetDispatch/FleetDispatchAcsAttackTest.php
+++ b/tests/Feature/FleetDispatch/FleetDispatchAcsAttackTest.php
@@ -946,8 +946,6 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
 
     /**
      * Test that an ACS attack with multiple fleets creates return missions for all survivors.
-     * Note: per-fleet loot distribution (survivingCargo/lootShare) is not yet implemented
-     * for multi-fleet ACS attacks; this test verifies return missions are created correctly.
      */
     public function testAcsAttackMultiFleetReturnMissionsCreated(): void
     {
@@ -1364,5 +1362,122 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
 
         $response->assertStatus(200);
         $response->assertJson(['orders' => [2 => false]]);
+    }
+
+    /**
+     * Test that ACS Attack distributes loot proportionally by surviving cargo capacity
+     * and preserves resources carried by each fleet.
+     *
+     * Setup:
+     *   Initiator: 2 large cargoes (25 000 capacity each = 50 000 total), carrying 1 000 metal
+     *   Ally:      1 small cargo  ( 5 000 capacity),                       carrying   500 metal
+     *   Defender:  22 000 metal, no ships / defense
+     *
+     * Expected after battle (all ships survive, attacker wins):
+     *   Total loot = 50% of 22 000 = 11 000 metal
+     *   Initiator fraction = 50 000 / 55 000 → loot = 10 000 metal (exact integer)
+     *   Ally      fraction =  5 000 / 55 000 → loot =  1 000 metal (exact integer)
+     *
+     *   Initiator return: 1 000 (surviving cargo) + 10 000 (loot) = 11 000 metal
+     *   Ally      return:   500 (surviving cargo) +  1 000 (loot) =  1 500 metal
+     *
+     * Using different ship types per fleet (large_cargo vs small_cargo) avoids triggering
+     * the UnitCollection reference-aliasing mutation, which is fixed by a separate PR.
+     */
+    public function testAcsAttackCargoAndLootDistribution(): void
+    {
+        $this->basicSetup();
+        $this->createTargetPlayer();
+        $this->createAllyPlayer();
+
+        // Set exact defender resources for deterministic loot calculation.
+        DB::table('planets')
+            ->where('id', $this->targetPlanet->getPlanetId())
+            ->update(['metal' => 22000, 'crystal' => 0, 'deuterium' => 0]);
+
+        // Give initiator planet metal to carry as cargo and add 2 large cargoes.
+        $this->planetAddResources(new Resources(2000, 0, 0, 0));
+        $this->planetAddUnit('large_cargo', 2);
+        $initiatorFleet = new UnitCollection();
+        $initiatorFleet->addUnit(ObjectService::getUnitObjectByMachineName('large_cargo'), 2);
+        $this->dispatchFleet(
+            $this->targetPlanet->getPlanetCoordinates(),
+            $initiatorFleet,
+            new Resources(1000, 0, 0, 0),
+            PlanetType::Planet
+        );
+
+        $fleetMissionService = resolve(FleetMissionService::class);
+        $initiatorMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+
+        // Create union and invite ally.
+        $this->post('/ajax/fleet/union/create', [
+            'fleetID' => $initiatorMission->id,
+            'groupname' => 'LootDistTest',
+            'unionUsers' => $this->allyUser->username,
+            '_token' => csrf_token(),
+        ]);
+        $initiatorMission->refresh();
+        $unionId = $initiatorMission->union_id;
+
+        // Give ally planet metal to carry and add 1 small cargo (different type from initiator
+        // to avoid the reference-aliasing mutation that affects same-type multi-fleet combinations).
+        $this->allyPlanet->addResources(new Resources(1000, 0, 0, 0));
+        $this->allyPlanet->addUnit('small_cargo', 1);
+        $allyFleet = new UnitCollection();
+        $allyFleet->addUnit(ObjectService::getUnitObjectByMachineName('small_cargo'), 1);
+
+        $allyFleetMissionService = resolve(FleetMissionService::class, ['player' => $this->allyPlanet->getPlayer()]);
+        $allyMission = $allyFleetMissionService->createNewFromPlanet(
+            $this->allyPlanet,
+            $this->targetPlanet->getPlanetCoordinates(),
+            PlanetType::Planet,
+            1,
+            $allyFleet,
+            new Resources(500, 0, 0, 0),
+            10,
+            0
+        );
+
+        $fleetUnionService = resolve(FleetUnionService::class);
+        $union = FleetUnion::find($unionId);
+        $fleetUnionService->joinUnion($union, $allyMission);
+
+        // Advance time past arrival and trigger fleet processing.
+        $arrivalTime = max($initiatorMission->time_arrival, $allyMission->time_arrival);
+        $this->travelTo(Date::createFromTimestamp($arrivalTime + 10));
+        $this->reloadApplication();
+        $this->get('/overview');
+
+        // Fetch return missions.
+        $initiatorReturn = FleetMission::where('parent_id', $initiatorMission->id)
+            ->where('canceled', 0)
+            ->first();
+        $allyReturn = FleetMission::where('parent_id', $allyMission->id)
+            ->where('canceled', 0)
+            ->first();
+
+        $this->assertNotNull($initiatorReturn, 'Initiator should have a return mission');
+        $this->assertNotNull($allyReturn, 'Ally should have a return mission');
+
+        // Verify loot distribution and cargo preservation.
+        // Initiator: 50 000 / 55 000 of 11 000 = 10 000 metal loot + 1 000 surviving cargo = 11 000
+        $this->assertEquals(
+            11000,
+            $initiatorReturn->metal,
+            'Initiator return should carry 1000 (surviving cargo) + 10000 (10/11 loot) = 11000 metal'
+        );
+        // Ally: 5 000 / 55 000 of 11 000 = 1 000 metal loot + 500 surviving cargo = 1 500
+        $this->assertEquals(
+            1500,
+            $allyReturn->metal,
+            'Ally return should carry 500 (surviving cargo) + 1000 (1/11 loot) = 1500 metal'
+        );
+
+        // No crystal was looted (defender had none) and none was carried.
+        $this->assertEquals(0, $initiatorReturn->crystal);
+        $this->assertEquals(0, $allyReturn->crystal);
+        // Note: deuterium is not asserted because the mission's deuterium field combines
+        // cargo and fuel; fuel is returned with surviving ships (same behaviour as single-attacker).
     }
 }

--- a/tests/Feature/FleetDispatch/FleetDispatchAttackTest.php
+++ b/tests/Feature/FleetDispatch/FleetDispatchAttackTest.php
@@ -4,13 +4,16 @@ namespace Tests\Feature\FleetDispatch;
 
 use Exception;
 use Illuminate\Contracts\Container\BindingResolutionException;
-use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\DB;
 use OGame\Factories\PlanetServiceFactory;
 use OGame\GameMissions\AttackMission;
 use OGame\GameObjects\Models\Units\UnitCollection;
 use OGame\Models\BattleReport;
 use OGame\Models\Enums\PlanetType;
+use OGame\Models\FleetMission;
 use OGame\Models\Message;
+use OGame\Models\Planet;
 use OGame\Models\Resources;
 use OGame\Services\DebrisFieldService;
 use OGame\Services\FleetMissionService;
@@ -211,6 +214,59 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
     }
 
     /**
+     * Regression test: if the attacker's surviving free cargo space is below the theoretical
+     * loot, only the carried amount should be stolen and the remainder must stay on the target.
+     */
+    public function testAttackLeavesUncarriedLootOnDefenderPlanet(): void
+    {
+        $this->basicSetup();
+
+        $this->planetAddResources(new Resources(5000, 0, 0, 0));
+        $this->planetAddUnit('small_cargo', 1);
+
+        $unitCollection = new UnitCollection();
+        $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('small_cargo'), 1);
+        $foreignPlanet = $this->sendMissionToOtherPlayerCleanPlanet($unitCollection, new Resources(4900, 0, 0, 0));
+
+        DB::table('planets')
+            ->where('id', $foreignPlanet->getPlanetId())
+            ->update(['metal' => 12000, 'crystal' => 0, 'deuterium' => 0]);
+
+        $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
+        $mission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        $this->assertNotNull($mission, 'Attack mission should exist');
+
+        $this->travelTo(Date::createFromTimestamp($mission->time_arrival + 10));
+        $this->reloadApplication();
+        $this->get('/overview')->assertStatus(200);
+
+        $returnMission = FleetMission::where('parent_id', $mission->id)
+            ->where('canceled', 0)
+            ->first();
+
+        $this->assertNotNull($returnMission, 'Return mission should exist');
+
+        $actualLootTaken = $returnMission->metal - 4900;
+        $this->assertGreaterThanOrEqual(0, $actualLootTaken);
+        $this->assertLessThan(
+            6000,
+            $actualLootTaken,
+            'Actual loot should be lower than the theoretical 6 000 because the fleet is nearly full'
+        );
+
+        $planetServiceFactory = resolve(PlanetServiceFactory::class);
+        $refreshedForeignPlanet = $planetServiceFactory->makeForPlayer(
+            $foreignPlanet->getPlayer(),
+            $foreignPlanet->getPlanetId()
+        );
+        $this->assertEquals(
+            12000 - $actualLootTaken,
+            $refreshedForeignPlanet->getResources()->metal->get(),
+            'Any loot that does not fit on the return fleet must remain on the defender planet'
+        );
+    }
+
+    /**
      * Verify that dispatching a fleet launches a return trip.
      * @throws Exception
      */
@@ -265,14 +321,15 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
         $this->assertCount(1, $activeMissions, 'No return trip launched after fleet with deployment mission has arrived at destination.');
 
         // Advance time by amount of minutes it takes for the return trip to arrive.
-        $this->travelTo(Carbon::createFromTimestamp($activeMissions->first()->time_arrival));
+        $this->travelTo(Date::createFromTimestamp($activeMissions->first()->time_arrival));
 
         // Do a request to trigger the update logic.
         $response = $this->get('/overview');
         $response->assertStatus(200);
 
-        // Assert that the return trip is processed and that the resources mentioned in battle report
-        // match the resources of the return trip.
+        // Assert that the return trip is processed and that the stolen resources mentioned in the
+        // battle report are present on the return trip. Return deuterium can be higher because the
+        // fleet mission payload also includes surviving mission fuel.
         $fleetMission = $fleetMissionService->getFleetMissionById($activeMissions->first()->id, false);
         $this->assertTrue($fleetMission->processed == 1, 'Return trip is not processed after fleet has arrived back at origin planet.');
 
@@ -280,8 +337,13 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
         $battleReport = BattleReport::orderBy('id', 'desc')->first();
         $battleReportResources = new Resources($battleReport->loot['metal'], $battleReport->loot['crystal'], $battleReport->loot['deuterium'], 0);
 
-        // Assert that the resources of the return trip match the resources of the battle report.
-        $this->assertEquals($battleReportResources, new Resources($fleetMission->metal, $fleetMission->crystal, $fleetMission->deuterium, 0), 'Resources of return trip do not match resources of battle report.');
+        $this->assertEquals($battleReportResources->metal->get(), $fleetMission->metal, 'Return trip metal should match looted metal in the battle report.');
+        $this->assertEquals($battleReportResources->crystal->get(), $fleetMission->crystal, 'Return trip crystal should match looted crystal in the battle report.');
+        $this->assertGreaterThanOrEqual(
+            $battleReportResources->deuterium->get(),
+            $fleetMission->deuterium,
+            'Return trip deuterium should contain at least the looted deuterium from the battle report.'
+        );
     }
 
     /**
@@ -341,7 +403,7 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
 
         // Advance time by 5 seconds.
         $this->travel(5)->seconds();
-        $fleetParentTime = Carbon::getTestNow();
+        $fleetParentTime = Date::getTestNow();
 
         // Cancel the mission
         $response = $this->post('/ajax/fleet/dispatch/recall-fleet', [
@@ -374,7 +436,7 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
         $this->playerSetAllMessagesRead();
 
         // Advance time by amount of minutes it takes for the return trip to arrive.
-        $this->travelTo(Carbon::createFromTimestamp($fleetMission->time_arrival));
+        $this->travelTo(Date::createFromTimestamp($fleetMission->time_arrival));
 
         // Do a request to trigger the update logic.
         $response = $this->get('/overview');
@@ -953,7 +1015,7 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
         $this->assertNotNull($moonAtCoordinates, 'Moon should still exist at coordinates after battle.');
 
         // Verify there's no duplicate by checking the planet database directly
-        $moonsAtLocation = \OGame\Models\Planet::where('galaxy', $moonCoordinates->galaxy)
+        $moonsAtLocation = Planet::where('galaxy', $moonCoordinates->galaxy)
             ->where('system', $moonCoordinates->system)
             ->where('planet', $moonCoordinates->position)
             ->where('planet_type', PlanetType::Moon->value)
@@ -1046,9 +1108,6 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
         // Assert that a moon was created within the maximum attempts
         $this->assertTrue($moonCreated, sprintf('Moon was not created within %d attempts with 20%% maximum moon chance.', $maxAttempts));
         $this->assertLessThanOrEqual($maxAttempts, $attempts, 'Test exceeded maximum allowed attempts.');
-
-        // Output the number of attempts it took to create the moon
-        dump("Moon was created after amount of attempts: " . $attempts);
     }
 
     /**
@@ -1233,7 +1292,7 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
         $fleetMission = $fleetMissionService->getFleetMissionById($fleetMissionId, false);
 
         // Recall the mission before it arrives
-        $fleetParentTime = Carbon::createFromTimestamp($fleetMission->time_departure);
+        $fleetParentTime = Date::createFromTimestamp($fleetMission->time_departure);
         $this->travel(60)->seconds();
 
         // Send recall request
@@ -1253,7 +1312,7 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
         $this->assertGreaterThanOrEqual(10000, $returnMission->deuterium);
 
         // Advance time to return mission arrival
-        $this->travelTo(Carbon::createFromTimestamp($returnMission->time_arrival));
+        $this->travelTo(Date::createFromTimestamp($returnMission->time_arrival));
 
         // Trigger update to process the return
         $this->get('/overview');

--- a/tests/Unit/BattleEngine/BattleEngineResourceDistributionTest.php
+++ b/tests/Unit/BattleEngine/BattleEngineResourceDistributionTest.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Tests\Unit\BattleEngine;
+
+use OGame\GameMissions\BattleEngine\BattleEngine;
+use OGame\GameMissions\BattleEngine\Models\AttackerFleet;
+use OGame\GameMissions\BattleEngine\Models\AttackerFleetResult;
+use OGame\GameMissions\BattleEngine\Models\BattleResult;
+use OGame\GameMissions\BattleEngine\Models\DefenderFleet;
+use OGame\GameObjects\Models\Units\UnitCollection;
+use OGame\Models\Resources;
+use OGame\Services\ObjectService;
+use Tests\UnitTestCase;
+
+class BattleEngineResourceDistributionTest extends UnitTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createAndSetPlanetModel([
+            'metal' => 0,
+            'crystal' => 0,
+            'deuterium' => 0,
+        ]);
+        $this->createAndSetUserTechModel([]);
+    }
+
+    public function testDistributeResourcesScalesSurvivingCargoAfterPartialFleetLoss(): void
+    {
+        $smallCargo = ObjectService::getUnitObjectByMachineName('small_cargo');
+
+        $fleetOneUnits = new UnitCollection();
+        $fleetOneUnits->addUnit($smallCargo, 2);
+
+        $fleetTwoUnits = new UnitCollection();
+        $fleetTwoUnits->addUnit($smallCargo, 1);
+
+        $fleetOne = $this->makeAttackerFleet(101, $fleetOneUnits, new Resources(2000, 0, 0, 0));
+        $fleetTwo = $this->makeAttackerFleet(102, $fleetTwoUnits, new Resources(500, 0, 0, 0));
+
+        $engine = new BattleEngineResourceDistributionHarness(
+            [$fleetOne, $fleetTwo],
+            $this->planetService,
+            [DefenderFleet::fromPlanet($this->planetService)],
+            $this->settingsService
+        );
+
+        $result = new BattleResult();
+        $result->loot = new Resources(3000, 0, 0, 0);
+
+        $fleetOneResult = new AttackerFleetResult($fleetOne->fleetMissionId, $fleetOne->ownerId, $fleetOneUnits);
+        $fleetOneResult->unitsResult = new UnitCollection();
+        $fleetOneResult->unitsResult->addUnit($smallCargo, 1);
+        $fleetOneResult->completelyDestroyed = false;
+
+        $fleetTwoResult = new AttackerFleetResult($fleetTwo->fleetMissionId, $fleetTwo->ownerId, $fleetTwoUnits);
+        $fleetTwoResult->unitsResult = clone $fleetTwoUnits;
+        $fleetTwoResult->completelyDestroyed = false;
+
+        $result->attackerFleetResults = [$fleetOneResult, $fleetTwoResult];
+
+        $engine->runDistributeResources($result);
+
+        $this->assertEquals(
+            1000,
+            $fleetOneResult->survivingCargo->metal->get(),
+            'Fleet one should keep 50% of its carried cargo after losing half its cargo capacity'
+        );
+        $this->assertEquals(
+            500,
+            $fleetTwoResult->survivingCargo->metal->get(),
+            'Fleet two should keep all carried cargo when all ships survive'
+        );
+        $this->assertEquals(
+            1500,
+            $fleetOneResult->lootShare->metal->get(),
+            'Remaining loot should be split by surviving cargo capacity after surviving cargo is accounted for'
+        );
+        $this->assertEquals(1500, $fleetTwoResult->lootShare->metal->get());
+        $this->assertEquals(
+            3000,
+            $result->loot->metal->get(),
+            'Normalized battle loot should match the sum of the assigned per-fleet loot shares'
+        );
+    }
+
+    public function testDistributeResourcesAssignsOddRemainderToInitiator(): void
+    {
+        $smallCargo = ObjectService::getUnitObjectByMachineName('small_cargo');
+
+        $initiatorUnits = new UnitCollection();
+        $initiatorUnits->addUnit($smallCargo, 1);
+
+        $allyUnits = new UnitCollection();
+        $allyUnits->addUnit($smallCargo, 1);
+
+        $initiator = $this->makeAttackerFleet(201, $initiatorUnits, new Resources(0, 0, 0, 0));
+        $ally = $this->makeAttackerFleet(202, $allyUnits, new Resources(0, 0, 0, 0));
+
+        $engine = new BattleEngineResourceDistributionHarness(
+            [$initiator, $ally],
+            $this->planetService,
+            [DefenderFleet::fromPlanet($this->planetService)],
+            $this->settingsService
+        );
+
+        $result = new BattleResult();
+        $result->loot = new Resources(1, 1, 0, 0);
+
+        $initiatorResult = new AttackerFleetResult($initiator->fleetMissionId, $initiator->ownerId, $initiatorUnits);
+        $initiatorResult->unitsResult = clone $initiatorUnits;
+        $initiatorResult->completelyDestroyed = false;
+
+        $allyResult = new AttackerFleetResult($ally->fleetMissionId, $ally->ownerId, $allyUnits);
+        $allyResult->unitsResult = clone $allyUnits;
+        $allyResult->completelyDestroyed = false;
+
+        $result->attackerFleetResults = [$initiatorResult, $allyResult];
+
+        $engine->runDistributeResources($result);
+
+        $this->assertEquals(1, $initiatorResult->lootShare->metal->get());
+        $this->assertEquals(0, $allyResult->lootShare->metal->get());
+        $this->assertEquals(1, $initiatorResult->lootShare->crystal->get());
+        $this->assertEquals(0, $allyResult->lootShare->crystal->get());
+    }
+
+    private function makeAttackerFleet(int $fleetMissionId, UnitCollection $units, Resources $cargoResources): AttackerFleet
+    {
+        $attacker = new AttackerFleet();
+        $attacker->units = clone $units;
+        $attacker->player = $this->playerService;
+        $attacker->fleetMissionId = $fleetMissionId;
+        $attacker->ownerId = $this->playerService->getId();
+        $attacker->cargoResources = $cargoResources;
+        $attacker->isInitiator = in_array($fleetMissionId, [101, 201], true);
+        $attacker->fleetMission = null;
+
+        return $attacker;
+    }
+}
+
+class BattleEngineResourceDistributionHarness extends BattleEngine
+{
+    public function runDistributeResources(BattleResult $result): void
+    {
+        $this->distributeResources($result);
+    }
+
+    protected function fightBattleRounds(BattleResult $result): array
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
## Description
This PR implements OGame-accurate ACS loot distribution for multi-attacker battles:

- Distributes loot by each fleet’s surviving cargo capacity using each owner’s real cargo modifiers
- Preserves resources correctly when fleets are partially destroyed
- Gives odd-unit loot remainders to the ACS initiator, matching OGame behavior
- Prevents overfilling return fleets and keeps any uncarried loot on the defender planet
- Aligns single-attacker return handling with actual carried loot/cargo outcomes

### Type of Change:
- [ ] Bug fix
- [X] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #[issue-number]

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [X] **Automated Refactoring:** Rector has been run and no outstanding issues remain.
- [X] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [X] **Static Analysis:** Code passes PHPStan static code analysis.
- [X] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [X] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [X] **Documentation:** Documentation has been updated to reflect any changes made.

## Additional Information
Add any additional context, screenshots, or explanations to help reviewers understand your PR. If this change introduces any breaking changes or significant impacts, please detail them here.
