### PR TITLE
fix(1395): unbanning lifts the 48h minimum-vacation restriction

### DIFF
--- a/app/Http/Controllers/Admin/ServerAdministrationController.php
+++ b/app/Http/Controllers/Admin/ServerAdministrationController.php
@@ -640,6 +640,15 @@ class ServerAdministrationController extends OGameController
                 'canceled'   => true,
                 'canceled_at' => now(),
             ]);
+
+            // Lift the 48h minimum-vacation restriction that was imposed by the ban
+            // so the player can leave vacation mode immediately after being unbanned.
+            // The vacation_mode flag itself is left ON — the player chooses when to
+            // disable it; we only release the time-lock that the ban introduced.
+            if ($user->vacation_mode && $user->vacation_mode_until !== null && now()->lessThan($user->vacation_mode_until)) {
+                $user->vacation_mode_until = now();
+                $user->save();
+            }
         }
 
         return redirect()->route('admin.server-administration.index')

--- a/app/Http/Controllers/Admin/ServerAdministrationController.php
+++ b/app/Http/Controllers/Admin/ServerAdministrationController.php
@@ -720,6 +720,15 @@ class ServerAdministrationController extends OGameController
                 'canceled'   => true,
                 'canceled_at' => now(),
             ]);
+
+            // Lift the 48h minimum-vacation restriction that was imposed by the ban
+            // so the player can leave vacation mode immediately after being unbanned.
+            // The vacation_mode flag itself is left ON — the player chooses when to
+            // disable it; we only release the time-lock that the ban introduced.
+            if ($user->vacation_mode && $user->vacation_mode_until !== null && now()->lessThan($user->vacation_mode_until)) {
+                $user->vacation_mode_until = now();
+                $user->save();
+            }
         }
 
         return redirect()->route('admin.server-administration.index')

--- a/tests/Feature/BanTest.php
+++ b/tests/Feature/BanTest.php
@@ -175,6 +175,32 @@ class BanTest extends AccountTestCase
     }
 
     /**
+     * Test that unbanning lifts the 48h vacation time-lock so the player can leave vacation immediately.
+     * The vacation_mode flag stays ON; only vacation_mode_until is released back to now().
+     */
+    public function testUnbanLiftsVacationModeUntilRestriction(): void
+    {
+        $this->artisan('ogamex:admin:assign-role', ['username' => $this->currentUsername()]);
+
+        $target = $this->createTrackedUser();
+        Ban::create(['user_id' => $target->id, 'reason' => 'Some violation', 'banned_until' => null, 'canceled' => false]);
+        $target->vacation_mode = true;
+        $target->vacation_mode_activated_at = now();
+        $target->vacation_mode_until = now()->addHours(48);
+        $target->save();
+
+        $this->post(route('admin.server-administration.unban'), [
+            'user_id' => $target->id,
+        ]);
+
+        $target->refresh();
+        $this->assertFalse($target->isBanned());
+        $this->assertTrue((bool) $target->vacation_mode);
+        $this->assertNotNull($target->vacation_mode_until);
+        $this->assertTrue(now()->greaterThanOrEqualTo($target->vacation_mode_until));
+    }
+
+    /**
      * Test that a banned user accessing an ingame page is logged out and redirected to login.
      */
     public function testBannedUserBlockedByMiddleware(): void


### PR DESCRIPTION
Closes #1395

## Problem
When a player is banned, their account is put into vacation mode (which carries a hard 48h minimum). When unbanning them shortly after banning, the 48h lock remains and the player still cannot leave vacation mode — effectively extending the ban by up to 48 hours.

## Fix
In `ServerAdministrationController::unban()`, after canceling the ban, release the `vacation_mode_until` time-lock so the player can manually leave vacation mode immediately.

The vacation mode flag itself is intentionally **not** auto-disabled — the player chooses when to disable it; we only release the time-lock that the ban introduced.

```php
if ($user->vacation_mode && $user->vacation_mode_until !== null && now()->lessThan($user->vacation_mode_until)) {
    $user->vacation_mode_until = now();
    $user->save();
}
```