### PR TITLE
fix(1397): sidebar wreck field icon checks each planet's own Space Dock

### DIFF
--- a/resources/views/ingame/layouts/main.blade.php
+++ b/resources/views/ingame/layouts/main.blade.php
@@ -1785,7 +1785,7 @@ However, the Space Dock's engineers think that some of the remains can be salvag
 
                                     @if ($wreckField && in_array($wreckField->status, ['active', 'blocked']) && !$planet->isMoon())
                                         @php
-                                            $hasSpaceDock = $currentPlayer->planets->current()->getObjectLevel('space_dock') > 0;
+                                            $hasSpaceDock = $planet->getObjectLevel('space_dock') > 0;
                                             $isOwner = $wreckField->owner_player_id === $currentPlayer->getId();
                                         @endphp
                                         @if ($isOwner && $hasSpaceDock)


### PR DESCRIPTION
Closes #1397

## Problem
In `resources/views/ingame/layouts/main.blade.php` (line 1788) the sidebar planet list iterates over all of a player's planets to decide whether to show a wreck field icon next to each one, but the Space Dock check reads the **currently selected** planet's level instead of the planet being iterated:

```php
$hasSpaceDock = $currentPlayer->planets->current()->getObjectLevel('space_dock') > 0;
```

This causes two opposite failure modes for players with multiple planets:

- **False positive**: Planet A is selected (Space Dock ≥ 1), Planet B has wreckage but no Space Dock → icon appears next to Planet B even though it cannot be inspected/repaired from there.
- **False negative**: Planet B is selected (no Space Dock), Planet A has wreckage and a Space Dock → icon is hidden next to Planet A even though it can be inspected/repaired.

## Fix
Replace the global lookup with the per-iteration `$planet`:

```php
$hasSpaceDock = $planet->getObjectLevel('space_dock') > 0;
```