### PR TITLE
Set BCRYPT_ROUNDS in tests

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -13,6 +13,7 @@
     <env name="CACHE_DRIVER" value="array"/>
     <env name="SESSION_DRIVER" value="array"/>
     <env name="QUEUE_DRIVER" value="sync"/>
+    <env name="BCRYPT_ROUNDS" value="4"/>
   </php>
   <source>
     <include>


### PR DESCRIPTION
12 is default, but we set it to 4 in the phpunit.xml to improve speed for testing