### PR TITLE
feat: delete inbox messages after 7 days and archive chat messages after 7 days

### DIFF
--- a/app/Console/Commands/Scheduler/DeleteOldMessages.php
+++ b/app/Console/Commands/Scheduler/DeleteOldMessages.php
@@ -3,6 +3,7 @@
 namespace OGame\Console\Commands\Scheduler;
 
 use Illuminate\Console\Command;
+use OGame\Models\ChatMessage;
 use OGame\Models\Message;
 
 class DeleteOldMessages extends Command
@@ -21,7 +22,7 @@ class DeleteOldMessages extends Command
      *
      * @var string
      */
-    protected $description = 'Deletes player messages older than the message retention period.';
+    protected $description = 'Deletes player inbox messages and archives chat messages older than the retention period.';
 
     /**
      * Execute the console command.
@@ -30,13 +31,20 @@ class DeleteOldMessages extends Command
     {
         $cutoff = now()->subDays(self::RETENTION_DAYS);
         $deletedCount = 0;
+        $archivedCount = 0;
 
         Message::where('created_at', '<=', $cutoff)
             ->chunkById(1000, function ($messages) use (&$deletedCount): void {
                 $deletedCount += Message::whereIn('id', $messages->modelKeys())->delete();
             });
 
-        $this->info("Deleted {$deletedCount} message(s) older than " . self::RETENTION_DAYS . ' days.');
+        ChatMessage::where('created_at', '<=', $cutoff)
+            ->chunkById(1000, function ($messages) use (&$archivedCount): void {
+                $archivedCount += ChatMessage::whereIn('id', $messages->modelKeys())->delete();
+            });
+
+        $this->info("Deleted {$deletedCount} inbox message(s) older than " . self::RETENTION_DAYS . ' days.');
+        $this->info("Archived {$archivedCount} chat message(s) older than " . self::RETENTION_DAYS . ' days.');
 
         return Command::SUCCESS;
     }

--- a/app/Console/Commands/Scheduler/DeleteOldMessages.php
+++ b/app/Console/Commands/Scheduler/DeleteOldMessages.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace OGame\Console\Commands\Scheduler;
+
+use Illuminate\Console\Command;
+use OGame\Models\Message;
+
+class DeleteOldMessages extends Command
+{
+    private const RETENTION_DAYS = 7;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'ogamex:scheduler:delete-old-messages';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Deletes player messages older than the message retention period.';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $cutoff = now()->subDays(self::RETENTION_DAYS);
+        $deletedCount = 0;
+
+        Message::where('created_at', '<=', $cutoff)
+            ->chunkById(1000, function ($messages) use (&$deletedCount): void {
+                $deletedCount += Message::whereIn('id', $messages->modelKeys())->delete();
+            });
+
+        $this->info("Deleted {$deletedCount} message(s) older than " . self::RETENTION_DAYS . ' days.');
+
+        return Command::SUCCESS;
+    }
+}

--- a/app/Models/ChatMessage.php
+++ b/app/Models/ChatMessage.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Carbon;
 
 /**
@@ -21,6 +22,7 @@ use Illuminate\Support\Carbon;
  * @property Carbon|null $read_at
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
+ * @property Carbon|null $deleted_at
  * @property-read User $sender
  * @property-read User|null $recipient
  * @property-read Alliance|null $alliance
@@ -41,6 +43,7 @@ use Illuminate\Support\Carbon;
 class ChatMessage extends Model
 {
     use HasFactory;
+    use SoftDeletes;
 
     /**
      * Get the attributes that should be cast.

--- a/database/migrations/2026_05_05_000001_add_created_at_index_to_messages_table.php
+++ b/database/migrations/2026_05_05_000001_add_created_at_index_to_messages_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('messages', function (Blueprint $table) {
+            $table->index('created_at', 'messages_created_at_index');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('messages', function (Blueprint $table) {
+            $table->dropIndex('messages_created_at_index');
+        });
+    }
+};

--- a/database/migrations/2026_05_09_000001_add_soft_deletes_to_chat_messages_table.php
+++ b/database/migrations/2026_05_09_000001_add_soft_deletes_to_chat_messages_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('chat_messages', function (Blueprint $table) {
+            $table->softDeletes();
+            $table->index('created_at', 'chat_messages_created_at_index');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('chat_messages', function (Blueprint $table) {
+            $table->dropIndex('chat_messages_created_at_index');
+            $table->dropSoftDeletes();
+        });
+    }
+};

--- a/routes/console.php
+++ b/routes/console.php
@@ -2,6 +2,7 @@
 
 use OGame\Console\Commands\Scheduler\CleanupWreckFields;
 use OGame\Console\Commands\Scheduler\DarkMatterRegenerateCommand;
+use OGame\Console\Commands\Scheduler\DeleteOldMessages;
 use OGame\Console\Commands\Scheduler\GenerateAllianceHighscores;
 use OGame\Console\Commands\Scheduler\GenerateHighscoreRanks;
 use OGame\Console\Commands\Scheduler\GenerateHighscores;
@@ -29,6 +30,9 @@ Schedule::command(ResetDebrisFields::class)->weeklyOn(1, '1:00');
 
 // Clean up wreck fields hourly
 Schedule::command(CleanupWreckFields::class)->hourly()->withoutOverlapping();
+
+// Delete messages once they have aged out of the seven-day retention window
+Schedule::command(DeleteOldMessages::class)->hourly()->withoutOverlapping();
 
 // Process Dark Matter regeneration every 5 minutes
 Schedule::command(DarkMatterRegenerateCommand::class)->everyFiveMinutes()->withoutOverlapping();

--- a/tests/Feature/DeleteOldMessagesCommandTest.php
+++ b/tests/Feature/DeleteOldMessagesCommandTest.php
@@ -3,6 +3,8 @@
 namespace Tests\Feature;
 
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Date;
+use OGame\Models\ChatMessage;
 use OGame\Models\Message;
 use OGame\Models\User;
 use Tests\TestCase;
@@ -20,23 +22,24 @@ class DeleteOldMessagesCommandTest extends TestCase
 
     protected function tearDown(): void
     {
-        Carbon::setTestNow();
+        $this->travelTo(null);
 
         if (isset($this->user)) {
             Message::where('user_id', $this->user->id)->delete();
+            ChatMessage::withTrashed()->where('sender_id', $this->user->id)->forceDelete();
             User::where('id', $this->user->id)->delete();
         }
 
         parent::tearDown();
     }
 
-    public function test_deletes_messages_that_are_at_least_seven_days_old(): void
+    public function test_deletes_inbox_messages_that_are_at_least_seven_days_old(): void
     {
-        Carbon::setTestNow(Carbon::parse('2026-05-05 12:00:00'));
+        $this->travelTo(Date::parse('2026-05-05 12:00:00'));
 
-        $oldMessage = $this->createMessage(Carbon::now()->subDays(7)->subSecond());
-        $cutoffMessage = $this->createMessage(Carbon::now()->subDays(7));
-        $recentMessage = $this->createMessage(Carbon::now()->subDays(7)->addSecond());
+        $oldMessage = $this->createInboxMessage(Date::now()->subDays(7)->subSecond());
+        $cutoffMessage = $this->createInboxMessage(Date::now()->subDays(7));
+        $recentMessage = $this->createInboxMessage(Date::now()->subDays(7)->addSecond());
 
         // @phpstan-ignore-next-line
         $this->artisan('ogamex:scheduler:delete-old-messages')->assertSuccessful();
@@ -46,7 +49,24 @@ class DeleteOldMessagesCommandTest extends TestCase
         $this->assertDatabaseHas('messages', ['id' => $recentMessage->id]);
     }
 
-    private function createMessage(Carbon $createdAt): Message
+    public function test_archives_chat_messages_that_are_at_least_seven_days_old(): void
+    {
+        $this->travelTo(Date::parse('2026-05-05 12:00:00'));
+
+        $oldMessage = $this->createChatMessage(Date::now()->subDays(7)->subSecond());
+        $cutoffMessage = $this->createChatMessage(Date::now()->subDays(7));
+        $recentMessage = $this->createChatMessage(Date::now()->subDays(7)->addSecond());
+
+        // @phpstan-ignore-next-line
+        $this->artisan('ogamex:scheduler:delete-old-messages')->assertSuccessful();
+
+        // Old messages remain in the database (soft-deleted) but are hidden from users.
+        $this->assertSoftDeleted('chat_messages', ['id' => $oldMessage->id]);
+        $this->assertSoftDeleted('chat_messages', ['id' => $cutoffMessage->id]);
+        $this->assertNotSoftDeleted('chat_messages', ['id' => $recentMessage->id]);
+    }
+
+    private function createInboxMessage(Carbon $createdAt): Message
     {
         $message = new Message();
         $message->user_id = $this->user->id;
@@ -55,6 +75,18 @@ class DeleteOldMessagesCommandTest extends TestCase
         $message->body = 'Test body';
         $message->params = [];
         $message->viewed = 0;
+        $message->created_at = $createdAt;
+        $message->updated_at = $createdAt;
+        $message->save();
+
+        return $message;
+    }
+
+    private function createChatMessage(Carbon $createdAt): ChatMessage
+    {
+        $message = new ChatMessage();
+        $message->sender_id = $this->user->id;
+        $message->message = 'Test chat message';
         $message->created_at = $createdAt;
         $message->updated_at = $createdAt;
         $message->save();

--- a/tests/Feature/DeleteOldMessagesCommandTest.php
+++ b/tests/Feature/DeleteOldMessagesCommandTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Carbon;
+use OGame\Models\Message;
+use OGame\Models\User;
+use Tests\TestCase;
+
+class DeleteOldMessagesCommandTest extends TestCase
+{
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+
+        if (isset($this->user)) {
+            Message::where('user_id', $this->user->id)->delete();
+            User::where('id', $this->user->id)->delete();
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_deletes_messages_that_are_at_least_seven_days_old(): void
+    {
+        Carbon::setTestNow(Carbon::parse('2026-05-05 12:00:00'));
+
+        $oldMessage = $this->createMessage(Carbon::now()->subDays(7)->subSecond());
+        $cutoffMessage = $this->createMessage(Carbon::now()->subDays(7));
+        $recentMessage = $this->createMessage(Carbon::now()->subDays(7)->addSecond());
+
+        // @phpstan-ignore-next-line
+        $this->artisan('ogamex:scheduler:delete-old-messages')->assertSuccessful();
+
+        $this->assertDatabaseMissing('messages', ['id' => $oldMessage->id]);
+        $this->assertDatabaseMissing('messages', ['id' => $cutoffMessage->id]);
+        $this->assertDatabaseHas('messages', ['id' => $recentMessage->id]);
+    }
+
+    private function createMessage(Carbon $createdAt): Message
+    {
+        $message = new Message();
+        $message->user_id = $this->user->id;
+        $message->key = 'welcome_message';
+        $message->subject = 'Test message';
+        $message->body = 'Test body';
+        $message->params = [];
+        $message->viewed = 0;
+        $message->created_at = $createdAt;
+        $message->updated_at = $createdAt;
+        $message->save();
+
+        return $message;
+    }
+}


### PR DESCRIPTION
## Description
This PR adds auto-deletion of messages after 7 days. An hourly queue worker progressively deletes messages that are 7 days or older.

### Type of Change:
- [ ] Bug fix
- [X] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #1373 

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [X] **Automated Refactoring:** Rector has been run and no outstanding issues remain.
- [X] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [X] **Static Analysis:** Code passes PHPStan static code analysis.
- [X] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [X] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [X] **Documentation:** Documentation has been updated to reflect any changes made.

## Additional Information
Chat messages are archived as opposed to deleted so that server admins can retrieve chat messages. In the future I would like to have the capability for server admins to read old chat logs.
