### PR TITLE
fix: Hide wreck field when Space Dock has not been built

### DIFF
--- a/app/Http/Controllers/FacilitiesController.php
+++ b/app/Http/Controllers/FacilitiesController.php
@@ -77,8 +77,11 @@ class FacilitiesController extends AbstractBuildingsController
         // Get parent parameters
         $params = parent::indexPageParams($request, $player);
 
-        // Add wreck field data
-        $wreckFieldData = $this->wreckFieldService->getWreckFieldForCurrentPlanet($this->planet);
+        // Only expose wreck field data when the player has a Space Dock (level >= 1).
+        $spaceDockLevel = $this->planet->getObjectLevel('space_dock');
+        $wreckFieldData = $spaceDockLevel >= 1
+            ? $this->wreckFieldService->getWreckFieldForCurrentPlanet($this->planet)
+            : null;
         $params['wreckField'] = $wreckFieldData;
 
         return $params;
@@ -307,7 +310,11 @@ class FacilitiesController extends AbstractBuildingsController
             $planetService = $player->planets->current();
 
             $wreckFieldService = new WreckFieldService($player, app(SettingsService::class));
-            $wreckField = $wreckFieldService->getWreckFieldForCurrentPlanet($planetService);
+
+            $spaceDockLevel = $planetService->getObjectLevel('space_dock');
+            $wreckField = $spaceDockLevel >= 1
+                ? $wreckFieldService->getWreckFieldForCurrentPlanet($planetService)
+                : null;
 
             return response()->json([
                 'success' => true,

--- a/tests/Feature/FacilitiesWreckFieldTest.php
+++ b/tests/Feature/FacilitiesWreckFieldTest.php
@@ -8,6 +8,17 @@ use Tests\AccountTestCase;
 
 class FacilitiesWreckFieldTest extends AccountTestCase
 {
+    protected function tearDown(): void
+    {
+        $coords = $this->planetService->getPlanetCoordinates();
+        WreckField::where('galaxy', $coords->galaxy)
+            ->where('system', $coords->system)
+            ->where('planet', $coords->position)
+            ->delete();
+
+        parent::tearDown();
+    }
+
     /**
      * Set the space_dock column on the current planet directly.
      */
@@ -261,6 +272,35 @@ class FacilitiesWreckFieldTest extends AccountTestCase
         $this->assertTrue($data['wreckField']['can_repair']);
         $this->assertFalse($data['wreckField']['is_repairing']);
         $this->assertFalse($data['wreckField']['is_completed']);
+    }
+
+    public function test_wreck_field_hidden_without_space_dock(): void
+    {
+        $this->giveCurrentPlanetSpaceDock(0);
+        $this->createWreckField();
+
+        // Status endpoint must return null wreckField when Space Dock is not built.
+        $response = $this->getJson(route('facilities.wreckfieldstatus'));
+        $response->assertStatus(200);
+        $response->assertJson([
+            'success' => true,
+            'error' => false,
+        ]);
+        $this->assertNull($response->json('wreckField'));
+    }
+
+    public function test_wreck_field_visible_with_space_dock(): void
+    {
+        $this->giveCurrentPlanetSpaceDock(1);
+        $this->createWreckField();
+
+        $response = $this->getJson(route('facilities.wreckfieldstatus'));
+        $response->assertStatus(200);
+        $response->assertJson([
+            'success' => true,
+            'error' => false,
+        ]);
+        $this->assertNotNull($response->json('wreckField'));
     }
 
     public function test_all_endpoints_fail_when_not_authenticated(): void


### PR DESCRIPTION
## Description
This PR fixes a bug where wreckage / wreck fields were visible to players despite the Space Dock not having been built. Wreck field data is now gated behind space_dock >= 1 in both the page load and the AJAX status endpoint. The `FacilitiesController` was unconditionally fetching and returning wreck field data regardless of the player's Space Dock level. The check that enforced space_dock >= 1 only existed on the start repairs action, leaving the inspection overlay visible to players with no Space Dock at all.

### Type of Change:
- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #1315 

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [X] **Automated Refactoring:** Rector has been run and no outstanding issues remain.
- [X] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [X] **Static Analysis:** Code passes PHPStan static code analysis.
- [X] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [X] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [X] **Documentation:** Documentation has been updated to reflect any changes made.

## Additional Information
Add any additional context, screenshots, or explanations to help reviewers understand your PR. If this change introduces any breaking changes or significant impacts, please detail them here.
