### PR TITLE
Show max fleet slots message in galaxy tooltips (#666)

### DIFF
--- a/app/Http/Controllers/GalaxyController.php
+++ b/app/Http/Controllers/GalaxyController.php
@@ -75,8 +75,8 @@ class GalaxyController extends OGameController
             'espionage_probe_count' => $planet->getObjectAmount('espionage_probe'),
             'recycler_count' => $planet->getObjectAmount('recycler'),
             'interplanetary_missiles_count' => $planet->getObjectAmount('interplanetary_missile'),
-            'used_slots' => 0,
-            'max_slots' => 1,
+            'used_slots' => $player->getFleetSlotsInUse(),
+            'max_slots' => $player->getFleetSlotsMax(),
             'max_galaxies' => $settingsService->numberOfGalaxies(),
             'is_in_vacation_mode' => $player->isInVacationMode(),
             'planet_relocation_cost' => (int)$settingsService->get('planet_relocation_cost', 240000),
@@ -594,6 +594,32 @@ class GalaxyController extends OGameController
         $has_colonize_ship = $this->playerService->planets->current()->getObjectAmount('colony_ship') > 0;
         $colonize_ship_message = "<br><div><img src='/img/galaxy/activity.gif' />" . __('t_galaxy.mission.colonize.no_ship') . "</div>";
 
+        $astrophysicsLevel = $this->playerService->getResearchLevel('astrophysics');
+        $canColonizePosition = $this->playerService->canColonizePosition($position);
+        $usedFleetSlots = $this->playerService->getFleetSlotsInUse();
+        $maximumFleetSlots = $this->playerService->getFleetSlotsMax();
+        $canFly = $usedFleetSlots < $maximumFleetSlots;
+        $hasAdmiral = $this->playerService->hasAdmiral();
+
+        $description = __('t_galaxy.mission.colonize.name') . "<br>{$planet_description}";
+        if (!$has_colonize_ship) {
+            $description .= $colonize_ship_message;
+        }
+        if ($astrophysicsLevel === 0 || !$canColonizePosition) {
+            $description .= '<br>' . __('t_ingame.galaxy.astro_required');
+        }
+        if (!$canFly) {
+            $description .= '<br>' . __('t_ingame.fleet.no_free_slots');
+            if (!$hasAdmiral) {
+                $description .= '<br>' . __('t_ingame.galaxy.hire_admiral');
+            }
+        }
+
+        $canColonize = $has_colonize_ship
+            && $astrophysicsLevel > 0
+            && $canColonizePosition
+            && $canFly;
+
         // Check if the current planet already has a pending move.
         $planetMoveService = app(PlanetMoveService::class);
         $activeMove = $planetMoveService->getActiveMoveForPlanet($this->playerService->planets->current());
@@ -610,8 +636,8 @@ class GalaxyController extends OGameController
             ],
             [
                 'missionType' => 7,
-                'link' => $has_colonize_ship ? "/fleet?galaxy={$galaxy}&system={$system}&position={$position}&type=1&mission=7" : '#',
-                'description' => __('t_galaxy.mission.colonize.name') . "<br>{$planet_description}" . (!$has_colonize_ship ? $colonize_ship_message : '')
+                'link' => $canColonize ? "/fleet?galaxy={$galaxy}&system={$system}&position={$position}&type=1&mission=7" : '#',
+                'description' => $description,
             ]
         ];
 
@@ -705,6 +731,9 @@ class GalaxyController extends OGameController
             $can_system_phalanx = $phalanx_level > 0;
         }
 
+        $usedFleetSlots = $player->getFleetSlotsInUse();
+        $maximumFleetSlots = $player->getFleetSlotsMax();
+
         return response()->json([
             'components' => [],
             'filterSettings' => [],
@@ -717,9 +746,9 @@ class GalaxyController extends OGameController
                 'availablePathfinders' => $planet->getObjectAmount('pathfinder'),
                 'availableProbes' => $planet->getObjectAmount('espionage_probe'),
                 'availableRecyclers' => $planet->getObjectAmount('recycler'),
-                'canColonize' => true,
+                'canColonize' => $player->getResearchLevel('astrophysics') > 0,
                 'canExpedition' => true,
-                'canFly' => true,
+                'canFly' => $usedFleetSlots < $maximumFleetSlots,
                 'canSendSystemDiscovery' => true,
                 'canSwitchGalaxy' => true,
                 'canSystemEspionage' => false,
@@ -729,17 +758,17 @@ class GalaxyController extends OGameController
                 'galaxy' => $galaxy,
                 'system' => $system,
                 'galaxyContent' => $galaxyContent,
-                'hasAdmiral' => false,
+                'hasAdmiral' => $player->hasAdmiral(),
                 'hasBirthdayPlanet' => false,
                 'isOutlaw' => false,
-                'maximumFleetSlots' => 13,
+                'maximumFleetSlots' => $maximumFleetSlots,
                 'playerId' => $player->getId(),
                 'settingsProbeCount' => 3,
                 'showOutlawWarning' => true,
                 'slotsColonized' => $slotsColonized,
                 'switchGalaxyDeuteriumCosts' => 10,
                 'toGalaxyLink' => route('galaxy.index', ['galaxy' => $galaxy, 'system' => $system]),
-                'usedFleetSlots' => 1
+                'usedFleetSlots' => $usedFleetSlots,
             ],
         ]);
     }

--- a/tests/Feature/GalaxyTest.php
+++ b/tests/Feature/GalaxyTest.php
@@ -2,6 +2,9 @@
 
 namespace Tests\Feature;
 
+use Illuminate\Support\Facades\Date;
+use OGame\Models\Enums\PlanetType;
+use OGame\Models\FleetMission;
 use OGame\Models\Resources;
 use OGame\Services\DebrisFieldService;
 use Tests\AccountTestCase;
@@ -52,5 +55,123 @@ class GalaxyTest extends AccountTestCase
         $response->assertSeeText('5555');
         $response->assertSeeText('6666');
         $response->assertSeeText('7777');
+    }
+
+    /**
+     * Verify galaxy AJAX returns real fleet slot counts from the player.
+     */
+    public function testGalaxyAjaxReturnsRealFleetSlots(): void
+    {
+        $coordinates = $this->planetService->getPlanetCoordinates();
+        $player = $this->planetService->getPlayer();
+
+        $this->get('/');
+
+        $response = $this->post('ajax/galaxy', [
+            '_token' => csrf_token(),
+            'galaxy' => $coordinates->galaxy,
+            'system' => $coordinates->system,
+        ]);
+
+        $response->assertOk();
+        $response->assertJsonPath('system.usedFleetSlots', $player->getFleetSlotsInUse());
+        $response->assertJsonPath('system.maximumFleetSlots', $player->getFleetSlotsMax());
+        $response->assertJsonPath('system.canFly', true);
+        $response->assertJsonPath('system.hasAdmiral', $player->hasAdmiral());
+    }
+
+    /**
+     * Verify canFly is false when all fleet slots are in use.
+     */
+    public function testGalaxyAjaxCanFlyFalseWhenSlotsFull(): void
+    {
+        $this->playerSetResearchLevel('computer_technology', 0);
+
+        $coordinates = $this->planetService->getPlanetCoordinates();
+        $player = $this->planetService->getPlayer();
+
+        // Fill the only available fleet slot with an active mission.
+        $mission = new FleetMission();
+        $mission->user_id = $player->getId();
+        $mission->planet_id_from = $this->planetService->getPlanetId();
+        $mission->galaxy_from = $coordinates->galaxy;
+        $mission->system_from = $coordinates->system;
+        $mission->position_from = $coordinates->position;
+        $mission->type_from = PlanetType::Planet->value;
+        $mission->galaxy_to = $coordinates->galaxy;
+        $mission->system_to = $coordinates->system;
+        $mission->position_to = $coordinates->position;
+        $mission->type_to = PlanetType::Planet->value;
+        $mission->mission_type = 3;
+        $mission->time_departure = (int) Date::now()->timestamp;
+        $mission->time_arrival = (int) Date::now()->addHour()->timestamp;
+        $mission->processed = 0;
+        $mission->processed_hold = 0;
+        $mission->canceled = 0;
+        $mission->small_cargo = 1;
+        $mission->save();
+
+        $this->assertEquals(1, $player->getFleetSlotsInUse());
+        $this->assertEquals(1, $player->getFleetSlotsMax());
+
+        $this->get('/');
+
+        $response = $this->post('ajax/galaxy', [
+            '_token' => csrf_token(),
+            'galaxy' => $coordinates->galaxy,
+            'system' => $coordinates->system,
+        ]);
+
+        $response->assertOk();
+        $response->assertJsonPath('system.usedFleetSlots', 1);
+        $response->assertJsonPath('system.maximumFleetSlots', 1);
+        $response->assertJsonPath('system.canFly', false);
+    }
+
+    /**
+     * Verify empty-slot colonisation tooltip warns about missing astrophysics and disables the link.
+     */
+    public function testGalaxyColoniseTooltipShowsAstrophysicsWarning(): void
+    {
+        $this->playerSetResearchLevel('astrophysics', 0);
+        $this->planetAddUnit('colony_ship', 1);
+
+        $coordinates = $this->planetService->getPlanetCoordinates();
+
+        $this->get('/');
+
+        $response = $this->post('ajax/galaxy', [
+            '_token' => csrf_token(),
+            'galaxy' => $coordinates->galaxy,
+            'system' => $coordinates->system,
+        ]);
+
+        $response->assertOk();
+        $response->assertJsonPath('system.canColonize', false);
+
+        $galaxyContent = $response->json('system.galaxyContent');
+        $this->assertIsArray($galaxyContent);
+
+        $emptySlot = null;
+        foreach ($galaxyContent as $row) {
+            if (($row['positionFilters'] ?? null) === 'empty_filter') {
+                $emptySlot = $row;
+                break;
+            }
+        }
+
+        $this->assertNotNull($emptySlot, 'Expected an empty galaxy slot for colonisation tooltip assertion.');
+
+        $coloniseMission = null;
+        foreach ($emptySlot['availableMissions'] as $mission) {
+            if (($mission['missionType'] ?? null) === 7) {
+                $coloniseMission = $mission;
+                break;
+            }
+        }
+
+        $this->assertNotNull($coloniseMission, 'Expected a colonisation mission on the empty slot.');
+        $this->assertSame('#', $coloniseMission['link']);
+        $this->assertStringContainsString(__('t_ingame.galaxy.astro_required'), $coloniseMission['description']);
     }
 }

--- a/tests/Feature/GalaxyTest.php
+++ b/tests/Feature/GalaxyTest.php
@@ -64,6 +64,7 @@ class GalaxyTest extends AccountTestCase
     {
         $coordinates = $this->planetService->getPlanetCoordinates();
         $player = $this->planetService->getPlayer();
+        $this->assertNotNull($player, 'Player not found');
 
         $this->get('/');
 
@@ -89,6 +90,7 @@ class GalaxyTest extends AccountTestCase
 
         $coordinates = $this->planetService->getPlanetCoordinates();
         $player = $this->planetService->getPlayer();
+        $this->assertNotNull($player, 'Player not found');
 
         // Fill the only available fleet slot with an active mission.
         $mission = new FleetMission();


### PR DESCRIPTION
## Summary
- Wire real `usedFleetSlots`, `maximumFleetSlots`, `canFly`, and `hasAdmiral` into the galaxy AJAX response so existing planet/moon/debris tooltips show "No fleet slots available" when slots are full
- Enrich empty-slot colonisation tooltips with astrophysics and max-fleet-slots warnings, and disable the colonise link when colonisation is not allowed
- Add GalaxyTest coverage for slot counts, `canFly: false`, and the astrophysics colonisation warning

Closes #666

## Test plan
- [ ] Fill all fleet slots, open galaxy, hover a foreign planet/moon — tooltip shows "No fleet slots available" (+ Hire admiral) instead of mission links
- [ ] Same check for a debris field tooltip
- [ ] With astrophysics at 0, hover an empty-slot colonise icon — tooltip includes astrophysics warning and icon is inactive
- [ ] With slots full and astrophysics researched, colonise tooltip shows no-fleet-slots message
- [ ] Confirm used/total fleet slot counters in the galaxy header match the fleet page
- [ ] `php artisan test --filter=GalaxyTest`


Made with [Cursor](https://cursor.com)