### PR TITLE
Fix PhalanxTest failing when moon is near system boundary

### DIFF
--- a/tests/Feature/PhalanxTest.php
+++ b/tests/Feature/PhalanxTest.php
@@ -184,7 +184,7 @@ class PhalanxTest extends FleetDispatchTestCase
         // Build phalanx level 1 (range: 0, can only scan same system)
         $moonCoords = $this->moonService->getPlanetCoordinates();
 
-        // Wrap forward like a donut universe — always valid, always a different system.
+        // Wrap around to system 1 if at the boundary, so the target is always valid and always different.
         $targetSystem = ($moonCoords->system % UniverseConstants::MAX_SYSTEM_COUNT) + 1;
 
         // Try to scan a different system (out of range for level 1)
@@ -343,7 +343,7 @@ class PhalanxTest extends FleetDispatchTestCase
 
         $moonCoords = $this->moonService->getPlanetCoordinates();
 
-        // Wrap forward like a donut universe — always valid, always a different system.
+        // Wrap around to system 1 if at the boundary, so the target is always valid and always different.
         $targetSystem = ($moonCoords->system % UniverseConstants::MAX_SYSTEM_COUNT) + 1;
 
         // Try to scan 1 system away - should fail

--- a/tests/Feature/PhalanxTest.php
+++ b/tests/Feature/PhalanxTest.php
@@ -184,10 +184,8 @@ class PhalanxTest extends FleetDispatchTestCase
         // Build phalanx level 1 (range: 0, can only scan same system)
         $moonCoords = $this->moonService->getPlanetCoordinates();
 
-        // Pick a target 2 systems away, clamping direction to stay within universe bounds.
-        $targetSystem = $moonCoords->system <= UniverseConstants::MAX_SYSTEM_COUNT - 2
-            ? $moonCoords->system + 2
-            : $moonCoords->system - 2;
+        // Wrap forward like a donut universe — always valid, always a different system.
+        $targetSystem = ($moonCoords->system % UniverseConstants::MAX_SYSTEM_COUNT) + 1;
 
         // Try to scan a different system (out of range for level 1)
         $response = $this->post('/ajax/phalanx/scan', [
@@ -345,10 +343,8 @@ class PhalanxTest extends FleetDispatchTestCase
 
         $moonCoords = $this->moonService->getPlanetCoordinates();
 
-        // Pick a target 1 system away, clamping direction to stay within universe bounds.
-        $targetSystem = $moonCoords->system < UniverseConstants::MAX_SYSTEM_COUNT
-            ? $moonCoords->system + 1
-            : $moonCoords->system - 1;
+        // Wrap forward like a donut universe — always valid, always a different system.
+        $targetSystem = ($moonCoords->system % UniverseConstants::MAX_SYSTEM_COUNT) + 1;
 
         // Try to scan 1 system away - should fail
         $response = $this->post('/ajax/phalanx/scan', [

--- a/tests/Feature/PhalanxTest.php
+++ b/tests/Feature/PhalanxTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use OGame\GameConstants\UniverseConstants;
 use OGame\GameObjects\Models\Units\UnitCollection;
 use OGame\Models\Resources;
 use OGame\Services\ObjectService;
@@ -18,6 +19,15 @@ class PhalanxTest extends FleetDispatchTestCase
      * @var string The mission name for fleet tests
      */
     protected string $missionName = 'Attack';
+
+    /**
+     * Reset per-test mutations that could bleed into subsequent tests.
+     */
+    protected function tearDown(): void
+    {
+        $this->missionType = 1;
+        parent::tearDown();
+    }
 
     /**
      * Basic setup required by FleetDispatchTestCase
@@ -174,10 +184,15 @@ class PhalanxTest extends FleetDispatchTestCase
         // Build phalanx level 1 (range: 0, can only scan same system)
         $moonCoords = $this->moonService->getPlanetCoordinates();
 
+        // Pick a target 2 systems away, clamping direction to stay within universe bounds.
+        $targetSystem = $moonCoords->system <= UniverseConstants::MAX_SYSTEM_COUNT - 2
+            ? $moonCoords->system + 2
+            : $moonCoords->system - 2;
+
         // Try to scan a different system (out of range for level 1)
         $response = $this->post('/ajax/phalanx/scan', [
             'galaxy' => $moonCoords->galaxy,
-            'system' => $moonCoords->system + 2, // 2 systems away, out of range
+            'system' => $targetSystem,
             'position' => 5,
         ]);
 
@@ -315,9 +330,6 @@ class PhalanxTest extends FleetDispatchTestCase
         // Check that it shows "Own fleet" (scanner's own fleet)
         $contentHtml = $response->json('content_html');
         $this->assertStringContainsString('Own fleet', $contentHtml);
-
-        // Reset mission type
-        $this->missionType = 1;
     }
 
     /**
@@ -333,10 +345,15 @@ class PhalanxTest extends FleetDispatchTestCase
 
         $moonCoords = $this->moonService->getPlanetCoordinates();
 
+        // Pick a target 1 system away, clamping direction to stay within universe bounds.
+        $targetSystem = $moonCoords->system < UniverseConstants::MAX_SYSTEM_COUNT
+            ? $moonCoords->system + 1
+            : $moonCoords->system - 1;
+
         // Try to scan 1 system away - should fail
         $response = $this->post('/ajax/phalanx/scan', [
             'galaxy' => $moonCoords->galaxy,
-            'system' => $moonCoords->system + 1,
+            'system' => $targetSystem,
             'position' => 5,
         ]);
 

--- a/tests/Feature/PhalanxTest.php
+++ b/tests/Feature/PhalanxTest.php
@@ -37,7 +37,7 @@ class PhalanxTest extends FleetDispatchTestCase
         // Add some ships for fleet dispatch tests
         $this->planetAddUnit('light_fighter', 10);
         $this->planetAddUnit('small_cargo', 10);
-        $this->planetAddResources(new Resources(0, 0, 100000, 0));
+        $this->planetAddResources(new Resources(5000, 5000, 100000, 0));
     }
 
     /**
@@ -265,7 +265,7 @@ class PhalanxTest extends FleetDispatchTestCase
         // Send an attack fleet to a foreign planet
         $unitCollection = new UnitCollection();
         $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 5);
-        $targetPlanet = $this->sendMissionToOtherPlayerPlanet($unitCollection, new Resources(0, 0, 0, 0));
+        $targetPlanet = $this->sendMissionToOtherPlayerCleanPlanet($unitCollection, new Resources(0, 0, 0, 0));
 
         $coords = $targetPlanet->getPlanetCoordinates();
 


### PR DESCRIPTION
## Description
Several issues caused `PhalanxTest` to fail intermittently on CI:
  
1. `testScanOutOfRangeFails` and `testPhalanxRangeCalculation` picked out-of-range scan targets by adding 1 or 2 to the moon's system number. When a test user's moon lands in system 498 or 499, those values exceed `MAX_SYSTEM_COUNT (499)` and hit the controller's validation before the phalanx range logic runs, causing a `ValidationException` instead of the expected JSON error response. Fixed by wrapping forward within the boundary instead, so the target system is always valid and always different from the current one.
     
2. `testSuccessfulScanWithIncomingFleet` asserted exactly 1 fleet movement but `getNearbyForeignPlanet()` can return a planet that already has unprocessed fleet missions from other tests in the same CI run. Fixed by using `sendMissionToOtherPlayerCleanPlanet()` which creates a fresh planet with no prior fleet missions.
     
3. `testScanShowsYourFleetLabelForTransport` failed with "Not enough resources" because `basicSetup()` only added deuterium. The transport payload requires metal and crystal too. Fixed by adding metal and crystal to `basicSetup()`, consistent with how other fleet dispatch tests handle this. 
     
4. Added a `tearDown()` that resets `missionType` after each test, so a mid-test failure in `testScanShowsYourFleetLabelForTransport` cannot leak `missionType=3` into subsequent tests.

### Type of Change:
- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #1471 

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [X] **Automated Refactoring:** Rector has been run and no outstanding issues remain.
- [X] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [X] **Static Analysis:** Code passes PHPStan static code analysis.
- [X] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [X] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [X] **Documentation:** Documentation has been updated to reflect any changes made.

## Additional Information
Add any additional context, screenshots, or explanations to help reviewers understand your PR. If this change introduces any breaking changes or significant impacts, please detail them here.
