### PR TITLE
Lift vacation time-lock when unbanning a player

### DIFF
--- a/app/Http/Controllers/Admin/ServerAdministrationController.php
+++ b/app/Http/Controllers/Admin/ServerAdministrationController.php
@@ -720,6 +720,15 @@ class ServerAdministrationController extends OGameController
                 'canceled'   => true,
                 'canceled_at' => now(),
             ]);
+
+            // Lift the 48h minimum-vacation restriction that was imposed by the ban
+            // so the player can leave vacation mode immediately after being unbanned.
+            // The vacation_mode flag itself is left ON — the player chooses when to
+            // disable it; we only release the time-lock that the ban introduced.
+            if ($user->vacation_mode && $user->vacation_mode_until !== null && now()->lessThan($user->vacation_mode_until)) {
+                $user->vacation_mode_until = now();
+                $user->save();
+            }
         }
 
         return redirect()->route('admin.server-administration.index')

--- a/tests/Feature/BanTest.php
+++ b/tests/Feature/BanTest.php
@@ -163,6 +163,30 @@ class BanTest extends AccountTestCase
     }
 
     /**
+     * Test that unbanning lifts the 48h vacation lock so the player can leave vacation immediately.
+     */
+    public function testUnbanLiftsVacationModeUntilRestriction(): void
+    {
+        $this->artisan('ogamex:admin:assign-role', ['username' => auth()->user()->username]);
+
+        $target = $this->createTrackedUser();
+        Ban::create(['user_id' => $target->id, 'reason' => 'Some violation', 'banned_until' => null, 'canceled' => false]);
+        $target->vacation_mode = true;
+        $target->vacation_mode_activated_at = now();
+        $target->vacation_mode_until = now()->addHours(48);
+        $target->save();
+
+        $this->post(route('admin.server-administration.unban'), [
+            'user_id' => $target->id,
+        ]);
+
+        $target->refresh();
+        $this->assertFalse($target->isBanned());
+        $this->assertTrue((bool) $target->vacation_mode);
+        $this->assertTrue(now()->greaterThanOrEqualTo($target->vacation_mode_until));
+    }
+
+    /**
      * Test that a banned user accessing an ingame page is logged out and redirected to login.
      */
     public function testBannedUserBlockedByMiddleware(): void


### PR DESCRIPTION
## Summary
When a timed ban activates vacation mode, the player gets a 48h minimum before they can leave vacation. If an admin unbans them early, the ban is lifted but `vacation_mode_until` stayed in the future — effectively extending the restriction up to 48 hours after the ban ended.

This sets `vacation_mode_until = now()` on unban when vacation is still time-locked. `vacation_mode` stays enabled until the player disables it manually.

Same approach as [#1411](https://github.com/lanedirt/OGameX/pull/1411); includes a regression test.

Fixes #1395

## Test plan
- [ ] `./vendor/bin/phpunit tests/Feature/BanTest.php`

Made with [Cursor](https://cursor.com)