### PR TITLE
fix(1393): hide Crawler from /resources page on moons

### DIFF
--- a/app/Http/Controllers/ResourcesController.php
+++ b/app/Http/Controllers/ResourcesController.php
@@ -53,9 +53,16 @@ class ResourcesController extends AbstractBuildingsController
             $this->header_filename_objects = [41, 42, 43];
         }
 
-        $this->objects = [
-            0 => ['metal_mine', 'crystal_mine', 'deuterium_synthesizer', 'solar_plant', 'fusion_plant', 'solar_satellite', 'crawler', 'metal_store', 'crystal_store', 'deuterium_store'],
-        ];
+        // Crawlers are a planet-only ship; they should not be listed on moons.
+        if ($this->planet->isMoon()) {
+            $this->objects = [
+                0 => ['metal_mine', 'crystal_mine', 'deuterium_synthesizer', 'solar_plant', 'fusion_plant', 'solar_satellite', 'metal_store', 'crystal_store', 'deuterium_store'],
+            ];
+        } else {
+            $this->objects = [
+                0 => ['metal_mine', 'crystal_mine', 'deuterium_synthesizer', 'solar_plant', 'fusion_plant', 'solar_satellite', 'crawler', 'metal_store', 'crystal_store', 'deuterium_store'],
+            ];
+        }
 
         // Parse shipyard queue because the resources page shows both the
         // building queue (handled by parent) but also the shipyard queue.


### PR DESCRIPTION
Closes #1393

## Problem
Crawlers are a planet-only ship and were being rendered in the resources/buildings list on moons too.

## Fix
In `ResourcesController::index()`, branch `$this->objects` on `$this->planet->isMoon()` and omit `'crawler'` from the moon variant, keeping it for planets:

```php
if ($this->planet->isMoon()) {
    $this->objects = [
        0 => ['metal_mine', 'crystal_mine', 'deuterium_synthesizer', 'solar_plant', 'fusion_plant', 'solar_satellite', 'metal_store', 'crystal_store', 'deuterium_store'],
    ];
} else {
    $this->objects = [
        0 => ['metal_mine', 'crystal_mine', 'deuterium_synthesizer', 'solar_plant', 'fusion_plant', 'solar_satellite', 'crawler', 'metal_store', 'crystal_store', 'deuterium_store'],
    ];
}
```