### PR TITLE
feat: Add server-wide attack block

### DIFF
--- a/app/GameMissions/Abstracts/GameMission.php
+++ b/app/GameMissions/Abstracts/GameMission.php
@@ -119,6 +119,10 @@ abstract class GameMission
             return new MissionPossibleStatus(false, __('You cannot send missions while in vacation mode!'));
         }
 
+        if ($this->settings->missionBlockedByAttackBlock(static::$typeId)) {
+            return new MissionPossibleStatus(false, __('The attack block is active. In that time only friendly fleets can be started.'));
+        }
+
         // If mission from and to coordinates and types are the same, the mission is not possible.
         if ($planet->getPlanetCoordinates()->equals($targetCoordinate) && $planet->getPlanetType() === $targetType) {
             return new MissionPossibleStatus(false);

--- a/app/GameMissions/Abstracts/GameMission.php
+++ b/app/GameMissions/Abstracts/GameMission.php
@@ -46,6 +46,11 @@ abstract class GameMission
     protected static bool $hasReturnMission;
 
     /**
+     * @var bool Whether this mission is blocked when the server-wide attack block is active.
+     */
+    protected static bool $blockedByServerAttackBlock = false;
+
+    /**
      * @var FleetSpeedType The fleet speed type for this mission.
      */
     protected static FleetSpeedType $fleetSpeedType;
@@ -79,6 +84,11 @@ abstract class GameMission
     public static function getTypeId(): int
     {
         return static::$typeId;
+    }
+
+    public static function isBlockedByServerAttackBlock(): bool
+    {
+        return static::$blockedByServerAttackBlock;
     }
 
     /**
@@ -119,7 +129,7 @@ abstract class GameMission
             return new MissionPossibleStatus(false, __('You cannot send missions while in vacation mode!'));
         }
 
-        if ($this->settings->missionBlockedByAttackBlock(static::$typeId)) {
+        if (static::$blockedByServerAttackBlock && $this->settings->attackBlockActive()) {
             return new MissionPossibleStatus(false, __('The attack block is active. In that time only friendly fleets can be started.'));
         }
 

--- a/app/GameMissions/AttackMission.php
+++ b/app/GameMissions/AttackMission.php
@@ -31,6 +31,7 @@ class AttackMission extends GameMission
     protected static string $name = 'Attack';
     protected static int $typeId = 1;
     protected static bool $hasReturnMission = true;
+    protected static bool $blockedByServerAttackBlock = true;
     protected static FleetSpeedType $fleetSpeedType = FleetSpeedType::war;
     protected static FleetMissionStatus $friendlyStatus = FleetMissionStatus::Hostile;
 

--- a/app/GameMissions/EspionageMission.php
+++ b/app/GameMissions/EspionageMission.php
@@ -31,6 +31,7 @@ class EspionageMission extends GameMission
     protected static string $name = 'Espionage';
     protected static int $typeId = 6;
     protected static bool $hasReturnMission = true;
+    protected static bool $blockedByServerAttackBlock = true;
     protected static FleetSpeedType $fleetSpeedType = FleetSpeedType::war;
     protected static FleetMissionStatus $friendlyStatus = FleetMissionStatus::Hostile;
 

--- a/app/GameMissions/MoonDestructionMission.php
+++ b/app/GameMissions/MoonDestructionMission.php
@@ -32,6 +32,7 @@ class MoonDestructionMission extends GameMission
     protected static string $name = 'Moon Destruction';
     protected static int $typeId = 9;
     protected static bool $hasReturnMission = true;
+    protected static bool $blockedByServerAttackBlock = true;
     protected static FleetSpeedType $fleetSpeedType = FleetSpeedType::war;
 
     public function isMissionPossible(PlanetService $planet, Coordinate $targetCoordinate, PlanetType $targetType, UnitCollection $units): MissionPossibleStatus

--- a/app/Http/Controllers/Admin/ServerAdministrationController.php
+++ b/app/Http/Controllers/Admin/ServerAdministrationController.php
@@ -4,6 +4,7 @@ namespace OGame\Http\Controllers\Admin;
 
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
@@ -138,6 +139,7 @@ class ServerAdministrationController extends OGameController
         $botSuspects = $allSuspects->reject(fn ($s) => in_array($s['user']->id, $dismissedUserIds, true))->values();
         $stuckMissionsSettings = $this->stuckMissionsSettings();
         $stuckMissions = $this->getStuckFleetMissions($stuckMissionsSettings['min_overdue_hours']);
+        $attackBlockUntil = (int) $settingsService->get('attack_block_until', 0);
 
         return view('ingame.admin.server-administration', [
             'sharedIpGroups'        => $sharedIpGroups,
@@ -149,7 +151,84 @@ class ServerAdministrationController extends OGameController
             'detectionSettings'     => $settings,
             'dismissedIpCount'      => count($dismissedIps),
             'dismissedSuspectCount' => $allSuspects->filter(fn ($s) => in_array($s['user']->id, $dismissedUserIds, true))->count(),
+            'attackBlockUntil'      => $attackBlockUntil,
+            'attackBlockActive'     => $attackBlockUntil > time(),
         ]);
+    }
+
+    /**
+     * Saves the server-wide attack block end time.
+     */
+    public function saveAttackBlock(Request $request): RedirectResponse
+    {
+        $request->validate([
+            'attack_block_until_date' => ['nullable', 'date_format:Y-m-d'],
+            'attack_block_until_time' => ['nullable', 'date_format:H:i'],
+            'attack_block_until' => ['nullable', 'string', 'max:32'],
+            'clear_attack_block' => ['nullable', 'boolean'],
+        ]);
+
+        $settingsService = resolve(SettingsService::class);
+        $untilInput = $this->attackBlockUntilInput($request);
+
+        if ($request->boolean('clear_attack_block') || empty($untilInput)) {
+            $settingsService->set('attack_block_until', 0);
+
+            return redirect()->route('admin.server-administration.index')
+                ->with('status', 'Attack block cleared.');
+        }
+
+        $until = $this->parseAttackBlockUntil((string) $untilInput);
+        if ($until === null) {
+            return redirect()->route('admin.server-administration.index')
+                ->with('error', 'Attack block end must use dd.mm.yyyy hh:mm.');
+        }
+
+        if ($until->timestamp <= time()) {
+            $settingsService->set('attack_block_until', 0);
+
+            return redirect()->route('admin.server-administration.index')
+                ->with('error', 'Attack block end must be in the future.');
+        }
+
+        $settingsService->set('attack_block_until', $until->timestamp);
+
+        return redirect()->route('admin.server-administration.index')
+            ->with('status', 'Attack block saved.');
+    }
+
+    /**
+     * Returns the attack block end value from the date/time picker fields or legacy single field.
+     */
+    private function attackBlockUntilInput(Request $request): string
+    {
+        $date = (string) $request->input('attack_block_until_date', '');
+        $time = (string) $request->input('attack_block_until_time', '');
+
+        if ($date !== '' || $time !== '') {
+            return trim($date . ' ' . ($time !== '' ? $time : '00:00'));
+        }
+
+        return (string) $request->input('attack_block_until', '');
+    }
+
+    /**
+     * Parses the attack block end time from the admin form.
+     */
+    private function parseAttackBlockUntil(string $value): ?Carbon
+    {
+        foreach (['d.m.Y H:i:s', 'd.m.Y H:i', 'Y-m-d H:i:s', 'Y-m-d H:i', 'Y-m-d\TH:i'] as $format) {
+            try {
+                $parsed = Carbon::createFromFormat($format, $value);
+                if ($parsed !== false) {
+                    return $parsed;
+                }
+            } catch (Throwable) {
+                continue;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/app/Http/Controllers/Admin/ServerAdministrationController.php
+++ b/app/Http/Controllers/Admin/ServerAdministrationController.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
 use Illuminate\View\View;
 use OGame\Factories\GameMissionFactory;
@@ -191,7 +192,7 @@ class ServerAdministrationController extends OGameController
                 ->with('error', 'Attack block end must be in the future.');
         }
 
-        $settingsService->set('attack_block_until', $until->timestamp);
+        $settingsService->set('attack_block_until', (int) $until->timestamp);
 
         return redirect()->route('admin.server-administration.index')
             ->with('status', 'Attack block saved.');
@@ -215,11 +216,11 @@ class ServerAdministrationController extends OGameController
     /**
      * Parses the attack block end time from the admin form.
      */
-    private function parseAttackBlockUntil(string $value): ?Carbon
+    private function parseAttackBlockUntil(string $value): Carbon|null
     {
         foreach (['d.m.Y H:i:s', 'd.m.Y H:i', 'Y-m-d H:i:s', 'Y-m-d H:i', 'Y-m-d\TH:i'] as $format) {
             try {
-                $parsed = Carbon::createFromFormat($format, $value);
+                $parsed = Date::createFromFormat($format, $value);
                 if ($parsed !== false) {
                     return $parsed;
                 }

--- a/app/Http/Controllers/FleetController.php
+++ b/app/Http/Controllers/FleetController.php
@@ -495,6 +495,10 @@ class FleetController extends OGameController
         // Extract mission type from the request
         $mission_type = (int)request()->input('mission');
 
+        if ($settingsService->missionBlockedByAttackBlock($mission_type)) {
+            return $this->validationErrorResponse(__('The attack block is active. In that time only friendly fleets can be started.'));
+        }
+
         // Extract resources from the request
         $metal = (int)request()->input('metal');
         $crystal = (int)request()->input('crystal');
@@ -625,6 +629,21 @@ class FleetController extends OGameController
         $targetType = (int)request()->input('type');
         $shipCount = (int)request()->input('shipCount');
         $mission_type = (int)request()->input('mission');
+        if ($settingsService->missionBlockedByAttackBlock($mission_type)) {
+            return response()->json([
+                'response' => [
+                    'message' => __('The attack block is active. In that time only friendly fleets can be started.'),
+                    'coordinates' => [
+                        'galaxy' => $galaxy,
+                        'system' => $system,
+                        'position' => $position,
+                    ],
+                    'success' => false,
+                ],
+                'newAjaxToken' => csrf_token(),
+                'components' => [],
+            ]);
+        }
         // Validate ship count is positive, if not, default to 1.
         if ($shipCount < 1) {
             $shipCount = 1;

--- a/app/Http/ViewComposers/IngameMainComposer.php
+++ b/app/Http/ViewComposers/IngameMainComposer.php
@@ -118,6 +118,8 @@ class IngameMainComposer
 
         $impersonateManager = app('impersonate');
         $isImpersonating = $impersonateManager->isImpersonating();
+        $attackBlockUntil = $this->settingsService->attackBlockUntil();
+        $attackBlockActive = $this->settingsService->attackBlockActive();
 
         $view->with([
             'underAttack' => $this->fleetMissionService->currentPlayerUnderAttack(),
@@ -135,6 +137,13 @@ class IngameMainComposer
             'locale' => $locale,
             'isImpersonating' => $isImpersonating,
             'impersonateLeaveUrl' => $isImpersonating ? route('impersonate.leave') : null,
+            'attackBlockActive' => $attackBlockActive,
+            'attackBlockUntil' => $attackBlockUntil,
+            'attackBlockTooltip' => $attackBlockActive
+                ? __('The attack block is active till :until. In that time only friendly fleets can be started.', [
+                    'until' => \Carbon\Carbon::createFromTimestamp($attackBlockUntil)->format('d.m.Y H:i:s'),
+                ])
+                : '',
         ]);
     }
 

--- a/app/Http/ViewComposers/IngameMainComposer.php
+++ b/app/Http/ViewComposers/IngameMainComposer.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\View\View;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Date;
 use OGame\Facades\AppUtil;
 use OGame\Models\Alliance;
 use OGame\Models\AllianceMember;
@@ -141,7 +142,7 @@ class IngameMainComposer
             'attackBlockUntil' => $attackBlockUntil,
             'attackBlockTooltip' => $attackBlockActive
                 ? __('The attack block is active till :until. In that time only friendly fleets can be started.', [
-                    'until' => \Carbon\Carbon::createFromTimestamp($attackBlockUntil)->format('d.m.Y H:i:s'),
+                    'until' => Date::createFromTimestamp($attackBlockUntil)->format('d.m.Y H:i:s'),
                 ])
                 : '',
         ]);

--- a/app/Services/SettingsService.php
+++ b/app/Services/SettingsService.php
@@ -2,6 +2,7 @@
 
 namespace OGame\Services;
 
+use Illuminate\Support\Facades\Date;
 use OGame\Models\Setting;
 
 /**
@@ -13,6 +14,11 @@ use OGame\Models\Setting;
  */
 class SettingsService
 {
+    /**
+     * @var array<int>
+     */
+    public const ATTACK_BLOCKED_MISSION_TYPES = [1, 2, 6, 9];
+
     /**
      * Array of setting objects.
      *
@@ -384,6 +390,39 @@ class SettingsService
     public function battleEngine(): string
     {
         return $this->get('battle_engine', 'rust');
+    }
+
+    /**
+     * Returns the configured attack block end timestamp.
+     *
+     * @return int
+     */
+    public function attackBlockUntil(): int
+    {
+        return (int)$this->get('attack_block_until', 0);
+    }
+
+    /**
+     * Returns whether the server-wide attack block is currently active.
+     *
+     * @return bool
+     */
+    public function attackBlockActive(): bool
+    {
+        $until = $this->attackBlockUntil();
+
+        return $until > Date::now()->timestamp;
+    }
+
+    /**
+     * Returns whether the given mission type is blocked by attack block.
+     *
+     * @param int $missionType
+     * @return bool
+     */
+    public function missionBlockedByAttackBlock(int $missionType): bool
+    {
+        return $this->attackBlockActive() && in_array($missionType, self::ATTACK_BLOCKED_MISSION_TYPES, true);
     }
 
     /**

--- a/app/Services/SettingsService.php
+++ b/app/Services/SettingsService.php
@@ -3,6 +3,7 @@
 namespace OGame\Services;
 
 use Illuminate\Support\Facades\Date;
+use OGame\Factories\GameMissionFactory;
 use OGame\Models\Setting;
 
 /**
@@ -14,11 +15,6 @@ use OGame\Models\Setting;
  */
 class SettingsService
 {
-    /**
-     * @var array<int>
-     */
-    public const ATTACK_BLOCKED_MISSION_TYPES = [1, 2, 6, 9];
-
     /**
      * Array of setting objects.
      *
@@ -422,7 +418,7 @@ class SettingsService
      */
     public function missionBlockedByAttackBlock(int $missionType): bool
     {
-        return $this->attackBlockActive() && in_array($missionType, self::ATTACK_BLOCKED_MISSION_TYPES, true);
+        return $this->attackBlockActive() && GameMissionFactory::getMissionById($missionType, [])->isBlockedByServerAttackBlock();
     }
 
     /**

--- a/resources/views/ingame/admin/server-administration.blade.php
+++ b/resources/views/ingame/admin/server-administration.blade.php
@@ -43,6 +43,74 @@
                         </div>
                     </form>
 
+                    {{-- ===== ATTACK BLOCK ===== --}}
+                    @php
+                        $attackBlockDateValue = $attackBlockUntil > 0
+                            ? \Illuminate\Support\Carbon::createFromTimestamp($attackBlockUntil)->format('Y-m-d')
+                            : '';
+                        $attackBlockTimeValue = $attackBlockUntil > 0
+                            ? \Illuminate\Support\Carbon::createFromTimestamp($attackBlockUntil)->format('H:i')
+                            : '';
+                    @endphp
+                    <p class="box_highlight textCenter no_buddies" style="margin-top: 20px;">@lang('Attack Block')</p>
+                    <form action="{{ route('admin.server-administration.attack-block') }}" method="post" style="margin-bottom: 20px;">
+                        {{ csrf_field() }}
+                        <style>
+                            #attack_block_until_date,
+                            #attack_block_until_time {
+                                background-color: #b3c3cb;
+                                border: 1px solid #668599;
+                                border-bottom-color: #d3d9de;
+                                border-radius: 3px;
+                                box-shadow: inset 0 1px 3px 0 #454f54;
+                                color: #000;
+                                font-size: 12px;
+                                height: 20px;
+                                line-height: 20px;
+                                padding: 2px 5px;
+                                box-sizing: content-box;
+                                vertical-align: middle;
+                            }
+                            #attack_block_until_date:focus,
+                            #attack_block_until_time:focus {
+                                background-color: #f0f3f5;
+                                border: 1px solid #a3b6c2;
+                                border-bottom-color: #fff;
+                                box-shadow: inset 0 1px 3px 0 #5c6970;
+                            }
+                        </style>
+                        <div class="group bborder" style="display: block;">
+                            <div class="fieldwrapper">
+                                <label class="styled textBeefy" for="attack_block_until_date" title="Hostile fleet missions are espionage, attack, ACS attack, and moon destruction.">Block hostile fleets until:</label>
+                                <div class="thefield">
+                                    <input type="date"
+                                           id="attack_block_until_date"
+                                           name="attack_block_until_date"
+                                           class="textInput w130 textCenter textBeefy"
+                                           value="{{ $attackBlockDateValue }}">
+                                    <input type="time"
+                                           id="attack_block_until_time"
+                                           name="attack_block_until_time"
+                                           class="textInput w80 textCenter textBeefy"
+                                           step="60"
+                                           value="{{ $attackBlockTimeValue }}"
+                                           style="margin-left: 6px;">
+                                </div>
+                            </div>
+                            <p style="text-align: center; padding: 4px 10px 0; color: {{ $attackBlockActive ? '#f48406' : '#888' }};">
+                                @if ($attackBlockActive)
+                                    Active until {{ \Illuminate\Support\Carbon::createFromTimestamp($attackBlockUntil)->format('d.m.Y H:i:s') }}.
+                                @else
+                                    No attack block is active.
+                                @endif
+                            </p>
+                            <div class="fieldwrapper" style="text-align: center; margin-top: 10px; margin-bottom: 10px;">
+                                <input type="submit" class="btn_blue" value="Save Attack Block">
+                                <button type="submit" class="btn_blue" name="clear_attack_block" value="1" style="margin-left: 8px;">Clear</button>
+                            </div>
+                        </div>
+                    </form>
+
                     {{-- ===== FLAGGED ACCOUNTS ===== --}}
                     <p class="box_highlight textCenter no_buddies">@lang('Flagged Accounts')</p>
 

--- a/resources/views/ingame/layouts/main.blade.php
+++ b/resources/views/ingame/layouts/main.blade.php
@@ -710,6 +710,60 @@
                     </li>
                 </ul>
 
+                @if ($attackBlockActive)
+                    <style>
+                        #attackblock {
+                            clear: both;
+                            margin: 0 0 0 49px;
+                            padding-top: 8px;
+                            width: 38px;
+                        }
+                        #attackblock .attackBlockIcon {
+                            position: relative;
+                            display: block;
+                            width: 34px;
+                            height: 34px;
+                            border-radius: 4px;
+                            border: 2px solid #6e2e00;
+                            background: linear-gradient(180deg, #d88020 0%, #be5d00 46%, #8c3800 100%);
+                            box-shadow:
+                                inset 0 0 0 2px rgba(255, 185, 70, 0.45),
+                                inset 0 -4px 8px rgba(80, 25, 0, 0.42),
+                                0 0 4px rgba(220, 100, 0, 0.55);
+                        }
+                        #attackblock .attackBlockIcon::before {
+                            content: "";
+                            position: absolute;
+                            left: 3px;
+                            top: 3px;
+                            width: 28px;
+                            height: 28px;
+                            border: 4px solid #fff;
+                            border-radius: 50%;
+                            box-sizing: border-box;
+                            box-shadow: 0 0 2px rgba(255, 255, 255, 0.55);
+                        }
+                        #attackblock .attackBlockIcon::after {
+                            content: "";
+                            position: absolute;
+                            left: 6px;
+                            top: 14px;
+                            width: 22px;
+                            height: 5px;
+                            border-radius: 3px;
+                            background: #fff;
+                            transform: rotate(45deg);
+                            transform-origin: center;
+                            box-shadow: 0 0 2px rgba(255, 255, 255, 0.55);
+                        }
+                    </style>
+                    <div id="attackblock">
+                        <a href="javascript:void(0);"
+                           class="tooltipHTML js_hideTipOnMobile attackBlockIcon"
+                           title="Attack block|{{ $attackBlockTooltip }}"></a>
+                    </div>
+                @endif
+
                 <div id="toolLinksWrapper">
                     <ul id="menuTableTools" class="leftmenu"></ul>
                 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -278,6 +278,7 @@ Route::middleware(['auth', 'globalgame', 'locale', 'admin'])->group(function () 
     Route::post('/admin/server-administration/detection-settings', [ServerAdministrationController::class, 'saveDetectionSettings'])->name('admin.server-administration.detection-settings');
     Route::post('/admin/server-administration/dismiss', [ServerAdministrationController::class, 'dismiss'])->name('admin.server-administration.dismiss');
     Route::post('/admin/server-administration/clear-cache', [ServerAdministrationController::class, 'clearCache'])->name('admin.server-administration.clear-cache');
+    Route::post('/admin/server-administration/attack-block', [ServerAdministrationController::class, 'saveAttackBlock'])->name('admin.server-administration.attack-block');
     Route::post('/admin/server-administration/stuck-missions/settings', [ServerAdministrationController::class, 'saveStuckMissionSettings'])->name('admin.server-administration.stuck-missions.settings');
     Route::post('/admin/server-administration/stuck-missions/process', [ServerAdministrationController::class, 'processStuckMission'])->name('admin.server-administration.stuck-missions.process');
     Route::post('/admin/server-administration/stuck-missions/recover-homeworld', [ServerAdministrationController::class, 'recoverStuckMissionToHomeworld'])->name('admin.server-administration.stuck-missions.recover-homeworld');

--- a/tests/Feature/AdminAttackBlockTest.php
+++ b/tests/Feature/AdminAttackBlockTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\Feature;
+
+use OGame\Services\SettingsService;
+use Tests\AccountTestCase;
+
+/**
+ * Test that the admin attack block save/clear endpoint works as expected.
+ */
+class AdminAttackBlockTest extends AccountTestCase
+{
+    /**
+     * Assign admin role before each test so the route is accessible.
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->artisan('ogamex:admin:assign-role', ['username' => auth()->user()->username]);
+    }
+
+    /**
+     * Reset attack block setting after each test to avoid state leaking between tests.
+     */
+    protected function tearDown(): void
+    {
+        $settingsService = resolve(SettingsService::class);
+        $settingsService->set('attack_block_until', 0);
+        parent::tearDown();
+    }
+
+    /**
+     * Assert that an admin can set an active attack block via the server administration form.
+     */
+    public function testAdminCanSetAttackBlock(): void
+    {
+        $response = $this->post(route('admin.server-administration.attack-block'), [
+            'attack_block_until' => '01.01.2099 12:00',
+        ]);
+
+        $response->assertRedirect(route('admin.server-administration.index'));
+        $response->assertSessionHas('status');
+
+        $settingsService = resolve(SettingsService::class);
+        $this->assertTrue($settingsService->attackBlockActive());
+    }
+
+    /**
+     * Assert that an admin can clear an active attack block.
+     */
+    public function testAdminCanClearAttackBlock(): void
+    {
+        $settingsService = resolve(SettingsService::class);
+        $settingsService->set('attack_block_until', time() + 3600);
+
+        $response = $this->post(route('admin.server-administration.attack-block'), [
+            'clear_attack_block' => '1',
+        ]);
+
+        $response->assertRedirect(route('admin.server-administration.index'));
+        $response->assertSessionHas('status');
+
+        $settingsService = resolve(SettingsService::class);
+        $this->assertFalse($settingsService->attackBlockActive());
+    }
+
+    /**
+     * Assert that submitting a past end timestamp is rejected and the attack block remains inactive.
+     */
+    public function testAdminAttackBlockRejectsTimestampInPast(): void
+    {
+        $response = $this->post(route('admin.server-administration.attack-block'), [
+            'attack_block_until' => '01.01.2000 12:00',
+        ]);
+
+        $response->assertRedirect(route('admin.server-administration.index'));
+        $response->assertSessionHas('error');
+
+        $settingsService = resolve(SettingsService::class);
+        $this->assertFalse($settingsService->attackBlockActive());
+    }
+}

--- a/tests/Feature/FleetDispatch/FleetDispatchAttackTest.php
+++ b/tests/Feature/FleetDispatch/FleetDispatchAttackTest.php
@@ -37,6 +37,16 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
     protected string $missionName = 'Attack';
 
     /**
+     * Reset attack block setting after each test to avoid state leaking between tests.
+     */
+    protected function tearDown(): void
+    {
+        $settingsService = resolve(SettingsService::class);
+        $settingsService->set('attack_block_until', 0);
+        parent::tearDown();
+    }
+
+    /**
      * Prepare the planet for the test, so it has the required buildings and research.
      *
      * @return void
@@ -52,6 +62,7 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
         $settingsService->set('fleet_speed_war', 1);
         $settingsService->set('fleet_speed_holding', 1);
         $settingsService->set('fleet_speed_peaceful', 1);
+        $settingsService->set('attack_block_until', 0);
 
         // Add sufficient deuterium to the planet to ensure we don't run into fuel capacity restriction.
         $this->planetAddResources(new Resources(0, 0, 1000000, 0));
@@ -96,6 +107,32 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
         $unitCollection = new UnitCollection();
         $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 1);
         $this->fleetCheckToOtherPlayer($unitCollection, true);
+    }
+
+    /**
+     * Assert that active attack block prevents launching hostile attack missions.
+     */
+    public function testAttackBlockPreventsAttackDispatch(): void
+    {
+        $this->basicSetup();
+
+        $settingsService = resolve(SettingsService::class);
+        $settingsService->set('attack_block_until', time() + 3600);
+
+        $unitCollection = new UnitCollection();
+        $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 1);
+        $nearbyForeignPlanet = $this->getNearbyForeignPlanet();
+
+        $this->checkTargetFleet($nearbyForeignPlanet->getPlanetCoordinates(), $unitCollection, PlanetType::Planet, false);
+
+        $this->dispatchFleet(
+            $nearbyForeignPlanet->getPlanetCoordinates(),
+            $unitCollection,
+            new Resources(0, 0, 0, 0),
+            PlanetType::Planet,
+            0,
+            false
+        );
     }
 
     /**

--- a/tests/Feature/FleetDispatch/FleetDispatchTransportTest.php
+++ b/tests/Feature/FleetDispatch/FleetDispatchTransportTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Feature\FleetDispatch;
 
-use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Date;
 use OGame\GameMissions\TransportMission;
 use OGame\GameObjects\Models\Units\UnitCollection;
 use OGame\Models\Enums\PlanetType;
@@ -10,6 +10,7 @@ use OGame\Models\Resources;
 use OGame\Services\FleetMissionService;
 use OGame\Services\ObjectService;
 use OGame\Services\PlanetService;
+use OGame\Services\SettingsService;
 use Tests\FleetDispatchTestCase;
 
 /**
@@ -26,6 +27,16 @@ class FleetDispatchTransportTest extends FleetDispatchTestCase
      * @var string The mission name for the test, displayed in UI.
      */
     protected string $missionName = 'Transport';
+
+    /**
+     * Reset attack block setting after each test to avoid state leaking between tests.
+     */
+    protected function tearDown(): void
+    {
+        $settingsService = resolve(SettingsService::class);
+        $settingsService->set('attack_block_until', 0);
+        parent::tearDown();
+    }
 
     /**
      * Prepare the planet for the test so it has the required buildings and research.
@@ -417,7 +428,7 @@ class FleetDispatchTransportTest extends FleetDispatchTestCase
         $fleetMissionId = $fleetMission->id;
 
         // Advance time by 1 minute
-        $fleetParentTime = Carbon::getTestNow()->addMinute();
+        $fleetParentTime = Date::getTestNow()->addMinute();
         $this->travelTo($fleetParentTime);
 
         // Cancel the mission
@@ -450,7 +461,7 @@ class FleetDispatchTransportTest extends FleetDispatchTestCase
         $this->assertTrue($fleetMission->time_arrival == $fleetParentTime->addSeconds(60)->timestamp, 'Return trip duration is not the same as the original mission has been active.');
 
         // Advance time by amount of minutes it takes for the return trip to arrive.
-        $this->travelTo(Carbon::createFromTimestamp($fleetMission->time_arrival));
+        $this->travelTo(Date::createFromTimestamp($fleetMission->time_arrival));
 
         // Do a request to trigger the update logic.
         $this->get('/overview');
@@ -541,5 +552,25 @@ class FleetDispatchTransportTest extends FleetDispatchTestCase
         // Verify resources and units were not deducted
         $response = $this->get('/shipyard');
         $this->assertObjectLevelOnPage($response, 'small_cargo', 5, 'Small Cargo ships were deducted despite failed mission.');
+    }
+
+    /**
+     * Assert that an active attack block does not prevent transport (friendly) missions from being dispatched.
+     */
+    public function testAttackBlockDoesNotPreventTransportDispatch(): void
+    {
+        $this->basicSetup();
+
+        $settingsService = resolve(SettingsService::class);
+        $settingsService->set('attack_block_until', time() + 3600);
+
+        $unitCollection = new UnitCollection();
+        $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('small_cargo'), 1);
+
+        // Fleet check to own second planet should succeed during an active attack block.
+        $this->fleetCheckToSecondPlanet($unitCollection, true);
+
+        // Dispatching to own second planet should also succeed during an active attack block.
+        $this->sendMissionToSecondPlanet($unitCollection, new Resources(100, 100, 0, 0));
     }
 }

--- a/tests/Feature/SettingsTest.php
+++ b/tests/Feature/SettingsTest.php
@@ -25,6 +25,15 @@ class SettingsTest extends TestCase
     }
 
     /**
+     * Reset attack block setting after each test to avoid state leaking between tests.
+     */
+    protected function tearDown(): void
+    {
+        $this->settingsService->set('attack_block_until', 0);
+        parent::tearDown();
+    }
+
+    /**
      * Check that settings records are correctly retrieved from database.
      */
     public function testSettingsGet(): void
@@ -59,5 +68,41 @@ class SettingsTest extends TestCase
 
         // Assert that set value equals the now new get value.
         $this->assertEquals($random_value, $get_value);
+    }
+
+    /**
+     * Check that attack block helper methods reflect the configured timestamp.
+     */
+    public function testAttackBlockHelpers(): void
+    {
+        $this->settingsService->set('attack_block_until', time() + 3600);
+
+        $this->assertTrue($this->settingsService->attackBlockActive());
+        $this->assertTrue($this->settingsService->missionBlockedByAttackBlock(1));
+        $this->assertTrue($this->settingsService->missionBlockedByAttackBlock(2));
+        $this->assertTrue($this->settingsService->missionBlockedByAttackBlock(6));
+        $this->assertTrue($this->settingsService->missionBlockedByAttackBlock(9));
+        $this->assertFalse($this->settingsService->missionBlockedByAttackBlock(3));
+
+        $this->settingsService->set('attack_block_until', time() - 1);
+
+        $this->assertFalse($this->settingsService->attackBlockActive());
+        $this->assertFalse($this->settingsService->missionBlockedByAttackBlock(1));
+    }
+
+    /**
+     * Check that mission types not in the blocked list are allowed during an active attack block.
+     */
+    public function testAttackBlockDoesNotBlockFriendlyMissions(): void
+    {
+        $this->settingsService->set('attack_block_until', time() + 3600);
+
+        $this->assertFalse($this->settingsService->missionBlockedByAttackBlock(3));  // Transport
+        $this->assertFalse($this->settingsService->missionBlockedByAttackBlock(4));  // Deployment
+        $this->assertFalse($this->settingsService->missionBlockedByAttackBlock(5));  // ACS Defend
+        $this->assertFalse($this->settingsService->missionBlockedByAttackBlock(7));  // Colonisation
+        $this->assertFalse($this->settingsService->missionBlockedByAttackBlock(8));  // Recycle
+        $this->assertFalse($this->settingsService->missionBlockedByAttackBlock(10)); // Missile
+        $this->assertFalse($this->settingsService->missionBlockedByAttackBlock(15)); // Expedition
     }
 }


### PR DESCRIPTION
## Description
Adds a configurable attack block that prevents hostile fleet missions (attack, ACS attack, espionage, moon destruction) from being dispatched while active. Friendly missions (transport, deployment, ACS defend, etc.) are unaffected.

### Type of Change:
- [ ] Bug fix
- [X] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #[issue-number]

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [X] **Automated Refactoring:** Rector has been run and no outstanding issues remain.
- [X] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [X] **Static Analysis:** Code passes PHPStan static code analysis.
- [X] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [X] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [X] **Documentation:** Documentation has been updated to reflect any changes made.

## Additional Information
One thing that still needs checking is how the fleet dispatch menu behaves in OGame when an attack block is in effect. As they are fairly rare, it may take a while to get the implementation 100% correct. With the recently announceed version 13.0 of OGame we may be able to see an attack block in effect soon(TM).
