### PR TITLE
Add stuck fleet mission recovery tool to server administration

### DIFF
--- a/app/Console/Commands/Dev/SeedStuckFleetMissions.php
+++ b/app/Console/Commands/Dev/SeedStuckFleetMissions.php
@@ -57,6 +57,8 @@ class SeedStuckFleetMissions extends Command
         }
 
         $now = (int) now()->timestamp;
+        // Anchor all arrivals 25h in the past so they exceed the default 24h display threshold.
+        $t = $now - (25 * 3600);
 
         $base = [
             'processed'             => 0,
@@ -77,7 +79,7 @@ class SeedStuckFleetMissions extends Command
             'galaxy_from'    => $planet1->galaxy, 'system_from' => $planet1->system, 'position_from' => $planet1->planet,
             'galaxy_to'      => $planet2->galaxy, 'system_to' => $planet2->system, 'position_to' => $planet2->planet,
             'mission_type'   => 3,
-            'time_departure' => $now - 3600, 'time_arrival' => $now - 1800,
+            'time_departure' => $t - 3600, 'time_arrival' => $t - 1800,
             'small_cargo'    => 10, 'metal' => 50000, 'crystal' => 30000,
         ]));
 
@@ -89,7 +91,7 @@ class SeedStuckFleetMissions extends Command
             'galaxy_from'    => $planet2->galaxy, 'system_from' => $planet2->system, 'position_from' => $planet2->planet,
             'galaxy_to'      => $planet3->galaxy, 'system_to' => $planet3->system, 'position_to' => $planet3->planet,
             'mission_type'   => 3,
-            'time_departure' => $now - 7200, 'time_arrival' => $now - 5400,
+            'time_departure' => $t - 7200, 'time_arrival' => $t - 5400,
             'large_cargo'    => 5, 'deuterium' => 20000,
         ]));
 
@@ -101,7 +103,7 @@ class SeedStuckFleetMissions extends Command
             'galaxy_from'    => $planet3->galaxy, 'system_from' => $planet3->system, 'position_from' => $planet3->planet,
             'galaxy_to'      => $planet1->galaxy, 'system_to' => $planet1->system, 'position_to' => $planet1->planet,
             'mission_type'   => 3,
-            'time_departure' => $now - 900, 'time_arrival' => $now - 300,
+            'time_departure' => $t - 900, 'time_arrival' => $t - 300,
             'small_cargo'    => 3, 'crystal' => 15000,
         ]));
 
@@ -113,7 +115,7 @@ class SeedStuckFleetMissions extends Command
             'galaxy_from'    => $planet2->galaxy, 'system_from' => $planet2->system, 'position_from' => $planet2->planet,
             'galaxy_to'      => $planet3->galaxy, 'system_to' => $planet3->system, 'position_to' => $planet3->planet,
             'mission_type'   => 1,
-            'time_departure' => $now - 1800, 'time_arrival' => $now - 600,
+            'time_departure' => $t - 1800, 'time_arrival' => $t - 600,
             'light_fighter'  => 50, 'heavy_fighter' => 20,
         ]));
 
@@ -125,7 +127,7 @@ class SeedStuckFleetMissions extends Command
             'galaxy_from'     => $planet1->galaxy, 'system_from' => $planet1->system, 'position_from' => $planet1->planet,
             'galaxy_to'       => $planet2->galaxy, 'system_to' => $planet2->system, 'position_to' => $planet2->planet,
             'mission_type'    => 6,
-            'time_departure'  => $now - 2700, 'time_arrival' => $now - 2400,
+            'time_departure'  => $t - 2700, 'time_arrival' => $t - 2400,
             'espionage_probe' => 3,
         ]));
 
@@ -138,7 +140,7 @@ class SeedStuckFleetMissions extends Command
             'galaxy_to'      => 1, 'system_to' => 250, 'position_to' => 16,
             'type_to'        => PlanetType::DeepSpace->value,
             'mission_type'   => 15,
-            'time_departure' => $now - 4500, 'time_arrival' => $now - 900,
+            'time_departure' => $t - 4500, 'time_arrival' => $t - 900,
             'large_cargo'    => 2,
         ]));
 
@@ -151,7 +153,7 @@ class SeedStuckFleetMissions extends Command
             'galaxy_to'      => $planet3->galaxy, 'system_to' => $planet3->system, 'position_to' => $planet3->planet,
             'type_to'        => PlanetType::DebrisField->value,
             'mission_type'   => 8,
-            'time_departure' => $now - 3000, 'time_arrival' => $now - 1200,
+            'time_departure' => $t - 3000, 'time_arrival' => $t - 1200,
             'recycler'       => 5,
         ]));
 
@@ -163,7 +165,7 @@ class SeedStuckFleetMissions extends Command
             'galaxy_from'    => $planet3->galaxy, 'system_from' => $planet3->system, 'position_from' => $planet3->planet,
             'galaxy_to'      => 2, 'system_to' => 100, 'position_to' => 7,
             'mission_type'   => 7,
-            'time_departure' => $now - 6000, 'time_arrival' => $now - 3600,
+            'time_departure' => $t - 6000, 'time_arrival' => $t - 3600,
             'colony_ship'    => 1,
         ]));
 
@@ -175,7 +177,7 @@ class SeedStuckFleetMissions extends Command
             'galaxy_from'    => $planet1->galaxy, 'system_from' => $planet1->system, 'position_from' => $planet1->planet,
             'galaxy_to'      => $planet2->galaxy, 'system_to' => $planet2->system, 'position_to' => $planet2->planet,
             'mission_type'   => 3,
-            'time_departure' => $now - 7200, 'time_arrival' => $now - 5400,
+            'time_departure' => $t - 7200, 'time_arrival' => $t - 5400,
             'processed'      => 1,
             'small_cargo'    => 5, 'metal' => 10000,
         ]));
@@ -190,7 +192,7 @@ class SeedStuckFleetMissions extends Command
             'type_from'      => PlanetType::Moon->value,
             'type_to'        => PlanetType::Planet->value,
             'mission_type'   => 3,
-            'time_departure' => $now - 4800, 'time_arrival' => $now - 3000,
+            'time_departure' => $t - 4800, 'time_arrival' => $t - 3000,
             'small_cargo'    => 5, 'metal' => 10000,
         ]));
 
@@ -202,7 +204,7 @@ class SeedStuckFleetMissions extends Command
             'galaxy_from'    => $planet3->galaxy, 'system_from' => $planet3->system, 'position_from' => $planet3->planet,
             'galaxy_to'      => $planet1->galaxy, 'system_to' => $planet1->system, 'position_to' => $planet1->planet,
             'mission_type'   => 3,
-            'time_departure' => $now - 2400, 'time_arrival' => $now - 1500,
+            'time_departure' => $t - 2400, 'time_arrival' => $t - 1500,
             'small_cargo'    => 8, 'metal' => 25000,
         ]));
 

--- a/app/Console/Commands/Dev/SeedStuckFleetMissions.php
+++ b/app/Console/Commands/Dev/SeedStuckFleetMissions.php
@@ -1,0 +1,239 @@
+<?php
+
+namespace OGame\Console\Commands\Dev;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use OGame\Models\Enums\PlanetType;
+use OGame\Models\Planet;
+use OGame\Models\User;
+
+class SeedStuckFleetMissions extends Command
+{
+    protected $signature = 'ogamex:dev:seed-stuck-fleet-missions
+                            {--fresh : Clear all unprocessed fleet missions for test users before seeding}';
+
+    protected $description = 'Seed stuck (overdue, unprocessed) fleet missions for admin tool testing. Requires ogamex:dev:seed-users to have been run first.';
+
+    private const EMAIL_DOMAIN = 'ogamex.dev';
+
+    public function handle(): int
+    {
+        $users = User::where('email', 'like', '%@' . self::EMAIL_DOMAIN)
+            ->whereIn('username', ['test1', 'test2', 'test3'])
+            ->get()
+            ->keyBy('username');
+
+        foreach (['test1', 'test2', 'test3'] as $needed) {
+            if (!$users->has($needed)) {
+                $this->error("Required user {$needed} not found. Run ogamex:dev:seed-users first.");
+                return self::FAILURE;
+            }
+        }
+
+        /** @var User $user1 */
+        $user1 = $users->get('test1');
+        /** @var User $user2 */
+        $user2 = $users->get('test2');
+        /** @var User $user3 */
+        $user3 = $users->get('test3');
+
+        $planet1 = Planet::where('user_id', $user1->id)->first();
+        $planet2 = Planet::where('user_id', $user2->id)->first();
+        $planet3 = Planet::where('user_id', $user3->id)->first();
+
+        if (!$planet1 || !$planet2 || !$planet3) {
+            $this->error('One or more test users have no planets. Run ogamex:dev:seed-users first.');
+            return self::FAILURE;
+        }
+
+        if ($this->option('fresh')) {
+            $this->warn('Clearing unprocessed fleet missions for test users...');
+            DB::table('fleet_missions')
+                ->whereIn('user_id', [$user1->id, $user2->id, $user3->id])
+                ->where('processed', 0)
+                ->where('canceled', 0)
+                ->delete();
+        }
+
+        $now = (int) now()->timestamp;
+
+        $base = [
+            'processed'             => 0,
+            'processed_hold'        => 0,
+            'canceled'              => 0,
+            'type_from'             => PlanetType::Planet->value,
+            'type_to'               => PlanetType::Planet->value,
+            'deuterium_consumption' => 0,
+            'created_at'            => now(),
+            'updated_at'            => now(),
+        ];
+
+        // 1 – healthy transport test1 → test2
+        $this->seed('Transport test1 → test2', array_merge($base, [
+            'user_id'        => $user1->id,
+            'planet_id_from' => $planet1->id,
+            'planet_id_to'   => $planet2->id,
+            'galaxy_from'    => $planet1->galaxy, 'system_from' => $planet1->system, 'position_from' => $planet1->planet,
+            'galaxy_to'      => $planet2->galaxy, 'system_to' => $planet2->system, 'position_to' => $planet2->planet,
+            'mission_type'   => 3,
+            'time_departure' => $now - 3600, 'time_arrival' => $now - 1800,
+            'small_cargo'    => 10, 'metal' => 50000, 'crystal' => 30000,
+        ]));
+
+        // 2 – healthy transport test2 → test3
+        $this->seed('Transport test2 → test3', array_merge($base, [
+            'user_id'        => $user2->id,
+            'planet_id_from' => $planet2->id,
+            'planet_id_to'   => $planet3->id,
+            'galaxy_from'    => $planet2->galaxy, 'system_from' => $planet2->system, 'position_from' => $planet2->planet,
+            'galaxy_to'      => $planet3->galaxy, 'system_to' => $planet3->system, 'position_to' => $planet3->planet,
+            'mission_type'   => 3,
+            'time_departure' => $now - 7200, 'time_arrival' => $now - 5400,
+            'large_cargo'    => 5, 'deuterium' => 20000,
+        ]));
+
+        // 3 – healthy transport test3 → test1
+        $this->seed('Transport test3 → test1', array_merge($base, [
+            'user_id'        => $user3->id,
+            'planet_id_from' => $planet3->id,
+            'planet_id_to'   => $planet1->id,
+            'galaxy_from'    => $planet3->galaxy, 'system_from' => $planet3->system, 'position_from' => $planet3->planet,
+            'galaxy_to'      => $planet1->galaxy, 'system_to' => $planet1->system, 'position_to' => $planet1->planet,
+            'mission_type'   => 3,
+            'time_departure' => $now - 900, 'time_arrival' => $now - 300,
+            'small_cargo'    => 3, 'crystal' => 15000,
+        ]));
+
+        // 4 – attack test2 → test3
+        $this->seed('Attack test2 → test3', array_merge($base, [
+            'user_id'        => $user2->id,
+            'planet_id_from' => $planet2->id,
+            'planet_id_to'   => $planet3->id,
+            'galaxy_from'    => $planet2->galaxy, 'system_from' => $planet2->system, 'position_from' => $planet2->planet,
+            'galaxy_to'      => $planet3->galaxy, 'system_to' => $planet3->system, 'position_to' => $planet3->planet,
+            'mission_type'   => 1,
+            'time_departure' => $now - 1800, 'time_arrival' => $now - 600,
+            'light_fighter'  => 50, 'heavy_fighter' => 20,
+        ]));
+
+        // 5 – espionage test1 → test2
+        $this->seed('Espionage test1 → test2', array_merge($base, [
+            'user_id'         => $user1->id,
+            'planet_id_from'  => $planet1->id,
+            'planet_id_to'    => $planet2->id,
+            'galaxy_from'     => $planet1->galaxy, 'system_from' => $planet1->system, 'position_from' => $planet1->planet,
+            'galaxy_to'       => $planet2->galaxy, 'system_to' => $planet2->system, 'position_to' => $planet2->planet,
+            'mission_type'    => 6,
+            'time_departure'  => $now - 2700, 'time_arrival' => $now - 2400,
+            'espionage_probe' => 3,
+        ]));
+
+        // 6 – expedition test1 → deep space
+        $this->seed('Expedition test1 → deep space', array_merge($base, [
+            'user_id'        => $user1->id,
+            'planet_id_from' => $planet1->id,
+            'planet_id_to'   => null,
+            'galaxy_from'    => $planet1->galaxy, 'system_from' => $planet1->system, 'position_from' => $planet1->planet,
+            'galaxy_to'      => 1, 'system_to' => 250, 'position_to' => 16,
+            'type_to'        => PlanetType::DeepSpace->value,
+            'mission_type'   => 15,
+            'time_departure' => $now - 4500, 'time_arrival' => $now - 900,
+            'large_cargo'    => 2,
+        ]));
+
+        // 7 – recycle test2 → debris field
+        $this->seed('Recycle test2 → debris', array_merge($base, [
+            'user_id'        => $user2->id,
+            'planet_id_from' => $planet2->id,
+            'planet_id_to'   => null,
+            'galaxy_from'    => $planet2->galaxy, 'system_from' => $planet2->system, 'position_from' => $planet2->planet,
+            'galaxy_to'      => $planet3->galaxy, 'system_to' => $planet3->system, 'position_to' => $planet3->planet,
+            'type_to'        => PlanetType::DebrisField->value,
+            'mission_type'   => 8,
+            'time_departure' => $now - 3000, 'time_arrival' => $now - 1200,
+            'recycler'       => 5,
+        ]));
+
+        // 8 – colonisation test3 → empty slot
+        $this->seed('Colonisation test3 → empty slot', array_merge($base, [
+            'user_id'        => $user3->id,
+            'planet_id_from' => $planet3->id,
+            'planet_id_to'   => null,
+            'galaxy_from'    => $planet3->galaxy, 'system_from' => $planet3->system, 'position_from' => $planet3->planet,
+            'galaxy_to'      => 2, 'system_to' => 100, 'position_to' => 7,
+            'mission_type'   => 7,
+            'time_departure' => $now - 6000, 'time_arrival' => $now - 3600,
+            'colony_ship'    => 1,
+        ]));
+
+        // 9 – broken return: insert a processed parent first, then an unprocessed return with no linked planets
+        $parentId = DB::table('fleet_missions')->insertGetId(array_merge($base, [
+            'user_id'        => $user1->id,
+            'planet_id_from' => $planet1->id,
+            'planet_id_to'   => $planet2->id,
+            'galaxy_from'    => $planet1->galaxy, 'system_from' => $planet1->system, 'position_from' => $planet1->planet,
+            'galaxy_to'      => $planet2->galaxy, 'system_to' => $planet2->system, 'position_to' => $planet2->planet,
+            'mission_type'   => 3,
+            'time_departure' => $now - 7200, 'time_arrival' => $now - 5400,
+            'processed'      => 1,
+            'small_cargo'    => 5, 'metal' => 10000,
+        ]));
+
+        $this->seed('Broken return (no linked planets)', array_merge($base, [
+            'user_id'        => $user1->id,
+            'parent_id'      => $parentId,
+            'planet_id_from' => null,
+            'planet_id_to'   => null,
+            'galaxy_from'    => $planet2->galaxy, 'system_from' => $planet2->system, 'position_from' => $planet2->planet,
+            'galaxy_to'      => $planet1->galaxy, 'system_to' => $planet1->system, 'position_to' => $planet1->planet,
+            'type_from'      => PlanetType::Moon->value,
+            'type_to'        => PlanetType::Planet->value,
+            'mission_type'   => 3,
+            'time_departure' => $now - 4800, 'time_arrival' => $now - 3000,
+            'small_cargo'    => 5, 'metal' => 10000,
+        ]));
+
+        // 10 – missing origin: planet_id_from=null, type_from=Planet → "Missing origin"
+        $this->seed('Missing origin (no planet_id_from)', array_merge($base, [
+            'user_id'        => $user2->id,
+            'planet_id_from' => null,
+            'planet_id_to'   => $planet1->id,
+            'galaxy_from'    => $planet3->galaxy, 'system_from' => $planet3->system, 'position_from' => $planet3->planet,
+            'galaxy_to'      => $planet1->galaxy, 'system_to' => $planet1->system, 'position_to' => $planet1->planet,
+            'mission_type'   => 3,
+            'time_departure' => $now - 2400, 'time_arrival' => $now - 1500,
+            'small_cargo'    => 8, 'metal' => 25000,
+        ]));
+
+        $this->newLine();
+        $this->info('Stuck fleet missions seeded. Visit /admin/server-administration to review.');
+        $this->newLine();
+        $this->table(
+            ['#', 'User', 'Mission type', 'Expected status'],
+            [
+                ['1', 'test1', 'Transport (3)',    'Ready to process'],
+                ['2', 'test2', 'Transport (3)',    'Ready to process'],
+                ['3', 'test3', 'Transport (3)',    'Ready to process'],
+                ['4', 'test2', 'Attack (1)',       'Ready to process'],
+                ['5', 'test1', 'Espionage (6)',    'Ready to process'],
+                ['6', 'test1', 'Expedition (15)',  'Ready to process'],
+                ['7', 'test2', 'Recycle (8)',      'Ready to process'],
+                ['8', 'test3', 'Colonisation (7)', 'Ready to process'],
+                ['9', 'test1', 'Transport (3)',    'Broken return target'],
+                ['10', 'test2', 'Transport (3)',   'Missing origin'],
+            ]
+        );
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function seed(string $label, array $data): void
+    {
+        $this->info("  Inserting: {$label}...");
+        DB::table('fleet_missions')->insert($data);
+    }
+}

--- a/app/Http/Controllers/Admin/ServerAdministrationController.php
+++ b/app/Http/Controllers/Admin/ServerAdministrationController.php
@@ -8,12 +8,19 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\View\View;
+use OGame\Factories\GameMissionFactory;
 use OGame\Factories\PlayerServiceFactory;
 use OGame\Http\Controllers\OGameController;
 use OGame\Models\Ban;
+use OGame\Models\Enums\PlanetType;
+use OGame\Models\FleetMission;
+use OGame\Models\Planet;
 use OGame\Models\User;
+use OGame\Services\FleetMissionService;
 use OGame\Services\SettingsService;
+use RuntimeException;
 use stdClass;
+use Throwable;
 
 class ServerAdministrationController extends OGameController
 {
@@ -129,12 +136,14 @@ class ServerAdministrationController extends OGameController
             ->values();
 
         $botSuspects = $allSuspects->reject(fn ($s) => in_array($s['user']->id, $dismissedUserIds, true))->values();
+        $stuckMissions = $this->getStuckFleetMissions();
 
         return view('ingame.admin.server-administration', [
             'sharedIpGroups'        => $sharedIpGroups,
             'botSuspects'           => $botSuspects,
             'activeBans'            => $activeBans,
             'banHistory'            => $banHistory,
+            'stuckMissions'         => $stuckMissions,
             'detectionSettings'     => $settings,
             'dismissedIpCount'      => count($dismissedIps),
             'dismissedSuspectCount' => $allSuspects->filter(fn ($s) => in_array($s['user']->id, $dismissedUserIds, true))->count(),
@@ -436,6 +445,104 @@ class ServerAdministrationController extends OGameController
     }
 
     /**
+     * Attempts to process a single overdue mission through the normal mission pipeline.
+     */
+    public function processStuckMission(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'mission_id' => ['required', 'integer', 'min:1'],
+        ]);
+
+        try {
+            $message = '';
+
+            DB::transaction(function () use ($validated, &$message) {
+                /** @var FleetMission|null $mission */
+                $mission = FleetMission::query()
+                    ->where('id', $validated['mission_id'])
+                    ->where('processed', 0)
+                    ->where('canceled', 0)
+                    ->lockForUpdate()
+                    ->first();
+
+                if ($mission === null) {
+                    throw new RuntimeException('Mission is no longer active.');
+                }
+
+                $player = resolve(PlayerServiceFactory::class)->make($mission->user_id, true);
+                $fleetMissionService = resolve(FleetMissionService::class, ['player' => $player]);
+                $fleetMissionService->updateMission($mission);
+
+                $mission->refresh();
+                if (!$mission->processed) {
+                    throw new RuntimeException('Mission remains active after processing attempt.');
+                }
+
+                $message = "Mission #{$mission->id} processed successfully.";
+            });
+
+            return redirect()->route('admin.server-administration.index')
+                ->with('status', $message);
+        } catch (Throwable $e) {
+            return redirect()->route('admin.server-administration.index')
+                ->with('error', "Mission #{$validated['mission_id']} could not be processed: {$e->getMessage()}");
+        }
+    }
+
+    /**
+     * Recovers a stuck mission by crediting its fleet and cargo to the player's first planet.
+     */
+    public function recoverStuckMissionToHomeworld(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'mission_id' => ['required', 'integer', 'min:1'],
+        ]);
+
+        try {
+            $message = '';
+
+            DB::transaction(function () use ($validated, &$message) {
+                /** @var FleetMission|null $mission */
+                $mission = FleetMission::query()
+                    ->where('id', $validated['mission_id'])
+                    ->where('processed', 0)
+                    ->where('canceled', 0)
+                    ->lockForUpdate()
+                    ->first();
+
+                if ($mission === null) {
+                    throw new RuntimeException('Mission is no longer active.');
+                }
+
+                $player = resolve(PlayerServiceFactory::class)->make($mission->user_id, true);
+                $homeworld = $player->planets->first();
+                if ($homeworld === null) {
+                    throw new RuntimeException('Player has no valid homeworld to recover the fleet to.');
+                }
+
+                $fleetMissionService = resolve(FleetMissionService::class, ['player' => $player]);
+                $homeworld->addUnits($fleetMissionService->getFleetUnits($mission));
+
+                $resources = $fleetMissionService->getResources($mission);
+                if ($resources->any()) {
+                    $homeworld->addResources($resources);
+                }
+
+                $mission->processed = 1;
+                $mission->save();
+
+                $message = "Mission #{$mission->id} recovered to {$homeworld->getPlanetCoordinates()->asString()}.";
+            });
+
+            return redirect()->route('admin.server-administration.index')
+                ->with('status', $message);
+        } catch (Throwable $e) {
+            return redirect()->route('admin.server-administration.index')
+                ->with('error', "Mission #{$validated['mission_id']} could not be recovered: {$e->getMessage()}");
+        }
+    }
+
+    /**
      * Bans a user.
      */
     public function ban(Request $request): RedirectResponse
@@ -503,5 +610,137 @@ class ServerAdministrationController extends OGameController
 
         return redirect()->route('admin.server-administration.index')
             ->with('status', "User \"{$user->username}\" has been unbanned.");
+    }
+
+    /**
+     * Returns overdue unprocessed missions with enough context for admin recovery actions.
+     */
+    private function getStuckFleetMissions(): Collection
+    {
+        $now = (int) now()->timestamp;
+
+        $missions = FleetMission::query()
+            ->where('processed', 0)
+            ->where('canceled', 0)
+            ->where('time_arrival', '<=', $now)
+            ->orderBy('time_arrival')
+            ->get();
+
+        if ($missions->isEmpty()) {
+            return collect();
+        }
+
+        $users = User::whereIn('id', $missions->pluck('user_id')->unique()->all())
+            ->get()
+            ->keyBy('id');
+
+        $planetIds = $missions
+            ->flatMap(fn (FleetMission $mission) => [$mission->planet_id_from, $mission->planet_id_to])
+            ->filter(fn ($planetId) => $planetId !== null)
+            ->unique()
+            ->values()
+            ->all();
+
+        $planets = Planet::whereIn('id', $planetIds)->get()->keyBy('id');
+
+        $missionTypeLabels = collect(GameMissionFactory::getAllMissions())
+            ->mapWithKeys(fn ($mission, $id) => [$id => $mission::getName()]);
+
+        $stuckMissionRows = [];
+
+        foreach ($missions as $mission) {
+            $originRequiresPlanet = in_array($mission->type_from, [PlanetType::Planet->value, PlanetType::Moon->value], true);
+            $destinationRequiresPlanet = in_array($mission->type_to, [PlanetType::Planet->value, PlanetType::Moon->value], true);
+            $destinationCanBeMissing = $mission->parent_id === null && in_array($mission->mission_type, [7, 8, 15], true);
+
+            $originExists = !$originRequiresPlanet || ($mission->planet_id_from !== null && $planets->has($mission->planet_id_from));
+            $destinationExists = !$destinationRequiresPlanet
+                || $destinationCanBeMissing
+                || ($mission->planet_id_to !== null && $planets->has($mission->planet_id_to));
+
+            [$statusLabel, $statusColor, $canProcess] = $this->classifyStuckMission(
+                $mission,
+                $originExists,
+                $destinationExists
+            );
+
+            $overdueSeconds = max(0, $now - (int) $mission->time_arrival);
+
+            $stuckMissionRows[] = [
+                'id' => $mission->id,
+                'user' => $users->get($mission->user_id),
+                'parent_id' => $mission->parent_id,
+                'mission_type' => $mission->mission_type,
+                'mission_label' => $missionTypeLabels->get($mission->mission_type, 'Unknown'),
+                'time_arrival' => (int) $mission->time_arrival,
+                'overdue_seconds' => $overdueSeconds,
+                'planet_id_from' => $mission->planet_id_from,
+                'planet_id_to' => $mission->planet_id_to,
+                'coordinates_from' => $mission->galaxy_from . ':' . $mission->system_from . ':' . $mission->position_from,
+                'coordinates_to' => $mission->galaxy_to . ':' . $mission->system_to . ':' . $mission->position_to,
+                'type_from_label' => $this->planetTypeLabel((int) $mission->type_from),
+                'type_to_label' => $this->planetTypeLabel((int) $mission->type_to),
+                'status_label' => $statusLabel,
+                'status_color' => $statusColor,
+                'can_process' => $canProcess,
+            ];
+        }
+
+        /** @var Collection<int, array{
+         *     id: int,
+         *     user: User|null,
+         *     parent_id: int|null,
+         *     mission_type: int,
+         *     mission_label: string,
+         *     time_arrival: int,
+         *     overdue_seconds: int,
+         *     planet_id_from: int|null,
+         *     planet_id_to: int|null,
+         *     coordinates_from: string,
+         *     coordinates_to: string,
+         *     type_from_label: string,
+         *     type_to_label: string,
+         *     status_label: string,
+         *     status_color: string,
+         *     can_process: bool
+         * }>$collection
+         */
+        $collection = collect($stuckMissionRows);
+
+        return $collection;
+    }
+
+    /**
+     * @return array{0:string,1:string,2:bool}
+     */
+    private function classifyStuckMission(FleetMission $mission, bool $originExists, bool $destinationExists): array
+    {
+        if ($mission->parent_id !== null) {
+            // Return missions: only the destination matters — processReturn() never reads planet_id_from.
+            return $destinationExists
+                ? ['Ready to process', '#2ecc71', true]
+                : ['Broken return target', '#e74c3c', false];
+        }
+
+        if (!$originExists) {
+            return ['Missing origin', '#f39c12', false];
+        }
+
+        if (!$destinationExists) {
+            return ['Missing destination', '#f39c12', true];
+        }
+
+        return ['Ready to process', '#2ecc71', true];
+    }
+
+    private function planetTypeLabel(int $planetType): string
+    {
+        return match ($planetType) {
+            PlanetType::Planet->value => 'Planet',
+            PlanetType::Moon->value => 'Moon',
+            PlanetType::DebrisField->value => 'Debris',
+            PlanetType::DeepSpace->value => 'Deep Space',
+            default => 'Unknown',
+        };
     }
 }

--- a/app/Http/Controllers/Admin/ServerAdministrationController.php
+++ b/app/Http/Controllers/Admin/ServerAdministrationController.php
@@ -136,7 +136,8 @@ class ServerAdministrationController extends OGameController
             ->values();
 
         $botSuspects = $allSuspects->reject(fn ($s) => in_array($s['user']->id, $dismissedUserIds, true))->values();
-        $stuckMissions = $this->getStuckFleetMissions();
+        $stuckMissionsSettings = $this->stuckMissionsSettings();
+        $stuckMissions = $this->getStuckFleetMissions($stuckMissionsSettings['min_overdue_hours']);
 
         return view('ingame.admin.server-administration', [
             'sharedIpGroups'        => $sharedIpGroups,
@@ -144,6 +145,7 @@ class ServerAdministrationController extends OGameController
             'activeBans'            => $activeBans,
             'banHistory'            => $banHistory,
             'stuckMissions'         => $stuckMissions,
+            'stuckMissionsSettings' => $stuckMissionsSettings,
             'detectionSettings'     => $settings,
             'dismissedIpCount'      => count($dismissedIps),
             'dismissedSuspectCount' => $allSuspects->filter(fn ($s) => in_array($s['user']->id, $dismissedUserIds, true))->count(),
@@ -445,6 +447,38 @@ class ServerAdministrationController extends OGameController
     }
 
     /**
+     * Returns the current stuck-mission display settings with their defaults.
+     *
+     * @return array<string, int>
+     */
+    private function stuckMissionsSettings(): array
+    {
+        $s = resolve(SettingsService::class);
+
+        return [
+            'min_overdue_hours' => (int) $s->get('stuck_missions_min_overdue_hours', 24),
+        ];
+    }
+
+    /**
+     * Saves the stuck-mission display settings.
+     */
+    public function saveStuckMissionSettings(Request $request): RedirectResponse
+    {
+        $request->validate([
+            'stuck_missions_min_overdue_hours' => ['required', 'integer', 'min:0', 'max:720'],
+        ]);
+
+        resolve(SettingsService::class)->set(
+            'stuck_missions_min_overdue_hours',
+            (string) $request->input('stuck_missions_min_overdue_hours')
+        );
+
+        return redirect()->route('admin.server-administration.index')
+            ->with('status', 'Stuck mission settings saved.');
+    }
+
+    /**
      * Attempts to process a single overdue mission through the normal mission pipeline.
      */
     public function processStuckMission(Request $request): RedirectResponse
@@ -615,14 +649,14 @@ class ServerAdministrationController extends OGameController
     /**
      * Returns overdue unprocessed missions with enough context for admin recovery actions.
      */
-    private function getStuckFleetMissions(): Collection
+    private function getStuckFleetMissions(int $minOverdueHours = 24): Collection
     {
-        $now = (int) now()->timestamp;
+        $cutoff = now()->subHours($minOverdueHours)->timestamp;
 
         $missions = FleetMission::query()
             ->where('processed', 0)
             ->where('canceled', 0)
-            ->where('time_arrival', '<=', $now)
+            ->where('time_arrival', '<=', $cutoff)
             ->orderBy('time_arrival')
             ->get();
 
@@ -664,7 +698,7 @@ class ServerAdministrationController extends OGameController
                 $destinationExists
             );
 
-            $overdueSeconds = max(0, $now - (int) $mission->time_arrival);
+            $overdueSeconds = max(0, (int) now()->timestamp - (int) $mission->time_arrival);
 
             $stuckMissionRows[] = [
                 'id' => $mission->id,

--- a/resources/views/ingame/admin/server-administration.blade.php
+++ b/resources/views/ingame/admin/server-administration.blade.php
@@ -320,6 +320,97 @@
                         </div>
                     @endif
 
+                    <style>
+                        .stuck-missions-scroll::-webkit-scrollbar { width: 5px; }
+                        .stuck-missions-scroll::-webkit-scrollbar-thumb { background: #3d5b75; border-radius: 5px; }
+                        .stuck-missions-scroll::-webkit-scrollbar-thumb:hover { background: #567394; }
+                        .stuck-missions-scroll::-webkit-scrollbar-track { background: #090909; border-radius: 5px; }
+                    </style>
+
+                    {{-- ===== STUCK FLEET MISSIONS ===== --}}
+                    <p class="box_highlight textCenter no_buddies" style="margin-top: 20px;">@lang('Stuck Fleet Missions')</p>
+                    @if ($stuckMissions->isEmpty())
+                        <div class="group bborder" style="display: block;">
+                            <p style="text-align: center; padding: 10px;">No overdue unprocessed fleet missions found.</p>
+                        </div>
+                    @else
+                        <div class="group bborder" style="display: block;">
+                            <div style="padding: 8px 10px; color: #aaa; font-size: 11px;">
+                                {{ $stuckMissions->count() }} overdue mission(s). Use normal processing for healthy rows, or recover broken fleets directly to the player's homeworld.
+                            </div>
+                            <div class="stuck-missions-scroll" style="max-height: 320px; overflow-y: auto;">
+                                <table style="width: 100%; border-collapse: collapse; font-size: 11px; table-layout: fixed;">
+                                    <colgroup>
+                                        <col style="width: 16%">
+                                        <col style="width: 9%">
+                                        <col style="width: 9%">
+                                        <col style="width: 9%">
+                                        <col style="width: 14%">
+                                        <col style="width: 18%">
+                                        <col style="width: 25%">
+                                    </colgroup>
+                                    <thead>
+                                        <tr style="background: #0d0d1a; color: #aaa; font-size: 11px;">
+                                            <th style="padding: 4px 6px; text-align: left;">Mission</th>
+                                            <th style="padding: 4px 6px; text-align: left;">Player</th>
+                                            <th style="padding: 4px 6px; text-align: left;">From</th>
+                                            <th style="padding: 4px 6px; text-align: left;">To</th>
+                                            <th style="padding: 4px 6px; text-align: left;">Arrival (overdue)</th>
+                                            <th style="padding: 4px 6px; text-align: left;">Status</th>
+                                            <th style="padding: 4px 6px; text-align: left;">Actions</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        @foreach ($stuckMissions as $mission)
+                                            <tr style="border-top: 1px solid #222;">
+                                                <td style="padding: 4px 6px; vertical-align: middle; overflow: hidden;">
+                                                    <strong style="color: #aaa;">#{{ $mission['id'] }}</strong>
+                                                    <span style="font-size: 10px; background: #1a0a0a; padding: 1px 5px; border-radius: 3px; color: #aaa; margin-left: 2px;">{{ $mission['mission_label'] }}</span>
+                                                    @if ($mission['parent_id'])
+                                                        <div style="font-size: 10px; color: #666;">↩ #{{ $mission['parent_id'] }}</div>
+                                                    @endif
+                                                </td>
+                                                <td style="padding: 4px 6px; vertical-align: middle; overflow: hidden;">
+                                                    {{ $mission['user']?->username ?? 'Unknown' }}
+                                                </td>
+                                                <td style="padding: 4px 6px; vertical-align: middle; font-family: monospace; overflow: hidden;">
+                                                    {{ $mission['coordinates_from'] }}
+                                                </td>
+                                                <td style="padding: 4px 6px; vertical-align: middle; font-family: monospace; overflow: hidden;">
+                                                    {{ $mission['coordinates_to'] }}
+                                                </td>
+                                                <td style="padding: 4px 6px; vertical-align: middle; overflow: hidden;">
+                                                    {{ \Illuminate\Support\Carbon::createFromTimestamp($mission['time_arrival'])->format('Y-m-d H:i') }}
+                                                </td>
+                                                <td style="padding: 4px 6px; vertical-align: middle; overflow: hidden;">
+                                                    <span style="font-weight: bold; color: {{ $mission['status_color'] }};">{{ $mission['status_label'] }}</span>
+                                                </td>
+                                                <td style="padding: 4px 6px; vertical-align: middle;">
+                                                    <div style="display: flex; flex-direction: column; gap: 3px; align-items: flex-start;">
+                                                        @if ($mission['can_process'])
+                                                            <form action="{{ route('admin.server-administration.stuck-missions.process') }}" method="post" style="display: inline-block; margin: 0;">
+                                                                {{ csrf_field() }}
+                                                                <input type="hidden" name="mission_id" value="{{ $mission['id'] }}">
+                                                                <input type="submit" class="btn_blue" value="Process" style="font-size: 10px; padding: 2px 8px;">
+                                                            </form>
+                                                        @else
+                                                            <span style="color: #555; font-size: 10px;">Processing blocked</span>
+                                                            <form action="{{ route('admin.server-administration.stuck-missions.recover-homeworld') }}" method="post" style="display: inline-block; margin: 0;">
+                                                                {{ csrf_field() }}
+                                                                <input type="hidden" name="mission_id" value="{{ $mission['id'] }}">
+                                                                <input type="submit" class="btn_blue" value="Recover to Homeworld" style="font-size: 10px; padding: 2px 6px;">
+                                                            </form>
+                                                        @endif
+                                                    </div>
+                                                </td>
+                                            </tr>
+                                        @endforeach
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    @endif
+
                     {{-- ===== BOT DETECTION SETTINGS ===== --}}
                     <p class="box_highlight textCenter no_buddies" style="margin-top: 20px;">@lang('Bot Detection Settings')</p>
                     <form action="{{ route('admin.server-administration.detection-settings') }}" method="post">

--- a/resources/views/ingame/admin/server-administration.blade.php
+++ b/resources/views/ingame/admin/server-administration.blade.php
@@ -329,14 +329,28 @@
 
                     {{-- ===== STUCK FLEET MISSIONS ===== --}}
                     <p class="box_highlight textCenter no_buddies" style="margin-top: 20px;">@lang('Stuck Fleet Missions')</p>
+                    <form action="{{ route('admin.server-administration.stuck-missions.settings') }}" method="post">
+                        {{ csrf_field() }}
+                        <div class="group bborder" style="display: block;">
+                            <div class="fieldwrapper">
+                                <label class="styled textBeefy" for="stuck_min_overdue_hours" title="Only show missions that have been overdue for at least this many hours. Filters out healthy missions that are simply waiting for the player to log in.">Min. overdue (hours):</label>
+                                <div class="thefield">
+                                    <input type="text" id="stuck_min_overdue_hours" name="stuck_missions_min_overdue_hours" class="textInput w80 textCenter textBeefy" pattern="^[0-9]+$" value="{{ $stuckMissionsSettings['min_overdue_hours'] }}">
+                                </div>
+                            </div>
+                            <div class="fieldwrapper" style="text-align: center; margin-top: 10px; margin-bottom: 10px;">
+                                <input type="submit" class="btn_blue" value="Save Settings">
+                            </div>
+                        </div>
+                    </form>
                     @if ($stuckMissions->isEmpty())
                         <div class="group bborder" style="display: block;">
-                            <p style="text-align: center; padding: 10px;">No overdue unprocessed fleet missions found.</p>
+                            <p style="text-align: center; padding: 10px;">No missions overdue by more than {{ $stuckMissionsSettings['min_overdue_hours'] }}h found.</p>
                         </div>
                     @else
                         <div class="group bborder" style="display: block;">
                             <div style="padding: 8px 10px; color: #aaa; font-size: 11px;">
-                                {{ $stuckMissions->count() }} overdue mission(s). Use normal processing for healthy rows, or recover broken fleets directly to the player's homeworld.
+                                {{ $stuckMissions->count() }} mission(s) overdue by more than {{ $stuckMissionsSettings['min_overdue_hours'] }}h. Use normal processing for healthy rows, or recover broken fleets directly to the player's homeworld.
                             </div>
                             <div class="stuck-missions-scroll" style="max-height: 320px; overflow-y: auto;">
                                 <table style="width: 100%; border-collapse: collapse; font-size: 11px; table-layout: fixed;">

--- a/routes/web.php
+++ b/routes/web.php
@@ -278,6 +278,8 @@ Route::middleware(['auth', 'globalgame', 'locale', 'admin'])->group(function () 
     Route::post('/admin/server-administration/detection-settings', [ServerAdministrationController::class, 'saveDetectionSettings'])->name('admin.server-administration.detection-settings');
     Route::post('/admin/server-administration/dismiss', [ServerAdministrationController::class, 'dismiss'])->name('admin.server-administration.dismiss');
     Route::post('/admin/server-administration/clear-cache', [ServerAdministrationController::class, 'clearCache'])->name('admin.server-administration.clear-cache');
+    Route::post('/admin/server-administration/stuck-missions/process', [ServerAdministrationController::class, 'processStuckMission'])->name('admin.server-administration.stuck-missions.process');
+    Route::post('/admin/server-administration/stuck-missions/recover-homeworld', [ServerAdministrationController::class, 'recoverStuckMissionToHomeworld'])->name('admin.server-administration.stuck-missions.recover-homeworld');
 
     // Developer shortcuts
     Route::get('/admin/developer-shortcuts', [DeveloperShortcutsController::class, 'index'])->name('admin.developershortcuts.index');

--- a/routes/web.php
+++ b/routes/web.php
@@ -278,6 +278,7 @@ Route::middleware(['auth', 'globalgame', 'locale', 'admin'])->group(function () 
     Route::post('/admin/server-administration/detection-settings', [ServerAdministrationController::class, 'saveDetectionSettings'])->name('admin.server-administration.detection-settings');
     Route::post('/admin/server-administration/dismiss', [ServerAdministrationController::class, 'dismiss'])->name('admin.server-administration.dismiss');
     Route::post('/admin/server-administration/clear-cache', [ServerAdministrationController::class, 'clearCache'])->name('admin.server-administration.clear-cache');
+    Route::post('/admin/server-administration/stuck-missions/settings', [ServerAdministrationController::class, 'saveStuckMissionSettings'])->name('admin.server-administration.stuck-missions.settings');
     Route::post('/admin/server-administration/stuck-missions/process', [ServerAdministrationController::class, 'processStuckMission'])->name('admin.server-administration.stuck-missions.process');
     Route::post('/admin/server-administration/stuck-missions/recover-homeworld', [ServerAdministrationController::class, 'recoverStuckMissionToHomeworld'])->name('admin.server-administration.stuck-missions.recover-homeworld');
 

--- a/tests/Feature/AdminStuckFleetMissionTest.php
+++ b/tests/Feature/AdminStuckFleetMissionTest.php
@@ -151,8 +151,8 @@ class AdminStuckFleetMissionTest extends AccountTestCase
             'type_from' => PlanetType::Planet->value,
             'type_to' => PlanetType::Moon->value,
             'mission_type' => 3,
-            'time_departure' => Date::now()->subMinutes(30)->timestamp,
-            'time_arrival' => Date::now()->subMinutes(20)->timestamp,
+            'time_departure' => Date::now()->subHours(26)->timestamp,
+            'time_arrival' => Date::now()->subHours(25)->timestamp,
             'processed' => 1,
         ]);
 
@@ -164,8 +164,8 @@ class AdminStuckFleetMissionTest extends AccountTestCase
             'type_from' => PlanetType::Moon->value,
             'type_to' => PlanetType::Planet->value,
             'mission_type' => 3,
-            'time_departure' => Date::now()->subMinutes(15)->timestamp,
-            'time_arrival' => Date::now()->subMinutes(10)->timestamp,
+            'time_departure' => Date::now()->subHours(25)->timestamp,
+            'time_arrival' => Date::now()->subHours(24)->subMinutes(30)->timestamp,
             'small_cargo' => 3,
             'metal' => 1234,
             'crystal' => 567,
@@ -182,8 +182,8 @@ class AdminStuckFleetMissionTest extends AccountTestCase
             'type_from' => PlanetType::Planet->value,
             'type_to' => PlanetType::Moon->value,
             'mission_type' => 3,
-            'time_departure' => Date::now()->subMinutes(12)->timestamp,
-            'time_arrival' => Date::now()->subMinutes(6)->timestamp,
+            'time_departure' => Date::now()->subHours(25)->timestamp,
+            'time_arrival' => Date::now()->subHours(24)->subMinutes(30)->timestamp,
             'small_cargo' => 2,
         ]);
     }

--- a/tests/Feature/AdminStuckFleetMissionTest.php
+++ b/tests/Feature/AdminStuckFleetMissionTest.php
@@ -1,0 +1,226 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\DB;
+use OGame\Factories\PlayerServiceFactory;
+use OGame\Models\Enums\PlanetType;
+use OGame\Models\FleetMission;
+use OGame\Models\Message;
+use OGame\Models\Planet;
+use OGame\Models\User;
+use Tests\AccountTestCase;
+
+class AdminStuckFleetMissionTest extends AccountTestCase
+{
+    /** @var array<int, int> */
+    private array $createdUserIds = [];
+
+    /** @var array<int, int> */
+    private array $createdMissionIds = [];
+
+    protected function tearDown(): void
+    {
+        if (!empty($this->createdMissionIds)) {
+            FleetMission::whereIn('parent_id', $this->createdMissionIds)->delete();
+            FleetMission::whereIn('id', $this->createdMissionIds)->delete();
+        }
+
+        if (!empty($this->createdUserIds)) {
+            $planetIds = Planet::whereIn('user_id', $this->createdUserIds)->pluck('id')->all();
+
+            if (!empty($planetIds)) {
+                FleetMission::where(function ($query) use ($planetIds) {
+                    $query->whereIn('planet_id_from', $planetIds)
+                        ->orWhereIn('planet_id_to', $planetIds);
+                })->delete();
+            }
+
+            Message::whereIn('user_id', $this->createdUserIds)->delete();
+            DB::table('users_tech')->whereIn('user_id', $this->createdUserIds)->delete();
+            Planet::whereIn('user_id', $this->createdUserIds)->delete();
+            User::whereIn('id', $this->createdUserIds)->delete();
+        }
+
+        parent::tearDown();
+    }
+
+    public function testAdminCanSeeBrokenOverdueMissionInServerAdministration(): void
+    {
+        $this->artisan('ogamex:admin:assign-role', ['username' => auth()->user()->username]);
+
+        $victim = $this->createTrackedSecondaryUser();
+        $returnMission = $this->createBrokenReturnMission($victim['user_id'], $victim['homeworld_id']);
+
+        $response = $this->get(route('admin.server-administration.index'));
+
+        $response->assertStatus(200);
+        $response->assertSee('Stuck Fleet Missions');
+        $response->assertSee((string) $returnMission->id);
+        $response->assertSee('Broken return target');
+        $response->assertSee('Recover to Homeworld');
+    }
+
+    public function testAdminCanRecoverBrokenReturnMissionToVictimHomeworld(): void
+    {
+        $this->artisan('ogamex:admin:assign-role', ['username' => auth()->user()->username]);
+
+        $victim = $this->createTrackedSecondaryUser();
+        $returnMission = $this->createBrokenReturnMission($victim['user_id'], $victim['homeworld_id']);
+
+        $homeworldBefore = Planet::findOrFail($victim['homeworld_id']);
+
+        $response = $this->post(route('admin.server-administration.stuck-missions.recover-homeworld'), [
+            'mission_id' => $returnMission->id,
+        ]);
+
+        $response->assertRedirect(route('admin.server-administration.index'));
+        $response->assertSessionHas('status');
+
+        $returnMission->refresh();
+        $homeworldAfter = Planet::findOrFail($victim['homeworld_id']);
+
+        $this->assertSame(1, $returnMission->processed);
+        $this->assertSame($homeworldBefore->small_cargo + 3, $homeworldAfter->small_cargo);
+        $this->assertEquals($homeworldBefore->metal + 1234, $homeworldAfter->metal);
+        $this->assertEquals($homeworldBefore->crystal + 567, $homeworldAfter->crystal);
+        $this->assertEquals($homeworldBefore->deuterium + 89, $homeworldAfter->deuterium);
+    }
+
+    public function testAdminCanProcessOverdueMissionWithMissingDestination(): void
+    {
+        $this->artisan('ogamex:admin:assign-role', ['username' => auth()->user()->username]);
+
+        $victim = $this->createTrackedSecondaryUser();
+        $outboundMission = $this->createMissingDestinationOutboundMission($victim['user_id'], $victim['homeworld_id']);
+
+        $response = $this->post(route('admin.server-administration.stuck-missions.process'), [
+            'mission_id' => $outboundMission->id,
+        ]);
+
+        $response->assertRedirect(route('admin.server-administration.index'));
+        $response->assertSessionHas('status');
+
+        $outboundMission->refresh();
+        $returnMission = FleetMission::where('parent_id', $outboundMission->id)->first();
+
+        $this->assertSame(1, $outboundMission->processed);
+        $this->assertNotNull($returnMission);
+        $this->assertSame($victim['homeworld_id'], $returnMission->planet_id_to);
+    }
+
+    /**
+     * @return array{user_id:int,homeworld_id:int}
+     */
+    private function createTrackedSecondaryUser(): array
+    {
+        $adminUserId = $this->currentUserId;
+        $adminUsername = $this->currentUsername;
+        $adminPlanetId = $this->currentPlanetId;
+
+        $this->createAndLoginUser();
+
+        $victimUserId = $this->currentUserId;
+        $victimHomeworldId = $this->planetService->getPlanetId();
+        $this->createdUserIds[] = $victimUserId;
+
+        $this->be(User::findOrFail($adminUserId));
+
+        $this->currentUserId = $adminUserId;
+        $this->currentUsername = $adminUsername;
+        $this->currentPlanetId = $adminPlanetId;
+
+        $adminPlayer = resolve(PlayerServiceFactory::class)->make($adminUserId, true);
+        $this->planetService = $adminPlayer->planets->current();
+        $allPlanets = $adminPlayer->planets->allPlanets();
+        $this->secondPlanetService = $allPlanets[1] ?? null;
+
+        return [
+            'user_id' => $victimUserId,
+            'homeworld_id' => $victimHomeworldId,
+        ];
+    }
+
+    private function createBrokenReturnMission(int $userId, int $homeworldId): FleetMission
+    {
+        $parentMission = $this->createMission([
+            'user_id' => $userId,
+            'planet_id_from' => $homeworldId,
+            'planet_id_to' => $homeworldId,
+            'type_from' => PlanetType::Planet->value,
+            'type_to' => PlanetType::Moon->value,
+            'mission_type' => 3,
+            'time_departure' => Date::now()->subMinutes(30)->timestamp,
+            'time_arrival' => Date::now()->subMinutes(20)->timestamp,
+            'processed' => 1,
+        ]);
+
+        return $this->createMission([
+            'user_id' => $userId,
+            'parent_id' => $parentMission->id,
+            'planet_id_from' => null,
+            'planet_id_to' => null,
+            'type_from' => PlanetType::Moon->value,
+            'type_to' => PlanetType::Planet->value,
+            'mission_type' => 3,
+            'time_departure' => Date::now()->subMinutes(15)->timestamp,
+            'time_arrival' => Date::now()->subMinutes(10)->timestamp,
+            'small_cargo' => 3,
+            'metal' => 1234,
+            'crystal' => 567,
+            'deuterium' => 89,
+        ]);
+    }
+
+    private function createMissingDestinationOutboundMission(int $userId, int $homeworldId): FleetMission
+    {
+        return $this->createMission([
+            'user_id' => $userId,
+            'planet_id_from' => $homeworldId,
+            'planet_id_to' => null,
+            'type_from' => PlanetType::Planet->value,
+            'type_to' => PlanetType::Moon->value,
+            'mission_type' => 3,
+            'time_departure' => Date::now()->subMinutes(12)->timestamp,
+            'time_arrival' => Date::now()->subMinutes(6)->timestamp,
+            'small_cargo' => 2,
+        ]);
+    }
+
+    /**
+     * @param array<string, int|float|string|null> $attributes
+     */
+    private function createMission(array $attributes): FleetMission
+    {
+        $mission = new FleetMission();
+        $mission->user_id = (int) $attributes['user_id'];
+        $mission->parent_id = isset($attributes['parent_id']) ? (int) $attributes['parent_id'] : null;
+        $mission->planet_id_from = isset($attributes['planet_id_from']) ? (int) $attributes['planet_id_from'] : null;
+        $mission->planet_id_to = isset($attributes['planet_id_to']) ? (int) $attributes['planet_id_to'] : null;
+        $mission->galaxy_from = isset($attributes['galaxy_from']) ? (int) $attributes['galaxy_from'] : 1;
+        $mission->system_from = isset($attributes['system_from']) ? (int) $attributes['system_from'] : 1;
+        $mission->position_from = isset($attributes['position_from']) ? (int) $attributes['position_from'] : 1;
+        $mission->galaxy_to = isset($attributes['galaxy_to']) ? (int) $attributes['galaxy_to'] : 1;
+        $mission->system_to = isset($attributes['system_to']) ? (int) $attributes['system_to'] : 1;
+        $mission->position_to = isset($attributes['position_to']) ? (int) $attributes['position_to'] : 1;
+        $mission->type_from = isset($attributes['type_from']) ? (int) $attributes['type_from'] : PlanetType::Planet->value;
+        $mission->type_to = isset($attributes['type_to']) ? (int) $attributes['type_to'] : PlanetType::Planet->value;
+        $mission->mission_type = isset($attributes['mission_type']) ? (int) $attributes['mission_type'] : 3;
+        $mission->time_departure = isset($attributes['time_departure']) ? (int) $attributes['time_departure'] : (int) Date::now()->subMinutes(10)->timestamp;
+        $mission->time_arrival = isset($attributes['time_arrival']) ? (int) $attributes['time_arrival'] : (int) Date::now()->subMinutes(5)->timestamp;
+        $mission->processed = isset($attributes['processed']) ? (int) $attributes['processed'] : 0;
+        $mission->processed_hold = 0;
+        $mission->canceled = 0;
+        $mission->metal = isset($attributes['metal']) ? (float) $attributes['metal'] : 0;
+        $mission->crystal = isset($attributes['crystal']) ? (float) $attributes['crystal'] : 0;
+        $mission->deuterium = isset($attributes['deuterium']) ? (float) $attributes['deuterium'] : 0;
+        $mission->deuterium_consumption = 0;
+        $mission->small_cargo = isset($attributes['small_cargo']) ? (int) $attributes['small_cargo'] : 0;
+        $mission->save();
+
+        $this->createdMissionIds[] = $mission->id;
+
+        return $mission;
+    }
+}


### PR DESCRIPTION
## Description
This PR adds a new Stuck Fleet Missions section to the server administration panel that lets admins detect and manually recover overdue unprocessed fleet missions, such as situations where the game scheduler fell behind or a mission entered a broken state (e.g. the origin or destination planet was deleted mid-flight).

What's new:                            

Two recovery actions per mission:
- Process: runs the mission through the normal game pipeline (`FleetMissionService::updateMission()`). Side effects (battle reports, messages, return missions) happen as normal. Use this for healthy missions the scheduler simply missed.                                                                                                                                                                        
- Recover to Homeworld:  bypasses game logic entirely; credits ships and cargo directly to the fleet owner's first planet and marks the mission processed. Only shown when normal processing is blocked (broken return target, missing origin).  

Classification logic distinguishes four states:
- `Ready to process`: normal pipeline will succeed                                                                                                                                                            
- `Missing destination`: outbound to a now-deleted planet; game already handles this by auto-returning the fleet                                                                                              
- `Missing origin`: dispatched from a deleted planet; recovery only                                             
- `Broken return target`: return mission with no valid destination; recovery only

Seeder for local testing:                                                                                                                                                                                    
`ogamex:dev:seed-stuck-fleet-missions`                                                                                                            
Requires `ogamex:dev:seed-users` to have been run first. Seeds 10 representative missions covering all four classification states across transport, attack, espionage, expedition, recycle, and colonisation types. 

### Type of Change:
- [ ] Bug fix
- [X] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #[issue-number]

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [X] **Automated Refactoring:** Rector has been run and no outstanding issues remain.
- [X] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [X] **Static Analysis:** Code passes PHPStan static code analysis.
- [X] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [X] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [X] **Documentation:** Documentation has been updated to reflect any changes made.

## Additional Information
Add any additional context, screenshots, or explanations to help reviewers understand your PR. If this change introduces any breaking changes or significant impacts, please detail them here.
