### PR TITLE
fix: remove crawler from resources page on moons

### DIFF
--- a/app/Http/Controllers/ResourcesController.php
+++ b/app/Http/Controllers/ResourcesController.php
@@ -53,9 +53,11 @@ class ResourcesController extends AbstractBuildingsController
             $this->header_filename_objects = [41, 42, 43];
         }
 
-        $this->objects = [
-            0 => ['metal_mine', 'crystal_mine', 'deuterium_synthesizer', 'solar_plant', 'fusion_plant', 'solar_satellite', 'crawler', 'metal_store', 'crystal_store', 'deuterium_store'],
-        ];
+        $resourceObjects = ['metal_mine', 'crystal_mine', 'deuterium_synthesizer', 'solar_plant', 'fusion_plant', 'solar_satellite', 'metal_store', 'crystal_store', 'deuterium_store'];
+        if ($this->planet->isPlanet()) {
+            array_splice($resourceObjects, 6, 0, ['crawler']);
+        }
+        $this->objects = [0 => $resourceObjects];
 
         // Parse shipyard queue because the resources page shows both the
         // building queue (handled by parent) but also the shipyard queue.

--- a/tests/Feature/MoonTest.php
+++ b/tests/Feature/MoonTest.php
@@ -46,4 +46,32 @@ class MoonTest extends MoonTestCase
         $response = $this->get('/resources');
         $this->assertObjectLevelOnPage($response, 'metal_mine', 0, 'Metal mine is built on moon while it can only be built on a planet.');
     }
+
+    /**
+     * Check that the crawler is not shown on the moon resources page (it is a planet-only unit).
+     */
+    public function testCrawlerNotShownOnMoonResources(): void
+    {
+        $response = $this->get('/resources');
+        $response->assertStatus(200);
+
+        $content = $response->getContent() ?: '';
+        $this->assertStringNotContainsString('data-technology="217"', $content, 'Crawler should not be shown on moon resources page');
+    }
+
+    /**
+     * Check that the crawler is shown on the planet resources page (for comparison).
+     */
+    public function testCrawlerShownOnPlanetResources(): void
+    {
+        // Switch back to the planet
+        $response = $this->get('/overview?cp=' . $this->planetService->getPlanetId());
+        $response->assertStatus(200);
+
+        $response = $this->get('/resources');
+        $response->assertStatus(200);
+
+        $content = $response->getContent() ?: '';
+        $this->assertStringContainsString('data-technology="217"', $content, 'Crawler should be shown on planet resources page');
+    }
 }


### PR DESCRIPTION
## Description
This PR removes crawler from the resources page on moons.

### Type of Change:
- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #1393 

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [X] **Automated Refactoring:** Rector has been run and no outstanding issues remain.
- [X] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [X] **Static Analysis:** Code passes PHPStan static code analysis.
- [X] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [X] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [X] **Documentation:** Documentation has been updated to reflect any changes made.

## Additional Information
Add any additional context, screenshots, or explanations to help reviewers understand your PR. If this change introduces any breaking changes or significant impacts, please detail them here.
