### PR TITLE
Fix phalanx range check to use donut system wrap-around

### DIFF
--- a/app/Services/CoordinateDistanceCalculator.php
+++ b/app/Services/CoordinateDistanceCalculator.php
@@ -56,8 +56,7 @@ class CoordinateDistanceCalculator
         $diffSystems = abs($from->system - $to->system);
 
         // Check if donut galaxy wrapping provides a shorter path
-        $altDiff = UniverseConstants::MAX_SYSTEM_COUNT - $diffSystems;
-        if ($altDiff < $diffSystems) {
+        if ($this->getSystemDistance($from->system, $to->system) < $diffSystems) {
             // Path wraps around, split into two segments
             $split1 = new Coordinate($from->galaxy, UniverseConstants::MIN_SYSTEM, UniverseConstants::MAX_PLANET_POSITION);
             $split2 = new Coordinate($to->galaxy, UniverseConstants::MAX_SYSTEM_COUNT, UniverseConstants::MAX_PLANET_POSITION);
@@ -115,8 +114,7 @@ class CoordinateDistanceCalculator
         $diffSystems = abs($from->system - $to->system);
 
         // Check if donut galaxy wrapping provides a shorter path
-        $altDiff = UniverseConstants::MAX_SYSTEM_COUNT - $diffSystems;
-        if ($altDiff < $diffSystems) {
+        if ($this->getSystemDistance($from->system, $to->system) < $diffSystems) {
             // Path wraps around, split into two segments
             $split1 = new Coordinate($from->galaxy, UniverseConstants::MIN_SYSTEM, UniverseConstants::MAX_PLANET_POSITION);
             $split2 = new Coordinate($to->galaxy, UniverseConstants::MAX_SYSTEM_COUNT, UniverseConstants::MAX_PLANET_POSITION);

--- a/app/Services/CoordinateDistanceCalculator.php
+++ b/app/Services/CoordinateDistanceCalculator.php
@@ -21,6 +21,19 @@ class CoordinateDistanceCalculator
     }
 
     /**
+     * Shortest system distance within a galaxy, accounting for donut wrap-around.
+     *
+     * Example: system 490 to system 5 is 14 systems via the wrap, not 485.
+     */
+    public function getSystemDistance(int $fromSystem, int $toSystem): int
+    {
+        $diffSystems = abs($fromSystem - $toSystem);
+        $wrapDiff = abs($diffSystems - UniverseConstants::MAX_SYSTEM_COUNT);
+
+        return min($diffSystems, $wrapDiff);
+    }
+
+    /**
      * Get the number of empty systems between two coordinates.
      * Only applies when coordinates are in the same galaxy.
      *

--- a/app/Services/PhalanxService.php
+++ b/app/Services/PhalanxService.php
@@ -28,8 +28,10 @@ class PhalanxService
     /**
      * PhalanxService constructor.
      */
-    public function __construct(private PlayerServiceFactory $playerServiceFactory)
-    {
+    public function __construct(
+        private PlayerServiceFactory $playerServiceFactory,
+        private CoordinateDistanceCalculator $coordinateDistanceCalculator,
+    ) {
     }
 
     /**
@@ -87,8 +89,11 @@ class PhalanxService
             return false;
         }
 
-        // Calculate system distance
-        $system_distance = abs($moon_system - $target_coordinate->system);
+        // Calculate shortest system distance (donut galaxy wrap-around)
+        $system_distance = $this->coordinateDistanceCalculator->getSystemDistance(
+            $moon_system,
+            $target_coordinate->system,
+        );
 
         return $system_distance <= $max_range;
     }

--- a/tests/Unit/CoordinateDistanceCalculatorTest.php
+++ b/tests/Unit/CoordinateDistanceCalculatorTest.php
@@ -35,6 +35,16 @@ class CoordinateDistanceCalculatorTest extends TestCase
     }
 
     /**
+     * Test shortest system distance accounts for donut wrap-around.
+     */
+    public function testGetSystemDistanceUsesWrapAround(): void
+    {
+        $this->assertEquals(14, $this->calculator->getSystemDistance(490, 5));
+        $this->assertEquals(3, $this->calculator->getSystemDistance(100, 103));
+        $this->assertEquals(0, $this->calculator->getSystemDistance(250, 250));
+    }
+
+    /**
      * Test that empty systems calculation returns 0 when setting is disabled.
      */
     public function testEmptySystemsDisabled(): void

--- a/tests/Unit/PhalanxServiceTest.php
+++ b/tests/Unit/PhalanxServiceTest.php
@@ -189,4 +189,22 @@ class PhalanxServiceTest extends UnitTestCase
         $targetCoords4 = new Coordinate(1, 109, 5); // 9 systems forwards
         $this->assertFalse($this->phalanxService->canScanTarget($moonGalaxy, $moonSystem, $phalanxLevel, $targetCoords4));
     }
+
+    /**
+     * Test that canScanTarget uses donut wrap-around for system distance.
+     */
+    public function testCanScanAcrossGalaxyWrap(): void
+    {
+        $moonGalaxy = 1;
+        $moonSystem = 490;
+        $phalanxLevel = 4; // Range 15
+
+        // 485 systems linearly, but only 14 via wrap-around
+        $targetCoords = new Coordinate(1, 5, 8);
+
+        $this->assertTrue($this->phalanxService->canScanTarget($moonGalaxy, $moonSystem, $phalanxLevel, $targetCoords));
+
+        $outOfRangeCoords = new Coordinate(1, 7, 8); // 16 systems via wrap (490 -> 499 -> 1 -> 7)
+        $this->assertFalse($this->phalanxService->canScanTarget($moonGalaxy, $moonSystem, $phalanxLevel, $outOfRangeCoords));
+    }
 }


### PR DESCRIPTION
## Summary
- Add `CoordinateDistanceCalculator::getSystemDistance()` for shortest system distance with donut wrap-around
- Use it in `PhalanxService::canScanTarget()` instead of plain `abs()`
- Add unit tests for wrap-around scanning (490 → 5) and the calculator helper

Fixes #1472

## Test plan
- [ ] `./vendor/bin/phpunit tests/Unit/PhalanxServiceTest.php`
- [ ] `./vendor/bin/phpunit tests/Unit/CoordinateDistanceCalculatorTest.php`
- [ ] Moon at system 490 with phalanx level 4 can scan system 5 in galaxy view

Made with [Cursor](https://cursor.com)