### PR TITLE
Fix 500 on fleet movement during moon destruction missions

### DIFF
--- a/app/GameMissions/MoonDestructionMission.php
+++ b/app/GameMissions/MoonDestructionMission.php
@@ -3,6 +3,7 @@
 namespace OGame\GameMissions;
 
 use Illuminate\Support\Facades\DB;
+use OGame\Enums\FleetMissionStatus;
 use OGame\Enums\FleetSpeedType;
 use OGame\GameMessages\FleetLostContact;
 use OGame\GameMessages\MoonDestroyed;
@@ -34,6 +35,7 @@ class MoonDestructionMission extends GameMission
     protected static bool $hasReturnMission = true;
     protected static bool $blockedByServerAttackBlock = true;
     protected static FleetSpeedType $fleetSpeedType = FleetSpeedType::war;
+    protected static FleetMissionStatus $friendlyStatus = FleetMissionStatus::Hostile;
 
     public function isMissionPossible(PlanetService $planet, Coordinate $targetCoordinate, PlanetType $targetType, UnitCollection $units): MissionPossibleStatus
     {

--- a/tests/Feature/FleetMovementTest.php
+++ b/tests/Feature/FleetMovementTest.php
@@ -340,6 +340,8 @@ class FleetMovementTest extends FleetDispatchTestCase
      */
     public function testFleetMovementShowsMoonDestructionMission(): void
     {
+        $this->missionType = 9; // Moon Destruction
+
         $this->planetAddUnit('deathstar', 1);
         $this->playerSetResearchLevel('computer_technology', 5);
         $this->planetAddResources(new Resources(0, 0, 100000, 0));
@@ -351,5 +353,6 @@ class FleetMovementTest extends FleetDispatchTestCase
         $response = $this->get('/fleet/movement');
         $response->assertStatus(200);
         $response->assertSee('Moon Destruction');
+        $response->assertSee('hostile', false);
     }
 }

--- a/tests/Feature/FleetMovementTest.php
+++ b/tests/Feature/FleetMovementTest.php
@@ -334,4 +334,22 @@ class FleetMovementTest extends FleetDispatchTestCase
         // Should show fleet slots info
         $response->assertSee('Fleets');
     }
+
+    /**
+     * Regression test for #1446: /fleet/movement must not 500 when a moon destruction fleet is active.
+     */
+    public function testFleetMovementShowsMoonDestructionMission(): void
+    {
+        $this->planetAddUnit('deathstar', 1);
+        $this->playerSetResearchLevel('computer_technology', 5);
+        $this->planetAddResources(new Resources(0, 0, 100000, 0));
+
+        $unitCollection = new UnitCollection();
+        $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('deathstar'), 1);
+        $this->sendMissionToOtherPlayerMoon($unitCollection, new Resources(0, 0, 0, 0));
+
+        $response = $this->get('/fleet/movement');
+        $response->assertStatus(200);
+        $response->assertSee('Moon Destruction');
+    }
 }

--- a/tests/Unit/MoonDestructionMissionTest.php
+++ b/tests/Unit/MoonDestructionMissionTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit;
 
+use OGame\Enums\FleetMissionStatus;
 use OGame\Factories\PlanetServiceFactory;
 use OGame\Factories\PlayerServiceFactory;
 use OGame\GameMissions\MoonDestructionMission;
@@ -29,6 +30,11 @@ class MoonDestructionMissionTest extends UnitTestCase
             $this->app->make(PlayerServiceFactory::class),
             $this->app->make(SettingsService::class)
         );
+    }
+
+    public function testFriendlyStatusIsHostile(): void
+    {
+        $this->assertSame(FleetMissionStatus::Hostile, MoonDestructionMission::getFriendlyStatus());
     }
 
     /**


### PR DESCRIPTION
## Summary
- Add missing `$friendlyStatus = Hostile` to `MoonDestructionMission`
- `/fleet/movement` calls `GameMission::getFriendlyStatus()` for every active mission; type 9 crashed with an uninitialized static property (PHP 8.2+)
- The fleet event widget was unaffected because it uses ownership-based `determineFriendly()` instead

Fixes #1446

## Test plan
- [ ] `./vendor/bin/phpunit tests/Unit/MoonDestructionMissionTest.php --filter testFriendlyStatusIsHostile`
- [ ] `./vendor/bin/phpunit tests/Feature/FleetMovementTest.php --filter testFleetMovementShowsMoonDestructionMission`
- [ ] With an active moon destruction fleet, `/fleet/movement` returns 200 instead of 500

Made with [Cursor](https://cursor.com)