### PR TITLE
fix: unstyled chat page title header

### DIFF
--- a/public/css/ingame.css
+++ b/public/css/ingame.css
@@ -6330,6 +6330,17 @@ div.content-box-s .header h3 {
 #messages #planet.shortHeader { background-image: url("/img/icons/969c4e267c1a550aad41b8fd1debe4.jpg"); }
 #chat #planet.shortHeader { background-image: url("/img/icons/c02c34215b665f753ae3e062c680d9.jpg"); }
 
+#chat #planet h2 {
+    color: #fff;
+    font: bold 18px/22px Verdana,Arial,Helvetica,sans-serif;
+    height: 22px;
+    margin: 0 0 0 144px;
+    overflow: hidden;
+    padding-top: 7px;
+    white-space: nowrap;
+    width: 470px;
+}
+
 #resourceSettings #planet.shortHeader { background-image: url("/img/icons/8a1aa7b42b1d117d9ebb04c97b6d6d.jpg"); }
 #movement #planet.shortHeader { background-image: url("/img/icons/9b0237402cdb812513f8a513a7d8e3.jpg"); }
 #tutorial #planet.shortHeader { background-image: url("/img/icons/4641cd55cd998ab2f71757c7c0fd9d.jpg"); }
@@ -34922,19 +34933,11 @@ ul.og-paginatable li.active {
 }
 
 #phalanxWrap .eventFleet .descFleet,
-#phalanxWrap .partnerInfo .descFleet {
+#phalanxWrap .eventFleet .originFleet,
+#phalanxWrap .partnerInfo .descFleet,
+#phalanxWrap .partnerInfo .originFleet {
     color:#7c8e9a;
     font-weight:700;
-    text-align:left;
-    width:215px;
-    white-space:nowrap;
-    overflow:hidden;
-}
-
-#phalanxWrap .eventFleet .originFleet,
-#phalanxWrap .partnerInfo .originFleet {
-    color:#fff;
-    font-weight:bold;
     text-align:left;
     width:215px;
     white-space:nowrap;
@@ -34950,8 +34953,6 @@ ul.og-paginatable li.active {
     white-space:nowrap;
     overflow:hidden;
 }
-
-
 
 #phalanxWrap .eventFleet .detailsFleet,
 #phalanxWrap .partnerInfo .detailsFleet {

--- a/resources/css/ingame/469500b3cd5158332fb20a56b14b2c.css
+++ b/resources/css/ingame/469500b3cd5158332fb20a56b14b2c.css
@@ -2175,6 +2175,17 @@ div.content-box-s .header h3 {
 #messages #planet.shortHeader { background-image: url("/img/icons/969c4e267c1a550aad41b8fd1debe4.jpg"); }
 #chat #planet.shortHeader { background-image: url("/img/icons/c02c34215b665f753ae3e062c680d9.jpg"); }
 
+#chat #planet h2 {
+    color: #fff;
+    font: bold 18px/22px Verdana,Arial,Helvetica,sans-serif;
+    height: 22px;
+    margin: 0 0 0 144px;
+    overflow: hidden;
+    padding-top: 7px;
+    white-space: nowrap;
+    width: 470px;
+}
+
 #resourceSettings #planet.shortHeader { background-image: url("/img/icons/8a1aa7b42b1d117d9ebb04c97b6d6d.jpg"); }
 #movement #planet.shortHeader { background-image: url("/img/icons/9b0237402cdb812513f8a513a7d8e3.jpg"); }
 #tutorial #planet.shortHeader { background-image: url("/img/icons/4641cd55cd998ab2f71757c7c0fd9d.jpg"); }


### PR DESCRIPTION
## Description
This PR fixes the unstyled Chat page title header by adding the missing #chat #planet h2 CSS rule that styles the h2 inside the shortHeader on the /chat page, matching the pattern used by all other pages (buddies, fleet, messages, etc.).

### Type of Change:
- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #1289 

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [X] **Automated Refactoring:** Rector has been run and no outstanding issues remain.
- [X] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [X] **Static Analysis:** Code passes PHPStan static code analysis.
- [X] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [X] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [X] **Documentation:** Documentation has been updated to reflect any changes made.

## Additional Information
Add any additional context, screenshots, or explanations to help reviewers understand your PR. If this change introduces any breaking changes or significant impacts, please detail them here.
