### PR TITLE
fix:  prevent flaky BuildingQueueServiceTest due to coordinate collisions

### DIFF
--- a/tests/Unit/BuildingQueueServiceTest.php
+++ b/tests/Unit/BuildingQueueServiceTest.php
@@ -3,6 +3,9 @@
 namespace Tests\Unit;
 
 use Exception;
+use Illuminate\Support\Facades\DB;
+use OGame\Models\Planet;
+use OGame\Models\Planet\Coordinate;
 use OGame\Models\Resources;
 use OGame\Models\User;
 use OGame\Services\BuildingQueueService;
@@ -17,6 +20,13 @@ class BuildingQueueServiceTest extends UnitTestCase
     {
         parent::setUp();
         $this->buildingQueueService = resolve(BuildingQueueService::class);
+        DB::beginTransaction();
+    }
+
+    protected function tearDown(): void
+    {
+        DB::rollBack();
+        parent::tearDown();
     }
 
     /**
@@ -27,12 +37,13 @@ class BuildingQueueServiceTest extends UnitTestCase
         // Create user in database for foreign key constraints
         $user = User::factory()->create();
 
-        // Create planet in database for foreign key constraints (use random coordinates to avoid conflicts)
-        $planet = \OGame\Models\Planet::factory()->create([
+        // Create planet in database for foreign key constraints (use DB lookup to avoid coordinate conflicts)
+        $coords = $this->getSafeEmptyCoordinate(new Coordinate(1, 1, 1));
+        $planet = Planet::factory()->create([
             'user_id' => $user->id,
-            'galaxy' => rand(1, 9),
-            'system' => rand(1, 499),
-            'planet' => rand(1, 15),
+            'galaxy' => $coords->galaxy,
+            'system' => $coords->system,
+            'planet' => $coords->position,
             'metal_mine' => 5,
             'metal' => 1000000,
             'crystal' => 1000000,
@@ -87,12 +98,13 @@ class BuildingQueueServiceTest extends UnitTestCase
         // Create user in database for foreign key constraints
         $user = User::factory()->create();
 
-        // Create planet in database for foreign key constraints (use random coordinates to avoid conflicts)
-        $planet = \OGame\Models\Planet::factory()->create([
+        // Create planet in database for foreign key constraints (use DB lookup to avoid coordinate conflicts)
+        $coords = $this->getSafeEmptyCoordinate(new Coordinate(1, 1, 1));
+        $planet = Planet::factory()->create([
             'user_id' => $user->id,
-            'galaxy' => rand(1, 9),
-            'system' => rand(1, 499),
-            'planet' => rand(1, 15),
+            'galaxy' => $coords->galaxy,
+            'system' => $coords->system,
+            'planet' => $coords->position,
             'metal_mine' => 5,
             'metal' => 1000000,
             'crystal' => 1000000,
@@ -157,11 +169,12 @@ class BuildingQueueServiceTest extends UnitTestCase
     {
         // Create user and planet
         $user = User::factory()->create();
-        $planet = \OGame\Models\Planet::factory()->create([
+        $coords = $this->getSafeEmptyCoordinate(new Coordinate(1, 1, 1));
+        $planet = Planet::factory()->create([
             'user_id' => $user->id,
-            'galaxy' => rand(1, 9),
-            'system' => rand(1, 499),
-            'planet' => rand(1, 15),
+            'galaxy' => $coords->galaxy,
+            'system' => $coords->system,
+            'planet' => $coords->position,
             'metal_mine' => 4,
             'metal' => 1000000,
             'crystal' => 1000000,
@@ -240,11 +253,12 @@ class BuildingQueueServiceTest extends UnitTestCase
     {
         // Create user and planet
         $user = User::factory()->create();
-        $planet = \OGame\Models\Planet::factory()->create([
+        $coords = $this->getSafeEmptyCoordinate(new Coordinate(1, 1, 1));
+        $planet = Planet::factory()->create([
             'user_id' => $user->id,
-            'galaxy' => rand(1, 9),
-            'system' => rand(1, 499),
-            'planet' => rand(1, 15),
+            'galaxy' => $coords->galaxy,
+            'system' => $coords->system,
+            'planet' => $coords->position,
             'metal_mine' => 3,
             'metal' => 1000000,
             'crystal' => 1000000,
@@ -298,11 +312,12 @@ class BuildingQueueServiceTest extends UnitTestCase
     {
         // Create user and planet
         $user = User::factory()->create();
-        $planet = \OGame\Models\Planet::factory()->create([
+        $coords = $this->getSafeEmptyCoordinate(new Coordinate(1, 1, 1));
+        $planet = Planet::factory()->create([
             'user_id' => $user->id,
-            'galaxy' => rand(1, 9),
-            'system' => rand(1, 499),
-            'planet' => rand(1, 15),
+            'galaxy' => $coords->galaxy,
+            'system' => $coords->system,
+            'planet' => $coords->position,
             'metal_mine' => 5,
             'metal' => 1000000,
             'crystal' => 1000000,


### PR DESCRIPTION
## Description
This PR replaces the `rand()`-based coordinate generation with `getSafeEmptyCoordinate()`, which queries the DB to find a free slot before inserting. In addition, a`setUp`/`tearDown` wrapping each test in a DB transaction that rolls back on completion was added, cleaning up all created users, planets, and queue records automatically.

### Type of Change:
- [X] Bug fix
- [X] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #1400 

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [X] **Automated Refactoring:** Rector has been run and no outstanding issues remain.
- [X] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [X] **Static Analysis:** Code passes PHPStan static code analysis.
- [X] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [X] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [X] **Documentation:** Documentation has been updated to reflect any changes made.