### PR TITLE
Upgrade PHPStan analysis to level 8

### DIFF
--- a/app/Console/Commands/Dev/PreviewSeedUsers.php
+++ b/app/Console/Commands/Dev/PreviewSeedUsers.php
@@ -2,9 +2,9 @@
 
 namespace OGame\Console\Commands\Dev;
 
+use Exception;
 use Illuminate\Console\Attributes\Description;
 use Illuminate\Console\Attributes\Signature;
-use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Hash;
 use OGame\Enums\CharacterClass;
@@ -18,6 +18,7 @@ use OGame\Models\UserTech;
 use OGame\Models\WreckField;
 use OGame\Services\ObjectService;
 use OGame\Services\PlanetService;
+use RuntimeException;
 
 #[Description('Seed the database with test users. Recreates users on each run.')]
 #[Signature('ogamex:dev:seed-users
@@ -166,6 +167,9 @@ class PreviewSeedUsers extends Command
     public function handle(): int
     {
         $password = $this->option('password');
+        if (!is_string($password)) {
+            throw new RuntimeException('Password option must be a string.');
+        }
 
         $this->info('Seeding preview environment test users...');
         $this->newLine();
@@ -338,6 +342,9 @@ class PreviewSeedUsers extends Command
         // Apply custom config values (resources, buildings, ships, defense)
         // Get planet model directly from DB since PlanetService has it as private
         $planet = Planet::find($planetService->getPlanetId());
+        if ($planet === null) {
+            throw new RuntimeException('Planet not found.');
+        }
 
         // Only set custom name if provided
         if ($planetName !== null) {

--- a/app/Console/Commands/Test/TestBattleEnginePerformance.php
+++ b/app/Console/Commands/Test/TestBattleEnginePerformance.php
@@ -2,9 +2,9 @@
 
 namespace OGame\Console\Commands\Test;
 
+use Exception;
 use Illuminate\Console\Attributes\Description;
 use Illuminate\Console\Attributes\Signature;
-use Exception;
 use Illuminate\Support\Facades\Date;
 use InvalidArgumentException;
 use OGame\GameMissions\BattleEngine\BattleEngine;
@@ -46,7 +46,8 @@ class TestBattleEnginePerformance extends TestCommand
     public function handle(): int
     {
         // Check for fleet option
-        if (!$this->option('fleet') || !$this->parseFleets($this->option('fleet'))) {
+        $fleetOption = $this->option('fleet');
+        if (!is_string($fleetOption) || !$this->parseFleets($fleetOption)) {
             $this->error('Specify valid --fleet option in JSON format like this: --fleet=\'{"attacker": {"light_fighter": 1667}, "defender": {"rocket_launcher": 1667}}\'');
             return 1;
         }
@@ -54,7 +55,11 @@ class TestBattleEnginePerformance extends TestCommand
         // Set up the test environment
         parent::setup();
 
-        $fleets = $this->parseFleets($this->option('fleet'));
+        $fleets = $this->parseFleets($fleetOption);
+        if ($fleets === null) {
+            $this->error('Invalid fleet option provided.');
+            return 1;
+        }
         $engine = $this->argument('engine');
 
         if (!in_array($engine, ['php', 'rust'])) {

--- a/app/Console/Commands/Test/TestCommand.php
+++ b/app/Console/Commands/Test/TestCommand.php
@@ -20,6 +20,7 @@ use OGame\Models\Planet\Coordinate;
 use OGame\Models\User;
 use OGame\Services\PlanetService;
 use OGame\Services\PlayerService;
+use RuntimeException;
 
 abstract class TestCommand extends Command
 {
@@ -214,6 +215,10 @@ abstract class TestCommand extends Command
             if (isset($matches[1])) {
                 $csrfToken = $matches[1];
             }
+        }
+
+        if ($csrfToken === null) {
+            throw new RuntimeException('Failed to retrieve CSRF token.');
         }
 
         return $csrfToken;

--- a/app/Console/Commands/Test/TestRaceConditionGameMission.php
+++ b/app/Console/Commands/Test/TestRaceConditionGameMission.php
@@ -2,14 +2,15 @@
 
 namespace OGame\Console\Commands\Test;
 
-use Illuminate\Console\Attributes\Description;
-use Illuminate\Console\Attributes\Signature;
 use Exception;
 use GuzzleHttp\Exception\GuzzleException;
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
 use Illuminate\Validation\ValidationException;
 use OGame\Models\FleetMission;
 use OGame\Models\Resources;
 use OGame\Services\ObjectService;
+use RuntimeException;
 
 /**
  * Class TestRaceConditionGameMission.
@@ -107,7 +108,11 @@ class TestRaceConditionGameMission extends TestCommand
     {
         $missionTypeTransport = 3;
         $secondPlanet = $this->playerService->planets->all()[1];
-        $this->playerService->planets->first()->addResources(new Resources(0, 0, 1000000, 0));
+        $firstPlanet = $this->playerService->planets->first();
+        if ($firstPlanet === null) {
+            throw new RuntimeException('Player has no planets.');
+        }
+        $firstPlanet->addResources(new Resources(0, 0, 1000000, 0));
         $secondPlanetCoordinates = $secondPlanet->getPlanetCoordinates();
 
         $csrfToken = $this->getCsrfToken();

--- a/app/Events/ChatMessageSent.php
+++ b/app/Events/ChatMessageSent.php
@@ -50,12 +50,14 @@ class ChatMessageSent implements ShouldBroadcast
      */
     public function broadcastWith(): array
     {
+        $createdAt = $this->message->created_at;
+
         $data = [
             'id' => $this->message->id,
             'senderId' => $this->message->sender_id,
             'senderName' => $this->message->sender->username,
             'text' => e($this->message->message),
-            'date' => $this->message->created_at->timestamp,
+            'date' => $createdAt !== null ? $createdAt->timestamp : 0,
         ];
 
         if ($this->message->alliance_id) {

--- a/app/Factories/PlanetServiceFactory.php
+++ b/app/Factories/PlanetServiceFactory.php
@@ -449,7 +449,12 @@ class PlanetServiceFactory
      */
     public function createMoonForPlanet(PlanetService $planet, int $debrisAmount, int $moonChance, int|null $xFactor = null): PlanetService
     {
-        return $this->createPlanet($planet->getPlayer(), $planet->getPlanetCoordinates(), 'Moon', PlanetType::Moon, $debrisAmount, $moonChance, $xFactor);
+        $player = $planet->getPlayer();
+        if ($player === null) {
+            throw new RuntimeException('Planet has no owner.');
+        }
+
+        return $this->createPlanet($player, $planet->getPlanetCoordinates(), 'Moon', PlanetType::Moon, $debrisAmount, $moonChance, $xFactor);
     }
 
     /**

--- a/app/GameMessages/Abstracts/GameMessage.php
+++ b/app/GameMessages/Abstracts/GameMessage.php
@@ -101,6 +101,9 @@ abstract class GameMessage
     public function getDateFormatted(): string
     {
         // Return in this format: 18.03.2024 14:50:38
+        if ($this->message->created_at === null) {
+            return '';
+        }
         return $this->message->created_at->format('d.m.Y H:i:s');
     }
 
@@ -304,14 +307,14 @@ abstract class GameMessage
                 // Do nothing
             }
 
-            if ($playerService->getId() > 0) {
+            if ($playerService !== null && $playerService->getId() > 0) {
                 $playerName = $playerService->getUsername();
             } else {
                 $playerName = 'Unknown Player';
             }
 
             return $playerName;
-        }, $body);
+        }, $body) ?? '';
 
         $body = preg_replace_callback('/\[planet\](\d+)\[\/planet\]/', function ($matches) {
             $planetService = null;
@@ -350,21 +353,21 @@ abstract class GameMessage
             }
 
             return $planetName;
-        }, $body);
+        }, $body) ?? '';
 
         $body = preg_replace_callback('/\[coordinates\](\d+):(\d+):(\d+)\[\/coordinates\]/', function ($matches) {
             $coordinates = new Coordinate((int)$matches[1], (int)$matches[2], (int)$matches[3]);
             return '<a href="' . route('galaxy.index', ['galaxy' => $coordinates->galaxy, 'system' => $coordinates->system, 'position' => $coordinates->position]) . '" class="txt_link">
                                 <figure class="planetIcon planet tooltip js_hideTipOnMobile" title="Planet"></figure>
                             [' . $coordinates->asString() . ']</a>';
-        }, $body);
+        }, $body) ?? '';
 
         $body = preg_replace_callback('/\[debrisfield\](\d+):(\d+):(\d+)\[\/debrisfield\]/', function ($matches) {
             $coordinates = new Coordinate((int)$matches[1], (int)$matches[2], (int)$matches[3]);
             return '<a href="' . route('galaxy.index', ['galaxy' => $coordinates->galaxy, 'system' => $coordinates->system, 'position' => $coordinates->position]) . '" class="txt_link">
                                 <figure class="planetIcon tf tooltip js_hideTipOnMobile" title="Planet"></figure>
                             debris field [' . $coordinates->asString() . ']</a>';
-        }, $body);
+        }, $body) ?? '';
 
         return $body;
     }

--- a/app/GameMessages/BattleReport.php
+++ b/app/GameMessages/BattleReport.php
@@ -29,15 +29,15 @@ class BattleReport extends GameMessage
     }
 
     /**
-     * Load battle report model from database. If already loaded, do nothing.
+     * Load battle report model from database. If already loaded, return the cached model.
      *
-     * @return void
+     * @return \OGame\Models\BattleReport
      */
-    private function loadBattleReportModel(): void
+    private function loadBattleReportModel(): \OGame\Models\BattleReport
     {
         if ($this->battleReportModel !== null) {
             // Already loaded.
-            return;
+            return $this->battleReportModel;
         }
 
         // Load battle report model from database associated with the message.
@@ -48,6 +48,8 @@ class BattleReport extends GameMessage
         } else {
             $this->battleReportModel = $battleReport;
         }
+
+        return $this->battleReportModel;
     }
 
     /**
@@ -55,11 +57,11 @@ class BattleReport extends GameMessage
      */
     public function getSubject(): string
     {
-        $this->loadBattleReportModel();
+        $battleReportModel = $this->loadBattleReportModel();
 
         // Load the planet name from the references table and return the subject filled with the planet name.
-        $coordinate = new Coordinate($this->battleReportModel->planet_galaxy, $this->battleReportModel->planet_system, $this->battleReportModel->planet_position);
-        $planet = $this->planetServiceFactory->makeForCoordinate($coordinate, true, PlanetType::from($this->battleReportModel->planet_type));
+        $coordinate = new Coordinate($battleReportModel->planet_galaxy, $battleReportModel->planet_system, $battleReportModel->planet_position);
+        $planet = $this->planetServiceFactory->makeForCoordinate($coordinate, true, PlanetType::from($battleReportModel->planet_type));
         if ($planet) {
             $subject = __('Combat report :planet', ['planet' => '[planet]' . $planet->getPlanetId() . '[/planet]']);
         } else {
@@ -112,7 +114,7 @@ class BattleReport extends GameMessage
     private function getBattleReportParams(): array
     {
         // Sanity check to make sure the battle report model is loaded.
-        $this->loadBattleReportModel();
+        $battleReportModel = $this->loadBattleReportModel();
 
         // TODO: add feature test for code below and check edgecases, such as when the planet has been deleted and
         // does not exist anymore. What should we show in that case?
@@ -120,22 +122,22 @@ class BattleReport extends GameMessage
         // Load planet by coordinate. Planet may be null if it was destroyed (e.g. after a
         // successful moon destruction). In that case we fall back to the coordinates and
         // player ID stored in the battle report model so the report remains readable.
-        $coordinate = new Coordinate($this->battleReportModel->planet_galaxy, $this->battleReportModel->planet_system, $this->battleReportModel->planet_position);
-        $planet = $this->planetServiceFactory->makeForCoordinate($coordinate, true, PlanetType::from($this->battleReportModel->planet_type));
+        $coordinate = new Coordinate($battleReportModel->planet_galaxy, $battleReportModel->planet_system, $battleReportModel->planet_position);
+        $planet = $this->planetServiceFactory->makeForCoordinate($coordinate, true, PlanetType::from($battleReportModel->planet_type));
 
         // Resolve defender planet display values, using stored data when planet no longer exists.
         $defenderPlanetName   = $planet?->getPlanetName()                      ?? $coordinate->asString();
         $defenderPlanetCoords = $planet?->getPlanetCoordinates()->asString()   ?? $coordinate->asString();
-        $defenderPlanetGalaxy = $planet?->getPlanetCoordinates()->galaxy       ?? $this->battleReportModel->planet_galaxy;
-        $defenderPlanetSystem = $planet?->getPlanetCoordinates()->system       ?? $this->battleReportModel->planet_system;
-        $defenderPlanetPos    = $planet?->getPlanetCoordinates()->position     ?? $this->battleReportModel->planet_position;
+        $defenderPlanetGalaxy = $planet?->getPlanetCoordinates()->galaxy       ?? $battleReportModel->planet_galaxy;
+        $defenderPlanetSystem = $planet?->getPlanetCoordinates()->system       ?? $battleReportModel->planet_system;
+        $defenderPlanetPos    = $planet?->getPlanetCoordinates()->position     ?? $battleReportModel->planet_position;
 
         // Handle defender
-        if ($this->battleReportModel->planet_user_id === null) {
+        if ($battleReportModel->planet_user_id === null) {
             $defender_name = __('Unknown');
             $defender = null;
         } else {
-            $defender = $this->playerServiceFactory->make($this->battleReportModel->planet_user_id);
+            $defender = $this->playerServiceFactory->make($battleReportModel->planet_user_id);
             $defender_name = $defender->getUsername(false);
         }
 
@@ -143,8 +145,8 @@ class BattleReport extends GameMessage
         // TODO: ACS Attack sends multiple attacking fleets (one per union member). The battle report
         // currently only renders a single attacker entry. Per-player ship counts, losses, and the
         // round-start fleet breakdown need to be extended to show all participating attackers.
-        $attackerPlayerId = $this->battleReportModel->attacker['player_id'];
-        $attackerPlanetId = $this->battleReportModel->attacker['planet_id'] ?? null;
+        $attackerPlayerId = $battleReportModel->attacker['player_id'] ?? 0;
+        $attackerPlanetId = $battleReportModel->attacker['planet_id'] ?? null;
 
         // NPC attacker - translate name based on player ID
         if ($attackerPlayerId < 0) {
@@ -170,7 +172,7 @@ class BattleReport extends GameMessage
         // For NPCs (planet_id is null), translate "Deep space" dynamically
         if ($attackerPlayerId < 0 && $attackerPlanetId === null) {
             $attacker_planet_name = __('Deep space');
-            $attacker_planet_coords = $this->battleReportModel->attacker['planet_coords'] ?? '';
+            $attacker_planet_coords = $battleReportModel->attacker['planet_coords'] ?? '';
             $attacker_planet_type = '';
         } elseif ($attackerPlanetId !== null) {
             // Try to load from database for real players
@@ -198,41 +200,41 @@ class BattleReport extends GameMessage
             $attacker_planet_type = '';
         }
 
-        $defender_weapons = $this->battleReportModel->defender['weapon_technology'] * 10;
-        $defender_shields = $this->battleReportModel->defender['shielding_technology'] * 10;
-        $defender_armor = $this->battleReportModel->defender['armor_technology'] * 10;
+        $defender_weapons = ($battleReportModel->defender['weapon_technology'] ?? 0) * 10;
+        $defender_shields = ($battleReportModel->defender['shielding_technology'] ?? 0) * 10;
+        $defender_armor = ($battleReportModel->defender['armor_technology'] ?? 0) * 10;
 
         // Extract params from the battle report model.
-        $attackerLosses = $this->battleReportModel->attacker['resource_loss'];
-        $defenderLosses = $this->battleReportModel->defender['resource_loss'];
+        $attackerLosses = $battleReportModel->attacker['resource_loss'] ?? 0;
+        $defenderLosses = $battleReportModel->defender['resource_loss'] ?? 0;
 
-        $lootPercentage = $this->battleReportModel->loot['percentage'];
-        $lootMetal = $this->battleReportModel->loot['metal'];
-        $lootCrystal = $this->battleReportModel->loot['crystal'];
-        $lootDeuterium = $this->battleReportModel->loot['deuterium'];
+        $lootPercentage = $battleReportModel->loot['percentage'] ?? 0;
+        $lootMetal = $battleReportModel->loot['metal'] ?? 0;
+        $lootCrystal = $battleReportModel->loot['crystal'] ?? 0;
+        $lootDeuterium = $battleReportModel->loot['deuterium'] ?? 0;
         $lootResources = new Resources($lootMetal, $lootCrystal, $lootDeuterium, 0);
 
-        $debrisMetal = $this->battleReportModel->debris['metal'] ?? 0;
-        $debrisCrystal = $this->battleReportModel->debris['crystal'] ?? 0;
-        $debrisDeuterium = $this->battleReportModel->debris['deuterium'] ?? 0;
+        $debrisMetal = $battleReportModel->debris['metal'] ?? 0;
+        $debrisCrystal = $battleReportModel->debris['crystal'] ?? 0;
+        $debrisDeuterium = $battleReportModel->debris['deuterium'] ?? 0;
         $debrisResources = new Resources($debrisMetal, $debrisCrystal, $debrisDeuterium, 0);
 
         // Extract collected debris (Reaper auto-collection)
-        $collectedDebrisMetal = $this->battleReportModel->debris['collected_metal'] ?? 0;
-        $collectedDebrisCrystal = $this->battleReportModel->debris['collected_crystal'] ?? 0;
-        $collectedDebrisDeuterium = $this->battleReportModel->debris['collected_deuterium'] ?? 0;
+        $collectedDebrisMetal = $battleReportModel->debris['collected_metal'] ?? 0;
+        $collectedDebrisCrystal = $battleReportModel->debris['collected_crystal'] ?? 0;
+        $collectedDebrisDeuterium = $battleReportModel->debris['collected_deuterium'] ?? 0;
         $collectedDebrisResources = new Resources($collectedDebrisMetal, $collectedDebrisCrystal, $collectedDebrisDeuterium, 0);
 
         // Extract attacker collected debris
-        $attackerCollectedMetal = $this->battleReportModel->debris['attacker_collected_metal'] ?? 0;
-        $attackerCollectedCrystal = $this->battleReportModel->debris['attacker_collected_crystal'] ?? 0;
-        $attackerCollectedDeuterium = $this->battleReportModel->debris['attacker_collected_deuterium'] ?? 0;
+        $attackerCollectedMetal = $battleReportModel->debris['attacker_collected_metal'] ?? 0;
+        $attackerCollectedCrystal = $battleReportModel->debris['attacker_collected_crystal'] ?? 0;
+        $attackerCollectedDeuterium = $battleReportModel->debris['attacker_collected_deuterium'] ?? 0;
         $attackerCollectedDebrisResources = new Resources($attackerCollectedMetal, $attackerCollectedCrystal, $attackerCollectedDeuterium, 0);
 
         // Extract defender collected debris
-        $defenderCollectedMetal = $this->battleReportModel->debris['defender_collected_metal'] ?? 0;
-        $defenderCollectedCrystal = $this->battleReportModel->debris['defender_collected_crystal'] ?? 0;
-        $defenderCollectedDeuterium = $this->battleReportModel->debris['defender_collected_deuterium'] ?? 0;
+        $defenderCollectedMetal = $battleReportModel->debris['defender_collected_metal'] ?? 0;
+        $defenderCollectedCrystal = $battleReportModel->debris['defender_collected_crystal'] ?? 0;
+        $defenderCollectedDeuterium = $battleReportModel->debris['defender_collected_deuterium'] ?? 0;
         $defenderCollectedDebrisResources = new Resources($defenderCollectedMetal, $defenderCollectedCrystal, $defenderCollectedDeuterium, 0);
 
         // Calculate remaining debris (debris created - collected by Reapers)
@@ -245,7 +247,7 @@ class BattleReport extends GameMessage
         // For expedition battles (when player classes are implemented with Discoverer class),
         // the debris field will be at position 16 and can only be collected by Pathfinders,
         // not Recyclers. Update this section to:
-        // 1. Check if this is an expedition battle (check $this->battleReportModel->general['expedition_battle'])
+        // 1. Check if this is an expedition battle (check $battleReportModel->general['expedition_battle'])
         // 2. If yes, calculate and display Pathfinders needed instead of Recyclers
         // 3. If no, continue showing Recyclers as normal
         //
@@ -268,8 +270,8 @@ class BattleReport extends GameMessage
 
         $wreckageCount = 0;
         $wreckageUnits = new UnitCollection();
-        if (!empty($this->battleReportModel->wreckage)) {
-            foreach ($this->battleReportModel->wreckage as $machine_name => $count) {
+        if (!empty($battleReportModel->wreckage)) {
+            foreach ($battleReportModel->wreckage as $machine_name => $count) {
                 $wreckageCount += $count;
                 if ($count > 0) {
                     $wreckageUnits->addUnit(ObjectService::getUnitObjectByMachineName($machine_name), $count);
@@ -279,8 +281,8 @@ class BattleReport extends GameMessage
 
         $repairedDefensesCount = 0;
         $repairedDefenses = new UnitCollection();
-        if (!empty($this->battleReportModel->repaired_defenses)) {
-            foreach ($this->battleReportModel->repaired_defenses as $defense_key => $defense_count) {
+        if (!empty($battleReportModel->repaired_defenses)) {
+            foreach ($battleReportModel->repaired_defenses as $defense_key => $defense_count) {
                 $repairedDefensesCount += $defense_count;
                 if ($defense_count > 0) {
                     $repairedDefenses->addUnit(ObjectService::getUnitObjectByMachineName($defense_key), $defense_count);
@@ -290,8 +292,8 @@ class BattleReport extends GameMessage
 
         $attackerWreckageCount = 0;
         $attackerWreckageUnits = new UnitCollection();
-        if (!empty($this->battleReportModel->general['attacker_wreckage'])) {
-            foreach ($this->battleReportModel->general['attacker_wreckage'] as $machine_name => $count) {
+        if (!empty($battleReportModel->general['attacker_wreckage'])) {
+            foreach ($battleReportModel->general['attacker_wreckage'] as $machine_name => $count) {
                 $attackerWreckageCount += $count;
                 if ($count > 0) {
                     $attackerWreckageUnits->addUnit(ObjectService::getUnitObjectByMachineName($machine_name), $count);
@@ -304,39 +306,39 @@ class BattleReport extends GameMessage
         $moonCreated = false;
         $hamillManoeuvreTriggered = false;
 
-        if (isset($this->battleReportModel->general['moon_existed'])) {
-            $moonExisted = $this->battleReportModel->general['moon_existed'];
+        if (isset($battleReportModel->general['moon_existed'])) {
+            $moonExisted = $battleReportModel->general['moon_existed'];
         }
-        if (isset($this->battleReportModel->general['moon_chance'])) {
-            $moonChance = $this->battleReportModel->general['moon_chance'];
+        if (isset($battleReportModel->general['moon_chance'])) {
+            $moonChance = $battleReportModel->general['moon_chance'];
         }
-        if (isset($this->battleReportModel->general['moon_created'])) {
-            $moonCreated = $this->battleReportModel->general['moon_created'];
+        if (isset($battleReportModel->general['moon_created'])) {
+            $moonCreated = $battleReportModel->general['moon_created'];
         }
-        if (isset($this->battleReportModel->general['hamill_manoeuvre_triggered'])) {
-            $hamillManoeuvreTriggered = $this->battleReportModel->general['hamill_manoeuvre_triggered'];
+        if (isset($battleReportModel->general['hamill_manoeuvre_triggered'])) {
+            $hamillManoeuvreTriggered = $battleReportModel->general['hamill_manoeuvre_triggered'];
         }
 
         // Load attacker player
         // TODO: add unit test for attacker/defender research levels.
-        $attacker_weapons = $this->battleReportModel->attacker['weapon_technology'] * 10;
-        $attacker_shields = $this->battleReportModel->attacker['shielding_technology'] * 10;
-        $attacker_armor = $this->battleReportModel->attacker['armor_technology'] * 10;
+        $attacker_weapons = ($battleReportModel->attacker['weapon_technology'] ?? 0) * 10;
+        $attacker_shields = ($battleReportModel->attacker['shielding_technology'] ?? 0) * 10;
+        $attacker_armor = ($battleReportModel->attacker['armor_technology'] ?? 0) * 10;
 
         $attacker_units = new UnitCollection();
-        foreach ($this->battleReportModel->attacker['units'] as $machine_name => $amount) {
+        foreach ($battleReportModel->attacker['units'] ?? [] as $machine_name => $amount) {
             $attacker_units->addUnit(ObjectService::getUnitObjectByMachineName($machine_name), $amount);
         }
 
         $defender_units = new UnitCollection();
-        foreach ($this->battleReportModel->defender['units'] as $machine_name => $amount) {
+        foreach ($battleReportModel->defender['units'] ?? [] as $machine_name => $amount) {
             $defender_units->addUnit(ObjectService::getUnitObjectByMachineName($machine_name), $amount);
         }
 
         // Load rounds and cast to battle result round object.
         $rounds = [];
-        if ($this->battleReportModel->rounds !== null) {
-            foreach ($this->battleReportModel->rounds as $round) {
+        if ($battleReportModel->rounds !== null) {
+            foreach ($battleReportModel->rounds as $round) {
                 $obj = new BattleResultRound();
                 $obj->fullStrengthAttacker = $round['full_strength_attacker'];
                 $obj->fullStrengthDefender = $round['full_strength_defender'];
@@ -399,7 +401,7 @@ class BattleReport extends GameMessage
 
         // Determine if the message recipient is the attacker or the defender.
         // This is used to show only the relevant wreckage section to each player.
-        $viewerIsAttacker = (int)$this->message->user_id === (int)$this->battleReportModel->attacker['player_id'];
+        $viewerIsAttacker = (int)$this->message->user_id === (int)($battleReportModel->attacker['player_id'] ?? 0);
 
         return [
             'subject' => $this->getSubject(),
@@ -413,8 +415,8 @@ class BattleReport extends GameMessage
             'defender_name' => $defender_name,
             'attacker_class' => ($winner === 'attacker') ? 'undermark' : (($winner === 'draw') ? 'middlemark' : 'overmark'),
             'defender_class' => ($winner === 'defender') ? 'undermark' : (($winner === 'draw') ? 'middlemark' : 'overmark'),
-            'attacker_character_class' => isset($this->battleReportModel->attacker['character_class']) ? $this->battleReportModel->attacker['character_class'] : null,
-            'defender_character_class' => isset($this->battleReportModel->defender['character_class']) ? $this->battleReportModel->defender['character_class'] : null,
+            'attacker_character_class' => isset($battleReportModel->attacker['character_class']) ? $battleReportModel->attacker['character_class'] : null,
+            'defender_character_class' => isset($battleReportModel->defender['character_class']) ? $battleReportModel->defender['character_class'] : null,
             'defender_planet_name' => $defenderPlanetName,
             'defender_planet_coords' => $defenderPlanetCoords,
             'defender_planet_link' => route('galaxy.index', ['galaxy' => $defenderPlanetGalaxy, 'system' => $defenderPlanetSystem, 'position' => $defenderPlanetPos]),

--- a/app/GameMessages/EspionageReport.php
+++ b/app/GameMessages/EspionageReport.php
@@ -25,15 +25,15 @@ class EspionageReport extends GameMessage
     }
 
     /**
-     * Load espionage report model from database. If already loaded, do nothing.
+     * Load espionage report model from database. If already loaded, return the cached model.
      *
-     * @return void
+     * @return \OGame\Models\EspionageReport
      */
-    private function loadEspionageReportModel(): void
+    private function loadEspionageReportModel(): \OGame\Models\EspionageReport
     {
         if ($this->espionageReportModel !== null) {
             // Already loaded.
-            return ;
+            return $this->espionageReportModel;
         }
 
         // Load espionage report model from database associated with the message.
@@ -44,6 +44,8 @@ class EspionageReport extends GameMessage
         } else {
             $this->espionageReportModel = $espionageReport;
         }
+
+        return $this->espionageReportModel;
     }
 
     /**
@@ -51,11 +53,11 @@ class EspionageReport extends GameMessage
      */
     public function getSubject(): string
     {
-        $this->loadEspionageReportModel();
+        $espionageReportModel = $this->loadEspionageReportModel();
 
         // Load the planet name from the references table and return the subject filled with the planet name.
-        $coordinate = new Coordinate($this->espionageReportModel->planet_galaxy, $this->espionageReportModel->planet_system, $this->espionageReportModel->planet_position);
-        $planet = $this->planetServiceFactory->makeForCoordinate($coordinate, true, PlanetType::from($this->espionageReportModel->planet_type));
+        $coordinate = new Coordinate($espionageReportModel->planet_galaxy, $espionageReportModel->planet_system, $espionageReportModel->planet_position);
+        $planet = $this->planetServiceFactory->makeForCoordinate($coordinate, true, PlanetType::from($espionageReportModel->planet_type));
         if ($planet) {
             $subject = __('Espionage report from :planet', ['planet' => '[planet]' . $planet->getPlanetId() . '[/planet]']);
         } else {
@@ -70,11 +72,11 @@ class EspionageReport extends GameMessage
      */
     public function getBody(): string
     {
-        $this->loadEspionageReportModel();
+        $espionageReportModel = $this->loadEspionageReportModel();
 
         // Load planet by coordinate.
-        $coordinate = new Coordinate($this->espionageReportModel->planet_galaxy, $this->espionageReportModel->planet_system, $this->espionageReportModel->planet_position);
-        $planet = $this->planetServiceFactory->makeForCoordinate($coordinate, true, PlanetType::from($this->espionageReportModel->planet_type));
+        $coordinate = new Coordinate($espionageReportModel->planet_galaxy, $espionageReportModel->planet_system, $espionageReportModel->planet_position);
+        $planet = $this->planetServiceFactory->makeForCoordinate($coordinate, true, PlanetType::from($espionageReportModel->planet_type));
 
         if ($planet === null) {
             return __('Planet has been deleted and espionage report is no longer available.');
@@ -89,11 +91,11 @@ class EspionageReport extends GameMessage
      */
     public function getBodyFull(): string
     {
-        $this->loadEspionageReportModel();
+        $espionageReportModel = $this->loadEspionageReportModel();
 
         // Load planet by coordinate.
-        $coordinate = new Coordinate($this->espionageReportModel->planet_galaxy, $this->espionageReportModel->planet_system, $this->espionageReportModel->planet_position);
-        $planet = $this->planetServiceFactory->makeForCoordinate($coordinate, true, PlanetType::from($this->espionageReportModel->planet_type));
+        $coordinate = new Coordinate($espionageReportModel->planet_galaxy, $espionageReportModel->planet_system, $espionageReportModel->planet_position);
+        $planet = $this->planetServiceFactory->makeForCoordinate($coordinate, true, PlanetType::from($espionageReportModel->planet_type));
 
         if ($planet === null) {
             return __('Planet has been deleted and espionage report is no longer available.');
@@ -124,38 +126,39 @@ class EspionageReport extends GameMessage
     private function getEspionageReportParams(): array
     {
         // Sanity check to make sure the espionage report model is loaded.
-        $this->loadEspionageReportModel();
+        $espionageReportModel = $this->loadEspionageReportModel();
 
         // TODO: add feature test for code below and check edgecases, such as when the planet has been deleted and
         // does not exist anymore. What should we show in that case?
 
         // Load planet by coordinate.
-        $coordinate = new Coordinate($this->espionageReportModel->planet_galaxy, $this->espionageReportModel->planet_system, $this->espionageReportModel->planet_position);
-        $planet = $this->planetServiceFactory->makeForCoordinate($coordinate, true, PlanetType::from($this->espionageReportModel->planet_type));
+        $coordinate = new Coordinate($espionageReportModel->planet_galaxy, $espionageReportModel->planet_system, $espionageReportModel->planet_position);
+        $planet = $this->planetServiceFactory->makeForCoordinate($coordinate, true, PlanetType::from($espionageReportModel->planet_type));
 
         // If planet owner is the same as the player, we load the player by planet owner which is already loaded.
-        if ($this->espionageReportModel->planet_user_id === $planet->getPlayer()->getId()) {
-            $player = $this->playerServiceFactory->make($planet->getPlayer()->getId());
+        $planetPlayer = $planet?->getPlayer();
+        if ($planetPlayer !== null && $espionageReportModel->planet_user_id === $planetPlayer->getId()) {
+            $player = $this->playerServiceFactory->make($planetPlayer->getId());
         } else {
             // It is theoretically possible that the original player has deleted their planet and another user has
             // colonized the same position of the original planet. In that case, we should load the player by user_id
             // from the espionage report.
-            $player = $this->playerServiceFactory->make($this->espionageReportModel->planet_user_id);
+            $player = $this->playerServiceFactory->make($espionageReportModel->planet_user_id);
         }
 
         // Extract resources
-        $resources = new Resources($this->espionageReportModel->resources['metal'], $this->espionageReportModel->resources['crystal'], $this->espionageReportModel->resources['deuterium'], $this->espionageReportModel->resources['energy']);
+        $resources = new Resources($espionageReportModel->resources['metal'] ?? 0, $espionageReportModel->resources['crystal'] ?? 0, $espionageReportModel->resources['deuterium'] ?? 0, $espionageReportModel->resources['energy'] ?? 0);
 
         // Extract debris if available.
         $debris = new Resources(0, 0, 0, 0);
-        if ($this->espionageReportModel->debris !== null) {
-            $debris = new Resources($this->espionageReportModel->debris['metal'], $this->espionageReportModel->debris['crystal'], $this->espionageReportModel->debris['deuterium'], 0);
+        if ($espionageReportModel->debris !== null) {
+            $debris = new Resources($espionageReportModel->debris['metal'] ?? 0, $espionageReportModel->debris['crystal'] ?? 0, $espionageReportModel->debris['deuterium'] ?? 0, 0);
         }
 
         // Extract ships
         $ships = [];
-        if ($this->espionageReportModel->ships !== null) {
-            foreach ($this->espionageReportModel->ships as $machine_name => $amount) {
+        if ($espionageReportModel->ships !== null) {
+            foreach ($espionageReportModel->ships as $machine_name => $amount) {
                 // Get object
                 $unit = ObjectService::getUnitObjectByMachineName($machine_name);
 
@@ -169,8 +172,8 @@ class EspionageReport extends GameMessage
 
         // Extract defense
         $defense = [];
-        if ($this->espionageReportModel->defense !== null) {
-            foreach ($this->espionageReportModel->defense as $machine_name => $amount) {
+        if ($espionageReportModel->defense !== null) {
+            foreach ($espionageReportModel->defense as $machine_name => $amount) {
                 // Get object
                 $unit = ObjectService::getUnitObjectByMachineName($machine_name);
 
@@ -184,8 +187,8 @@ class EspionageReport extends GameMessage
 
         // Extract buildings
         $buildings = [];
-        if ($this->espionageReportModel->buildings !== null) {
-            foreach ($this->espionageReportModel->buildings as $machine_name => $amount) {
+        if ($espionageReportModel->buildings !== null) {
+            foreach ($espionageReportModel->buildings as $machine_name => $amount) {
                 // Get object
                 $unit = ObjectService::getObjectByMachineName($machine_name);
 
@@ -199,8 +202,8 @@ class EspionageReport extends GameMessage
 
         // Extract research
         $research = [];
-        if ($this->espionageReportModel->research !== null) {
-            foreach ($this->espionageReportModel->research as $machine_name => $amount) {
+        if ($espionageReportModel->research !== null) {
+            foreach ($espionageReportModel->research as $machine_name => $amount) {
                 // Get object
                 $unit = ObjectService::getObjectByMachineName($machine_name);
 
@@ -223,11 +226,11 @@ class EspionageReport extends GameMessage
             'defense' => $defense,
             'buildings' => $buildings,
             'research' => $research,
-            'counter_espionage_chance' => $this->espionageReportModel->counter_espionage_chance ?? 0,
-            'galaxy' => $this->espionageReportModel->planet_galaxy,
-            'system' => $this->espionageReportModel->planet_system,
-            'position' => $this->espionageReportModel->planet_position,
-            'planet_type' => $this->espionageReportModel->planet_type,
+            'counter_espionage_chance' => $espionageReportModel->counter_espionage_chance ?? 0,
+            'galaxy' => $espionageReportModel->planet_galaxy,
+            'system' => $espionageReportModel->planet_system,
+            'position' => $espionageReportModel->planet_position,
+            'planet_type' => $espionageReportModel->planet_type,
         ];
     }
 }

--- a/app/GameMissions/Abstracts/GameMission.php
+++ b/app/GameMissions/Abstracts/GameMission.php
@@ -125,7 +125,11 @@ abstract class GameMission
     public function isMissionPossible(PlanetService $planet, Coordinate $targetCoordinate, PlanetType $targetType, UnitCollection $units): MissionPossibleStatus
     {
         // Cannot send missions while in vacation mode
-        if ($planet->getPlayer()->isInVacationMode()) {
+        $player = $planet->getPlayer();
+        if ($player === null) {
+            return new MissionPossibleStatus(false);
+        }
+        if ($player->isInVacationMode()) {
             return new MissionPossibleStatus(false, __('You cannot send missions while in vacation mode!'));
         }
 
@@ -223,7 +227,11 @@ abstract class GameMission
             throw new Exception('Not enough units on the planet to send the fleet. Units required: ' . $unitNames);
         }
 
-        if ($planet->getPlayer()->getFleetSlotsInUse() >= $planet->getPlayer()->getFleetSlotsMax()) {
+        $player = $planet->getPlayer();
+        if ($player === null) {
+            throw new Exception('Mission origin planet has no owner.');
+        }
+        if ($player->getFleetSlotsInUse() >= $player->getFleetSlotsMax()) {
             throw new Exception('Maximum number of fleets reached.');
         }
 
@@ -271,8 +279,12 @@ abstract class GameMission
 
         $this->startMissionSanityChecks($planet, $targetCoordinate, $targetType, $units, $deduct_resources);
 
-        $totalCargoCapacity = $units->getTotalCargoCapacity($planet->getPlayer());
-        $totalFuelCapacity = $units->getTotalFuelCapacity($planet->getPlayer());
+        $player = $planet->getPlayer();
+        if ($player === null) {
+            throw new Exception('Mission origin planet has no owner.');
+        }
+        $totalCargoCapacity = $units->getTotalCargoCapacity($player);
+        $totalFuelCapacity = $units->getTotalFuelCapacity($player);
 
         // Check if the player has sufficient deuterium storage capacity for the fleet.
         if ($totalFuelCapacity < $consumption) {
@@ -298,10 +310,13 @@ abstract class GameMission
         // mission linked to a previous mission.
         if (!empty($parentId)) {
             $parentMission = $this->fleetMissionService->getFleetMissionById($parentId);
+            if ($parentMission === null) {
+                throw new Exception('Parent mission not found.');
+            }
             $mission->parent_id = $parentMission->id;
         }
 
-        $mission->user_id = $planet->getPlayer()->getId();
+        $mission->user_id = $player->getId();
 
         $mission->type_from = $planet->getPlanetType()->value;
         $mission->planet_id_from = $planet->getPlanetId();
@@ -415,7 +430,7 @@ abstract class GameMission
      */
     protected function checkTargetVacationMode(PlanetService|null $targetPlanet): MissionPossibleStatus|null
     {
-        if ($targetPlanet !== null && $targetPlanet->getPlayer()->isInVacationMode()) {
+        if ($targetPlanet !== null && $targetPlanet->getPlayer()?->isInVacationMode()) {
             return new MissionPossibleStatus(false, __('This player is in vacation mode!'));
         }
         return null;
@@ -430,7 +445,7 @@ abstract class GameMission
      */
     protected function checkAdminProtection(PlanetService|null $targetPlanet, string $errorMessage): MissionPossibleStatus|null
     {
-        if ($targetPlanet !== null && $targetPlanet->getPlayer()->getUsername(false) === 'Legor') {
+        if ($targetPlanet !== null && $targetPlanet->getPlayer()?->getUsername(false) === 'Legor') {
             return new MissionPossibleStatus(false, $errorMessage);
         }
         return null;
@@ -445,7 +460,7 @@ abstract class GameMission
      */
     protected function checkOwnPlanet(PlanetService $planet, PlanetService|null $targetPlanet): MissionPossibleStatus|null
     {
-        if ($targetPlanet !== null && $planet->getPlayer()->equals($targetPlanet->getPlayer())) {
+        if ($targetPlanet !== null && $planet->getPlayer()?->equals($targetPlanet->getPlayer())) {
             return new MissionPossibleStatus(false);
         }
         return null;
@@ -514,6 +529,9 @@ abstract class GameMission
         if ($mission->type_from === PlanetType::Planet->value || $mission->type_from === PlanetType::Moon->value) {
             if ($parentMission->planet_id_to === null) {
                 // Attempt to load it from the target coordinates.
+                if ($parentMission->galaxy_to === null || $parentMission->system_to === null || $parentMission->position_to === null) {
+                    throw new Exception('Return mission parent has no target coordinate.');
+                }
                 $targetPlanet = $this->planetServiceFactory->makeForCoordinate(new Coordinate($parentMission->galaxy_to, $parentMission->system_to, $parentMission->position_to));
                 $mission->planet_id_from = $targetPlanet?->getPlanetId();
             } else {

--- a/app/GameMissions/AcsDefendMission.php
+++ b/app/GameMissions/AcsDefendMission.php
@@ -13,6 +13,7 @@ use OGame\Models\Planet\Coordinate;
 use OGame\Services\AllianceService;
 use OGame\Services\BuddyService;
 use OGame\Services\PlanetService;
+use RuntimeException;
 
 class AcsDefendMission extends GameMission
 {
@@ -60,8 +61,13 @@ class AcsDefendMission extends GameMission
         }
 
         // Check if players are buddies (accepted buddy request exists) or in the same alliance
-        $currentUserId = $planet->getPlayer()->getUser()->id;
-        $targetUserId = $targetPlanet->getPlayer()->getUser()->id;
+        $currentPlayer = $planet->getPlayer();
+        $targetPlayer = $targetPlanet->getPlayer();
+        if ($currentPlayer === null || $targetPlayer === null) {
+            return new MissionPossibleStatus(false);
+        }
+        $currentUserId = $currentPlayer->getUser()->id;
+        $targetUserId = $targetPlayer->getUser()->id;
 
         $buddyService = app(BuddyService::class);
         $isBuddy = $buddyService->areBuddies($currentUserId, $targetUserId);
@@ -103,7 +109,17 @@ class AcsDefendMission extends GameMission
     protected function processReturn(FleetMission $mission): void
     {
         // Load the destination planet (where ships are returning to)
+        if ($mission->planet_id_to === null) {
+            throw new RuntimeException('ACS Defend return mission has no target planet.');
+        }
         $destination_planet = $this->planetServiceFactory->make($mission->planet_id_to, true);
+        if ($destination_planet === null) {
+            throw new RuntimeException('ACS Defend return mission target planet does not exist.');
+        }
+        $targetPlayer = $destination_planet->getPlayer();
+        if ($targetPlayer === null) {
+            throw new RuntimeException('ACS Defend return mission target planet has no owner.');
+        }
 
         // Return units to the destination planet
         $destination_planet->addUnits($this->fleetMissionService->getFleetUnits($mission));
@@ -115,7 +131,7 @@ class AcsDefendMission extends GameMission
         }
 
         // Send message to player that the return mission has arrived.
-        $this->sendFleetReturnMessage($mission, $destination_planet->getPlayer());
+        $this->sendFleetReturnMessage($mission, $targetPlayer);
 
         // Mark the return mission as processed
         $mission->processed = 1;

--- a/app/GameMissions/AttackMission.php
+++ b/app/GameMissions/AttackMission.php
@@ -24,6 +24,7 @@ use OGame\Services\ObjectService;
 use OGame\Services\PlanetService;
 use OGame\Services\PlayerService;
 use OGame\Services\WreckFieldService;
+use RuntimeException;
 use Throwable;
 
 class AttackMission extends GameMission
@@ -88,7 +89,17 @@ class AttackMission extends GameMission
             return;
         }
 
+        if ($mission->planet_id_to === null) {
+            throw new RuntimeException('Attack mission has no target planet.');
+        }
         $defenderPlanet = $this->planetServiceFactory->make($mission->planet_id_to, true);
+        if ($defenderPlanet === null) {
+            throw new RuntimeException('Attack mission target planet does not exist.');
+        }
+        $defenderPlayer = $defenderPlanet->getPlayer();
+        if ($defenderPlayer === null) {
+            throw new RuntimeException('Attack mission target planet has no owner.');
+        }
 
         // Trigger defender planet update to make sure the battle uses up-to-date info.
         $defenderPlanet->update();
@@ -118,6 +129,9 @@ class AttackMission extends GameMission
         $battleResult = $battleEngine->simulateBattle();
 
         // Set the attacker's origin planet ID on the battle result for the battle report.
+        if ($mission->planet_id_from === null) {
+            throw new RuntimeException('Attack mission has no origin planet.');
+        }
         $battleResult->attackerPlanetId = $mission->planet_id_from;
 
         // Deduct loot from the target planet.
@@ -246,6 +260,9 @@ class AttackMission extends GameMission
                     // In original OGame, post-battle returns use each fleet's own natural speed,
                     // not the synced union speed. The origin planet provides correct tech levels
                     // for speed calculation, and distance is symmetric.
+                    if ($fleetMission->planet_id_from === null) {
+                        throw new RuntimeException('Attacking fleet mission has no origin planet.');
+                    }
                     $originPlanet = $this->planetServiceFactory->makeForPlayer(
                         $fleetOwner,
                         $fleetMission->planet_id_from
@@ -336,7 +353,7 @@ class AttackMission extends GameMission
         );
 
         // Defender Reaper collection (from remaining debris after attacker collection)
-        $defenderDebrisCollectionPercentage = $characterClassService->getReaperDebrisCollectionPercentage($defenderPlanet->getPlayer()->getUser());
+        $defenderDebrisCollectionPercentage = $characterClassService->getReaperDebrisCollectionPercentage($defenderPlayer->getUser());
         if ($defenderDebrisCollectionPercentage > 0 && $battleResult->defenderUnitsResult->getAmountByMachineName('reaper') > 0) {
             // Calculate 30% of the remaining debris
             $collectionAmount = new Resources(
@@ -349,7 +366,7 @@ class AttackMission extends GameMission
             // Calculate defender Reaper cargo capacity
             $reaperObject = ObjectService::getShipObjectByMachineName('reaper');
             $defenderReaperCount = $battleResult->defenderUnitsResult->getAmountByMachineName('reaper');
-            $defenderReaperCargoCapacity = $reaperObject->properties->capacity->calculate($defenderPlanet->getPlayer())->totalValue * $defenderReaperCount;
+            $defenderReaperCargoCapacity = $reaperObject->properties->capacity->calculate($defenderPlayer)->totalValue * $defenderReaperCount;
 
             // Limit collected debris to Reaper cargo capacity
             if ($collectionAmount->sum() <= $defenderReaperCargoCapacity) {
@@ -390,7 +407,7 @@ class AttackMission extends GameMission
         // IMPORTANT: If the battle is on a moon, the wreck field is created at the planet's coordinates
         // (not the moon's), and can only be interacted with from the planet.
         if (!empty($battleResult->wreckField) && $battleResult->wreckField['formed']) {
-            $wreckFieldService = new WreckFieldService($defenderPlanet->getPlayer(), $this->settings);
+            $wreckFieldService = new WreckFieldService($defenderPlayer, $this->settings);
 
             // Determine the coordinates for the wreck field
             // If battle is on a moon, use the planet's coordinates. If on a planet, use its own coordinates.
@@ -401,7 +418,7 @@ class AttackMission extends GameMission
             $wreckField = $wreckFieldService->createWreckField(
                 $wreckFieldCoordinates,
                 $battleResult->wreckField['ships'],
-                $defenderPlanet->getPlayer()->getId()
+                $defenderPlayer->getId()
             );
         }
 
@@ -432,14 +449,14 @@ class AttackMission extends GameMission
 
             // Send full battle report to defender
             $reportId = $this->createBattleReport($attackerPlayer, $defenderPlanet, $battleResult, $collectedDebris, $attackerCollectedDebris, $defenderCollectedDebris);
-            $this->messageService->sendBattleReportMessageToPlayer($defenderPlanet->getPlayer(), $reportId);
+            $this->messageService->sendBattleReportMessageToPlayer($defenderPlayer, $reportId);
         } else {
             // Normal behavior: send battle report to both attacker and defender
             $reportId = $this->createBattleReport($attackerPlayer, $defenderPlanet, $battleResult, $collectedDebris, $attackerCollectedDebris, $defenderCollectedDebris);
             // Send to attacker.
             $this->messageService->sendBattleReportMessageToPlayer($attackerPlayer, $reportId);
             // Send to defender.
-            $this->messageService->sendBattleReportMessageToPlayer($defenderPlanet->getPlayer(), $reportId);
+            $this->messageService->sendBattleReportMessageToPlayer($defenderPlayer, $reportId);
         }
 
         // Send Reaper auto-collection message to attacker if debris was collected
@@ -468,9 +485,9 @@ class AttackMission extends GameMission
         if ($defenderCollectedDebris->sum() > 0) {
             $reaperObject = ObjectService::getShipObjectByMachineName('reaper');
             $defenderReaperCount = $battleResult->defenderUnitsResult->getAmountByMachineName('reaper');
-            $defenderReaperCargoCapacity = $reaperObject->properties->capacity->calculate($defenderPlanet->getPlayer())->totalValue * $defenderReaperCount;
+            $defenderReaperCargoCapacity = $reaperObject->properties->capacity->calculate($defenderPlayer)->totalValue * $defenderReaperCount;
 
-            $this->messageService->sendSystemMessageToPlayer($defenderPlanet->getPlayer(), DebrisFieldHarvest::class, [
+            $this->messageService->sendSystemMessageToPlayer($defenderPlayer, DebrisFieldHarvest::class, [
                 'from' => '[planet]' . $defenderPlanet->getPlanetId() . '[/planet]',
                 'to' => '[debrisfield]' . $defenderPlanet->getPlanetCoordinates()->asString(). '[/debrisfield]',
                 'coordinates' => '[coordinates]' . $defenderPlanet->getPlanetCoordinates()->asString() . '[/coordinates]',
@@ -538,7 +555,17 @@ class AttackMission extends GameMission
     protected function processReturn(FleetMission $mission): void
     {
         // Load the target planet
+        if ($mission->planet_id_to === null) {
+            throw new RuntimeException('Attack return mission has no target planet.');
+        }
         $target_planet = $this->planetServiceFactory->make($mission->planet_id_to, true);
+        if ($target_planet === null) {
+            throw new RuntimeException('Attack return mission target planet does not exist.');
+        }
+        $targetPlayer = $target_planet->getPlayer();
+        if ($targetPlayer === null) {
+            throw new RuntimeException('Attack return mission target planet has no owner.');
+        }
 
         // Attack return trip: add back the units to the source planet. Then we're done.
         $target_planet->addUnits($this->fleetMissionService->getFleetUnits($mission));
@@ -552,7 +579,7 @@ class AttackMission extends GameMission
         // Create wreck field at origin planet if data exists (General class perk)
         // The wreck field is created from the attacker's lost ships and appears at the origin planet
         if (!empty($mission->wreck_field_data) && is_array($mission->wreck_field_data)) {
-            $wreckFieldService = new WreckFieldService($target_planet->getPlayer(), $this->settings);
+            $wreckFieldService = new WreckFieldService($targetPlayer, $this->settings);
 
             // Determine coordinates for wreck field
             // If returning to a moon, create wreck field at the planet's coordinates
@@ -564,12 +591,12 @@ class AttackMission extends GameMission
             $wreckFieldService->createWreckField(
                 $wreckFieldCoordinates,
                 $mission->wreck_field_data,
-                $target_planet->getPlayer()->getId()
+                $targetPlayer->getId()
             );
         }
 
         // Send message to player that the return mission has arrived.
-        $this->sendFleetReturnMessage($mission, $target_planet->getPlayer());
+        $this->sendFleetReturnMessage($mission, $targetPlayer);
 
         // Mark the return mission as processed
         $mission->processed = 1;
@@ -589,7 +616,11 @@ class AttackMission extends GameMission
     {
         $spaceDockPlanet = $originPlanet->isMoon() ? $originPlanet->planet() : $originPlanet;
         $spaceDockLevel = max(1, $spaceDockPlanet->getObjectLevel('space_dock'));
-        $wreckFieldService = new WreckFieldService($spaceDockPlanet->getPlayer(), $this->settings);
+        $spaceDockPlayer = $spaceDockPlanet->getPlayer();
+        if ($spaceDockPlayer === null) {
+            throw new RuntimeException('Space dock planet has no owner.');
+        }
+        $wreckFieldService = new WreckFieldService($spaceDockPlayer, $this->settings);
         $wreckFieldData = $wreckFieldService->calculateShipsForWreckField($attackerUnitsLost, $spaceDockLevel);
 
         // Check if wreck field conditions are met
@@ -629,6 +660,11 @@ class AttackMission extends GameMission
      */
     private function createBattleReport(PlayerService $attackPlayer, PlanetService $defenderPlanet, BattleResult $battleResult, Resources $collectedDebris, Resources $attackerCollectedDebris, Resources $defenderCollectedDebris): int
     {
+        $defenderPlayer = $defenderPlanet->getPlayer();
+        if ($defenderPlayer === null) {
+            throw new RuntimeException('Battle report defender planet has no owner.');
+        }
+
         // Create new battle report record.
         $report = new BattleReport();
         $report->planet_galaxy = $defenderPlanet->getPlanetCoordinates()->galaxy;
@@ -636,7 +672,7 @@ class AttackMission extends GameMission
         $report->planet_position = $defenderPlanet->getPlanetCoordinates()->position;
         $report->planet_type = $defenderPlanet->getPlanetType()->value;
 
-        $report->planet_user_id = $defenderPlanet->getPlayer()->getId();
+        $report->planet_user_id = $defenderPlayer->getId();
 
         $report->general = [
             'moon_existed' => $battleResult->moonExisted,
@@ -647,7 +683,7 @@ class AttackMission extends GameMission
 
         $characterClassService = app(CharacterClassService::class);
         $attackerCharacterClass = $characterClassService->getCharacterClass($attackPlayer->getUser());
-        $defenderCharacterClass = $characterClassService->getCharacterClass($defenderPlanet->getPlayer()->getUser());
+        $defenderCharacterClass = $characterClassService->getCharacterClass($defenderPlayer->getUser());
 
         $report->attacker = [
             'player_id' => $attackPlayer->getId(),
@@ -670,7 +706,7 @@ class AttackMission extends GameMission
         // - Per-fleet losses and survivors
         // Data available in: $battleResult->defenderFleetResults
         $report->defender = [
-            'player_id' => $defenderPlanet->getPlayer()->getId(),
+            'player_id' => $defenderPlayer->getId(),
             'resource_loss' => $battleResult->defenderResourceLoss->sum(),
             'units' => $battleResult->defenderUnitsStart->toArray(),
             'weapon_technology' => $battleResult->defenderWeaponLevel,

--- a/app/GameMissions/BattleEngine/BattleEngine.php
+++ b/app/GameMissions/BattleEngine/BattleEngine.php
@@ -20,6 +20,7 @@ use OGame\Services\PlanetService;
 use OGame\Services\PlayerService;
 use OGame\Services\SettingsService;
 use OGame\Services\WreckFieldService;
+use RuntimeException;
 
 /**
  * Abstract class BattleEngine.
@@ -105,14 +106,18 @@ abstract class BattleEngine
         $attackerShieldBase = $attackerPlayer->getResearchLevel('shielding_technology');
         $attackerArmorBase = $attackerPlayer->getResearchLevel('armor_technology');
 
-        $defenderWeaponBase = $this->defenderPlanet->getPlayer()->getResearchLevel('weapon_technology');
-        $defenderShieldBase = $this->defenderPlanet->getPlayer()->getResearchLevel('shielding_technology');
-        $defenderArmorBase = $this->defenderPlanet->getPlayer()->getResearchLevel('armor_technology');
+        $defenderPlayer = $this->defenderPlanet->getPlayer();
+        if ($defenderPlayer === null) {
+            throw new RuntimeException('Battle defender planet has no owner.');
+        }
+        $defenderWeaponBase = $defenderPlayer->getResearchLevel('weapon_technology');
+        $defenderShieldBase = $defenderPlayer->getResearchLevel('shielding_technology');
+        $defenderArmorBase = $defenderPlayer->getResearchLevel('armor_technology');
 
         // Apply General class combat research bonus (+2 levels)
         $characterClassService = app(CharacterClassService::class);
         $attackerCombatBonus = $characterClassService->getAdditionalCombatResearchLevels($attackerPlayer->getUser());
-        $defenderCombatBonus = $characterClassService->getAdditionalCombatResearchLevels($this->defenderPlanet->getPlayer()->getUser());
+        $defenderCombatBonus = $characterClassService->getAdditionalCombatResearchLevels($defenderPlayer->getUser());
 
         $result->attackerWeaponLevel = $attackerWeaponBase + $attackerCombatBonus;
         $result->attackerShieldLevel = $attackerShieldBase + $attackerCombatBonus;
@@ -601,7 +606,11 @@ abstract class BattleEngine
     {
         $spaceDockPlanet = $this->defenderPlanet->isMoon() ? $this->defenderPlanet->planet() : $this->defenderPlanet;
         $spaceDockLevel = max(1, $spaceDockPlanet->getObjectLevel('space_dock'));
-        $wreckFieldService = new WreckFieldService($spaceDockPlanet->getPlayer(), $this->settings);
+        $spaceDockPlayer = $spaceDockPlanet->getPlayer();
+        if ($spaceDockPlayer === null) {
+            throw new RuntimeException('Wreck field calculation planet has no owner.');
+        }
+        $wreckFieldService = new WreckFieldService($spaceDockPlayer, $this->settings);
         $wreckFieldPercentage = $wreckFieldService->getRecoverableWreckFieldPercentage($spaceDockLevel) / 100;
         $wreckFieldData = $wreckFieldService->calculateShipsForWreckField($defenderUnitsLost, $spaceDockLevel);
 

--- a/app/GameMissions/BattleEngine/Models/DefenderFleet.php
+++ b/app/GameMissions/BattleEngine/Models/DefenderFleet.php
@@ -9,6 +9,7 @@ use OGame\Services\FleetMissionService;
 use OGame\Services\ObjectService;
 use OGame\Services\PlanetService;
 use OGame\Services\PlayerService;
+use RuntimeException;
 
 /**
  * Represents a single defending fleet in a battle.
@@ -62,9 +63,13 @@ class DefenderFleet
         $defender->units->addCollection($planet->getShipUnits());
         $defender->units->addCollection(self::getDefenseUnitsForCombat($planet));
 
-        $defender->player = $planet->getPlayer();
+        $player = $planet->getPlayer();
+        if ($player === null) {
+            throw new RuntimeException('Defender planet has no owner.');
+        }
+        $defender->player = $player;
         $defender->fleetMissionId = 0; // 0 indicates stationary planet forces
-        $defender->ownerId = $planet->getPlayer()->getId();
+        $defender->ownerId = $player->getId();
         $defender->fleetMission = null;
 
         return $defender;

--- a/app/GameMissions/BattleEngine/RustBattleEngine.php
+++ b/app/GameMissions/BattleEngine/RustBattleEngine.php
@@ -12,6 +12,7 @@ use OGame\Services\CharacterClassService;
 use OGame\Services\ObjectService;
 use OGame\Services\PlanetService;
 use OGame\Services\SettingsService;
+use RuntimeException;
 use stdClass;
 
 /**
@@ -128,6 +129,10 @@ class RustBattleEngine extends BattleEngine
         }
 
         // Build defender fleets (planet owner + ACS defend fleets)
+        $defenderPlayer = $this->defenderPlanet->getPlayer();
+        if ($defenderPlayer === null) {
+            throw new RuntimeException('Battle defender planet has no owner.');
+        }
         $defenderFleets = [];
         foreach ($result->defenderFleetResults as $fleetResult) {
             $defenderUnits = new stdClass();
@@ -141,9 +146,9 @@ class RustBattleEngine extends BattleEngine
                 $defenderUnits->{$unit->unitObject->id} = (object)[
                     'unit_id' => $unit->unitObject->id,
                     'amount' => $unit->amount,
-                    'shield_points' => $unit->unitObject->properties->shield->calculate($this->defenderPlanet->getPlayer())->totalValue,
-                    'attack_power' => $unit->unitObject->properties->attack->calculate($this->defenderPlanet->getPlayer())->totalValue,
-                    'hull_plating' => floor($unit->unitObject->properties->structural_integrity->calculate($this->defenderPlanet->getPlayer())->totalValue / 10),
+                    'shield_points' => $unit->unitObject->properties->shield->calculate($defenderPlayer)->totalValue,
+                    'attack_power' => $unit->unitObject->properties->attack->calculate($defenderPlayer)->totalValue,
+                    'hull_plating' => floor($unit->unitObject->properties->structural_integrity->calculate($defenderPlayer)->totalValue / 10),
                     'rapidfire' => $rapidfire,
                 ];
             }

--- a/app/GameMissions/ColonisationMission.php
+++ b/app/GameMissions/ColonisationMission.php
@@ -17,6 +17,7 @@ use OGame\Models\Planet\Coordinate;
 use OGame\Models\Resources;
 use OGame\Services\ObjectService;
 use OGame\Services\PlanetService;
+use RuntimeException;
 
 class ColonisationMission extends GameMission
 {
@@ -54,6 +55,9 @@ class ColonisationMission extends GameMission
 
         // Check if the player's Astrophysics level is high enough for this position.
         $player = $planet->getPlayer();
+        if ($player === null) {
+            return new MissionPossibleStatus(false);
+        }
         if (!$player->canColonizePosition($targetCoordinate->position)) {
             return new MissionPossibleStatus(false, __('Your knowledge of astrophysics is not sufficient to colonize this planet position.'));
         }
@@ -74,6 +78,9 @@ class ColonisationMission extends GameMission
     protected function processArrival(FleetMission $mission): void
     {
         // Sanity check: make sure the target coordinates are valid and the planet is (still) empty.
+        if ($mission->galaxy_to === null || $mission->system_to === null || $mission->position_to === null) {
+            throw new RuntimeException('Colonisation mission has no target coordinate.');
+        }
         $target_coordinates = new Coordinate($mission->galaxy_to, $mission->system_to, $mission->position_to);
         $target_planet = $this->planetServiceFactory->makeForCoordinate($target_coordinates);
 
@@ -107,7 +114,7 @@ class ColonisationMission extends GameMission
         }
 
         // Create a new planet at the target coordinates.
-        $target_planet = $this->planetServiceFactory->createAdditionalPlanetForPlayer($player, new Coordinate($mission->galaxy_to, $mission->system_to, $mission->position_to));
+        $target_planet = $this->planetServiceFactory->createAdditionalPlanetForPlayer($player, $target_coordinates);
 
         // Send success message
         $this->messageService->sendSystemMessageToPlayer($player, ColonyEstablished::class, [
@@ -138,7 +145,17 @@ class ColonisationMission extends GameMission
      */
     protected function processReturn(FleetMission $mission): void
     {
+        if ($mission->planet_id_to === null) {
+            throw new RuntimeException('Colonisation return mission has no target planet.');
+        }
         $target_planet = $this->planetServiceFactory->make($mission->planet_id_to, true);
+        if ($target_planet === null) {
+            throw new RuntimeException('Colonisation return mission target planet does not exist.');
+        }
+        $targetPlayer = $target_planet->getPlayer();
+        if ($targetPlayer === null) {
+            throw new RuntimeException('Colonisation return mission target planet has no owner.');
+        }
 
         // Transport return trip: add back the units to the source planet. Then we're done.
         $target_planet->addUnits($this->fleetMissionService->getFleetUnits($mission));
@@ -150,7 +167,7 @@ class ColonisationMission extends GameMission
         }
 
         // Send message to player that the return mission has arrived.
-        $this->sendFleetReturnMessage($mission, $target_planet->getPlayer());
+        $this->sendFleetReturnMessage($mission, $targetPlayer);
 
         // Mark the return mission as processed
         $mission->processed = 1;

--- a/app/GameMissions/DeploymentMission.php
+++ b/app/GameMissions/DeploymentMission.php
@@ -13,6 +13,7 @@ use OGame\Models\Enums\PlanetType;
 use OGame\Models\FleetMission;
 use OGame\Models\Planet\Coordinate;
 use OGame\Services\PlanetService;
+use RuntimeException;
 
 class DeploymentMission extends GameMission
 {
@@ -44,7 +45,12 @@ class DeploymentMission extends GameMission
         }
 
         // If target player is not the same as current player, this mission is not possible.
-        if (!$planet->getPlayer()->equals($targetPlanet->getPlayer())) {
+        $currentPlayer = $planet->getPlayer();
+        $targetPlayer = $targetPlanet->getPlayer();
+        if ($currentPlayer === null || $targetPlayer === null) {
+            return new MissionPossibleStatus(false);
+        }
+        if (!$currentPlayer->equals($targetPlayer)) {
             return new MissionPossibleStatus(false);
         }
 
@@ -57,7 +63,17 @@ class DeploymentMission extends GameMission
      */
     protected function processArrival(FleetMission $mission): void
     {
+        if ($mission->planet_id_to === null) {
+            throw new RuntimeException('Deployment mission has no target planet.');
+        }
         $target_planet = $this->planetServiceFactory->make($mission->planet_id_to, true);
+        if ($target_planet === null) {
+            throw new RuntimeException('Deployment mission target planet does not exist.');
+        }
+        $targetPlayer = $target_planet->getPlayer();
+        if ($targetPlayer === null) {
+            throw new RuntimeException('Deployment mission target planet has no owner.');
+        }
         // Add resources to the target planet
         $resources = $this->fleetMissionService->getResources($mission);
 
@@ -68,7 +84,7 @@ class DeploymentMission extends GameMission
 
         // Send a message to the player that the mission has arrived
         if ($resources->any()) {
-            $this->messageService->sendSystemMessageToPlayer($target_planet->getPlayer(), FleetDeploymentWithResources::class, [
+            $this->messageService->sendSystemMessageToPlayer($targetPlayer, FleetDeploymentWithResources::class, [
                 'from' => '[planet]' . $mission->planet_id_from . '[/planet]',
                 'to' => '[planet]' . $mission->planet_id_to . '[/planet]',
                 'metal' => (string)$mission->metal,
@@ -76,7 +92,7 @@ class DeploymentMission extends GameMission
                 'deuterium' => (string)($mission->deuterium +  ($mission->deuterium_consumption / 2)), //if mission deployment: Add half of the consumed deuterium
             ]);
         } else {
-            $this->messageService->sendSystemMessageToPlayer($target_planet->getPlayer(), FleetDeployment::class, [
+            $this->messageService->sendSystemMessageToPlayer($targetPlayer, FleetDeployment::class, [
                 'from' => '[planet]' . $mission->planet_id_from . '[/planet]',
                 'to' => '[planet]' . $mission->planet_id_to . '[/planet]',
             ]);
@@ -92,7 +108,17 @@ class DeploymentMission extends GameMission
      */
     protected function processReturn(FleetMission $mission): void
     {
+        if ($mission->planet_id_to === null) {
+            throw new RuntimeException('Deployment return mission has no target planet.');
+        }
         $target_planet = $this->planetServiceFactory->make($mission->planet_id_to, true);
+        if ($target_planet === null) {
+            throw new RuntimeException('Deployment return mission target planet does not exist.');
+        }
+        $targetPlayer = $target_planet->getPlayer();
+        if ($targetPlayer === null) {
+            throw new RuntimeException('Deployment return mission target planet has no owner.');
+        }
 
         // Transport return trip: add back the units to the source planet. Then we're done.
         $target_planet->addUnits($this->fleetMissionService->getFleetUnits($mission));
@@ -104,7 +130,7 @@ class DeploymentMission extends GameMission
         }
 
         // Send message to player that the return mission has arrived.
-        $this->sendFleetReturnMessage($mission, $target_planet->getPlayer());
+        $this->sendFleetReturnMessage($mission, $targetPlayer);
 
         // Mark the return mission as processed
         $mission->processed = 1;

--- a/app/GameMissions/EspionageMission.php
+++ b/app/GameMissions/EspionageMission.php
@@ -24,6 +24,7 @@ use OGame\Services\CounterEspionageService;
 use OGame\Services\DebrisFieldService;
 use OGame\Services\PlanetService;
 use OGame\Services\PlayerService;
+use RuntimeException;
 use Throwable;
 
 class EspionageMission extends GameMission
@@ -86,8 +87,19 @@ class EspionageMission extends GameMission
      */
     protected function processArrival(FleetMission $mission): void
     {
+        if ($mission->planet_id_to === null || $mission->planet_id_from === null) {
+            throw new RuntimeException('Espionage mission is missing origin or target planet.');
+        }
         $target_planet = $this->planetServiceFactory->make($mission->planet_id_to, true);
         $origin_planet = $this->planetServiceFactory->make($mission->planet_id_from, true);
+        if ($target_planet === null || $origin_planet === null) {
+            throw new RuntimeException('Espionage mission origin or target planet does not exist.');
+        }
+        $originPlayer = $origin_planet->getPlayer();
+        $targetPlayer = $target_planet->getPlayer();
+        if ($originPlayer === null || $targetPlayer === null) {
+            throw new RuntimeException('Espionage mission origin or target planet has no owner.');
+        }
 
         // Trigger target planet update to make sure the espionage report is accurate.
         $target_planet->update();
@@ -95,8 +107,8 @@ class EspionageMission extends GameMission
         // Calculate counter-espionage chance
         $counterEspionageService = resolve(CounterEspionageService::class);
         $attackerProbeCount = $mission->espionage_probe;
-        $attackerEspionageLevel = $origin_planet->getPlayer()->getResearchLevel('espionage_technology');
-        $defenderEspionageLevel = $target_planet->getPlayer()->getResearchLevel('espionage_technology');
+        $attackerEspionageLevel = $originPlayer->getResearchLevel('espionage_technology');
+        $defenderEspionageLevel = $targetPlayer->getResearchLevel('espionage_technology');
 
         // TODO: Include ACS Defend fleets in counter-espionage chance calculation
         // Currently only counts planet owner's ships via getDefenderShipCount()
@@ -142,8 +154,8 @@ class EspionageMission extends GameMission
             $debrisFieldService->save();
 
             // Create battle report for defender
-            $battleReportId = $this->createCounterEspionageBattleReport($origin_planet->getPlayer(), $target_planet, $battleResult);
-            $this->messageService->sendBattleReportMessageToPlayer($target_planet->getPlayer(), $battleReportId);
+            $battleReportId = $this->createCounterEspionageBattleReport($originPlayer, $target_planet, $battleResult);
+            $this->messageService->sendBattleReportMessageToPlayer($targetPlayer, $battleReportId);
 
             // Update surviving units based on battle result
             $survivingUnits = $battleResult->attackerUnitsResult;
@@ -151,7 +163,7 @@ class EspionageMission extends GameMission
             // If all probes destroyed, send "fleet lost contact" message to attacker
             if ($survivingUnits->getAmount() === 0) {
                 $this->messageService->sendFleetLostContactMessageToPlayer(
-                    $origin_planet->getPlayer(),
+                    $originPlayer,
                     '[' . $target_planet->getPlanetCoordinates()->asString() . ']'
                 );
             }
@@ -162,11 +174,11 @@ class EspionageMission extends GameMission
 
         // --- Defender notification (mirror official OGame "you were spied" message)
         // Defender is the owner of the target planet
-        $defenderUserId = $target_planet->getPlayer()->getId();
+        $defenderUserId = $targetPlayer->getId();
 
         if ($defenderUserId) {
             // Params expected by t_messages.espionage_detected.*
-            $attackerName = $origin_planet->getPlayer()->getUsername();
+            $attackerName = $originPlayer->getUsername();
 
             $params = [
                 // IMPORTANT: pass the raw mission planet id inside [planet]...[/planet]
@@ -188,7 +200,7 @@ class EspionageMission extends GameMission
 
         // Send a message to the player with a reference to the espionage report.
         $this->messageService->sendEspionageReportMessageToPlayer(
-            $origin_planet->getPlayer(),
+            $originPlayer,
             $reportId,
         );
 
@@ -225,6 +237,9 @@ class EspionageMission extends GameMission
         int $ownerId
     ): BattleResult {
         $attackerPlayer = $originPlanet->getPlayer();
+        if ($attackerPlayer === null) {
+            throw new RuntimeException('Counter-espionage origin planet has no owner.');
+        }
 
         // Get only ships for counter-espionage battle (no defense)
         $defenderShips = $counterEspionageService->getDefenderShipsForBattle($targetPlanet);
@@ -313,13 +328,18 @@ class EspionageMission extends GameMission
         PlanetService $defenderPlanet,
         BattleResult $battleResult
     ): int {
+        $defenderPlayer = $defenderPlanet->getPlayer();
+        if ($defenderPlayer === null) {
+            throw new RuntimeException('Counter-espionage defender planet has no owner.');
+        }
+
         $report = new BattleReport();
         $report->planet_galaxy = $defenderPlanet->getPlanetCoordinates()->galaxy;
         $report->planet_system = $defenderPlanet->getPlanetCoordinates()->system;
         $report->planet_position = $defenderPlanet->getPlanetCoordinates()->position;
         $report->planet_type = $defenderPlanet->getPlanetType()->value;
 
-        $report->planet_user_id = $defenderPlanet->getPlayer()->getId();
+        $report->planet_user_id = $defenderPlayer->getId();
 
         $report->general = [
             'moon_existed' => $battleResult->moonExisted,
@@ -338,7 +358,7 @@ class EspionageMission extends GameMission
         ];
 
         $report->defender = [
-            'player_id' => $defenderPlanet->getPlayer()->getId(),
+            'player_id' => $defenderPlayer->getId(),
             'resource_loss' => $battleResult->defenderResourceLoss->sum(),
             'units' => $battleResult->defenderUnitsStart->toArray(),
             'weapon_technology' => $battleResult->defenderWeaponLevel,
@@ -391,7 +411,13 @@ class EspionageMission extends GameMission
     protected function processReturn(FleetMission $mission): void
     {
         // Load the target planet
+        if ($mission->planet_id_to === null) {
+            throw new RuntimeException('Espionage return mission has no target planet.');
+        }
         $target_planet = $this->planetServiceFactory->make($mission->planet_id_to, true);
+        if ($target_planet === null) {
+            throw new RuntimeException('Espionage return mission target planet does not exist.');
+        }
 
         // Espionage return trip: add back the units to the source planet. Then we're done.
         $target_planet->addUnits($this->fleetMissionService->getFleetUnits($mission));
@@ -420,6 +446,12 @@ class EspionageMission extends GameMission
      */
     private function createEspionageReport(FleetMission $mission, PlanetService $originPlanet, PlanetService $targetPlanet, int $counterEspionageChance = 0): int
     {
+        $originPlayer = $originPlanet->getPlayer();
+        $targetPlayer = $targetPlanet->getPlayer();
+        if ($originPlayer === null || $targetPlayer === null) {
+            throw new RuntimeException('Espionage report origin or target planet has no owner.');
+        }
+
         // Create new espionage report record.
         $report = new EspionageReport();
         $report->planet_galaxy = $targetPlanet->getPlanetCoordinates()->galaxy;
@@ -427,11 +459,11 @@ class EspionageMission extends GameMission
         $report->planet_position = $targetPlanet->getPlanetCoordinates()->position;
         $report->planet_type = $targetPlanet->getPlanetType()->value;
 
-        $report->planet_user_id = $targetPlanet->getPlayer()->getId();
+        $report->planet_user_id = $targetPlayer->getId();
 
         $report->player_info = [
-            'player_id' => (string)$targetPlanet->getPlayer()->getId(),
-            'player_name' => $targetPlanet->getPlayer()->getUsername(),
+            'player_id' => (string)$targetPlayer->getId(),
+            'player_name' => $targetPlayer->getUsername(),
         ];
 
         // Resources
@@ -455,8 +487,8 @@ class EspionageMission extends GameMission
         }
 
         // TODO: Validate this does not cause issues when probing slot 16
-        $attackerEspionageLevel = $originPlanet->getPlayer()->getResearchLevel('espionage_technology');
-        $defenderEspionageLevel = $targetPlanet->getPlayer()->getResearchLevel('espionage_technology');
+        $attackerEspionageLevel = $originPlayer->getResearchLevel('espionage_technology');
+        $defenderEspionageLevel = $targetPlayer->getResearchLevel('espionage_technology');
         $techDifference = $defenderEspionageLevel - $attackerEspionageLevel;
         $levelDifference = max(0, $techDifference);
         $extraProbesRequired = pow($levelDifference, 2);
@@ -484,7 +516,7 @@ class EspionageMission extends GameMission
 
         // Research
         if ($this->canRevealData($remainingProbes, $attackerEspionageLevel, $defenderEspionageLevel, 7, 4)) {
-            $report->research = $targetPlanet->getPlayer()->getResearchArray();
+            $report->research = $targetPlayer->getResearchArray();
         }
 
         // Store counter-espionage chance

--- a/app/GameMissions/ExpeditionMission.php
+++ b/app/GameMissions/ExpeditionMission.php
@@ -46,6 +46,7 @@ use OGame\Services\ObjectService;
 use OGame\Services\PlanetService;
 use OGame\Services\PlayerService;
 use OGame\Services\SettingsService;
+use RuntimeException;
 
 class ExpeditionMission extends GameMission
 {
@@ -99,7 +100,11 @@ class ExpeditionMission extends GameMission
     {
         parent::startMissionSanityChecks($planet, $targetCoordinate, $targetType, $units, $resources);
         // Check if there are enough expedition slots available.
-        if ($planet->getPlayer()->getExpeditionSlotsInUse() >= $planet->getPlayer()->getExpeditionSlotsMax()) {
+        $player = $planet->getPlayer();
+        if ($player === null) {
+            throw new Exception('Expedition mission origin planet has no owner.');
+        }
+        if ($player->getExpeditionSlotsInUse() >= $player->getExpeditionSlotsMax()) {
             throw new Exception('You are conducting too many expeditions at the same time.');
         }
 
@@ -129,7 +134,11 @@ class ExpeditionMission extends GameMission
         }
 
         // Only possible if player has astrophysics research level 1 or higher.
-        if ($planet->getPlayer()->getResearchLevel('astrophysics') <= 0) {
+        $player = $planet->getPlayer();
+        if ($player === null) {
+            return new MissionPossibleStatus(false);
+        }
+        if ($player->getResearchLevel('astrophysics') <= 0) {
             return new MissionPossibleStatus(false, __('Fleets cannot be sent to this target. You have to research Astrophysics first.'));
         }
 
@@ -218,7 +227,17 @@ class ExpeditionMission extends GameMission
      */
     protected function processReturn(FleetMission $mission): void
     {
+        if ($mission->planet_id_to === null) {
+            throw new RuntimeException('Expedition return mission has no target planet.');
+        }
         $target_planet = $this->planetServiceFactory->make($mission->planet_id_to, true);
+        if ($target_planet === null) {
+            throw new RuntimeException('Expedition return mission target planet does not exist.');
+        }
+        $targetPlayer = $target_planet->getPlayer();
+        if ($targetPlayer === null) {
+            throw new RuntimeException('Expedition return mission target planet has no owner.');
+        }
 
         // Expedition mission: add back the units to the source planet.
         $target_planet->addUnits($this->fleetMissionService->getFleetUnits($mission));
@@ -230,7 +249,7 @@ class ExpeditionMission extends GameMission
         }
 
         // Send message to player that the return mission has arrived.
-        $this->sendFleetReturnMessage($mission, $target_planet->getPlayer());
+        $this->sendFleetReturnMessage($mission, $targetPlayer);
 
         // Mark the return mission as processed
         $mission->processed = 1;
@@ -693,7 +712,13 @@ class ExpeditionMission extends GameMission
         $npcPlayer = $npcData['player'];
 
         // Get origin planet for battle context
+        if ($mission->planet_id_from === null) {
+            throw new RuntimeException('Expedition mission has no origin planet.');
+        }
         $originPlanet = $this->planetServiceFactory->make($mission->planet_id_from, true);
+        if ($originPlanet === null) {
+            throw new RuntimeException('Expedition mission origin planet does not exist.');
+        }
 
         // Create NPC planet service for the battle
         $npcPlanetService = new NPCPlanetService(
@@ -733,6 +758,9 @@ class ExpeditionMission extends GameMission
 
         // Create debris field for expedition battles at position 16 (deep space)
         // Expedition battles create debris fields that can only be collected by Pathfinders (Discoverer class)
+        if ($mission->galaxy_to === null || $mission->system_to === null) {
+            throw new RuntimeException('Expedition mission has no target coordinate.');
+        }
         $expeditionCoords = new Coordinate($mission->galaxy_to, $mission->system_to, 16);
         $debrisFieldService = resolve(DebrisFieldService::class);
         $debrisFieldService->loadOrCreateForCoordinates($expeditionCoords);
@@ -980,7 +1008,8 @@ class ExpeditionMission extends GameMission
         // < 75.000.000 points: 3.600.000 metal
         // < 100.000.000 points: 4.200.000 metal
         // > 100.000.000 points: 5.000.000 metal
-        $rank_1_highscore_points = Highscore::orderByDesc(HighscoreTypeEnum::general->name)->first()->general;
+        $rank_1_highscore = Highscore::orderByDesc(HighscoreTypeEnum::general->name)->first();
+        $rank_1_highscore_points = $rank_1_highscore === null ? 0 : $rank_1_highscore->general;
 
         if ($rank_1_highscore_points < 10000) {
             $max = 40000;

--- a/app/GameMissions/MissileMission.php
+++ b/app/GameMissions/MissileMission.php
@@ -18,6 +18,7 @@ use OGame\Services\MessageService;
 use OGame\Services\ObjectService;
 use OGame\Services\PlanetService;
 use OGame\Services\PlayerService;
+use RuntimeException;
 
 /**
  * Interplanetary Ballistic Missile (IBM/IPM) Attack Mission
@@ -70,6 +71,9 @@ class MissileMission extends GameMission
 
         // Check if target is within missile range
         $attackerPlayer = $planet->getPlayer();
+        if ($attackerPlayer === null) {
+            return new MissionPossibleStatus(false);
+        }
         $missileRange = $attackerPlayer->getMissileRange();
 
         // Calculate distance in systems
@@ -117,6 +121,17 @@ class MissileMission extends GameMission
     protected function processArrival(FleetMission $mission): void
     {
         try {
+            if ($mission->planet_id_to === null || $mission->planet_id_from === null) {
+                Log::error('Missile mission: Invalid planet IDs', [
+                    'mission_id' => $mission->id,
+                    'planet_id_from' => $mission->planet_id_from,
+                    'planet_id_to' => $mission->planet_id_to,
+                ]);
+                $mission->processed = 1;
+                $mission->save();
+                return;
+            }
+
             $defenderTarget = $this->planetServiceFactory->make($mission->planet_id_to, true);
             $attackerPlanet = $this->planetServiceFactory->make($mission->planet_id_from, true);
 
@@ -137,6 +152,10 @@ class MissileMission extends GameMission
             // Get players for technology levels
             $attackerPlayer = $attackerPlanet->getPlayer();
             $defenderPlayer = $defenderTarget->getPlayer();
+
+            if ($attackerPlayer === null || $defenderPlayer === null) {
+                throw new RuntimeException('Missile mission attacker or defender planet has no owner.');
+            }
 
             // Get number of missiles sent (now stored in dedicated column!)
             $missileCount = (int)$mission->interplanetary_missile;

--- a/app/GameMissions/MoonDestructionMission.php
+++ b/app/GameMissions/MoonDestructionMission.php
@@ -26,6 +26,7 @@ use OGame\Models\Resources;
 use OGame\Services\DebrisFieldService;
 use OGame\Services\PlanetService;
 use OGame\Services\PlayerService;
+use RuntimeException;
 
 class MoonDestructionMission extends GameMission
 {
@@ -98,6 +99,11 @@ class MoonDestructionMission extends GameMission
     protected function processArrival(FleetMission $mission): void
     {
         // Check if target moon still exists
+        if ($mission->planet_id_to === null) {
+            // Moon doesn't exist - redirect to planet or cancel
+            $this->handleMissingMoon($mission);
+            return;
+        }
         $targetMoon = $this->planetServiceFactory->make($mission->planet_id_to, true);
         if ($targetMoon === null || !$targetMoon->isMoon()) {
             // Moon doesn't exist - redirect to planet or cancel
@@ -105,12 +111,25 @@ class MoonDestructionMission extends GameMission
             return;
         }
 
+        if ($mission->planet_id_from === null) {
+            throw new RuntimeException('Moon Destruction mission has no origin planet.');
+        }
         $originPlanet = $this->planetServiceFactory->make($mission->planet_id_from, true);
+        if ($originPlanet === null) {
+            throw new RuntimeException('Moon Destruction mission origin planet does not exist.');
+        }
 
         // Trigger defender moon update to make sure the battle uses up-to-date info
         $targetMoon->update();
 
         $attackerPlayer = $originPlanet->getPlayer();
+        if ($attackerPlayer === null) {
+            throw new RuntimeException('Moon Destruction mission origin planet has no owner.');
+        }
+        $targetMoonPlayer = $targetMoon->getPlayer();
+        if ($targetMoonPlayer === null) {
+            throw new RuntimeException('Moon Destruction mission target moon has no owner.');
+        }
         $attackerUnits = $this->fleetMissionService->getFleetUnits($mission);
 
         // Create AttackerFleet for the mission
@@ -183,7 +202,7 @@ class MoonDestructionMission extends GameMission
         if (!$this->didAttackerWinBattle($battleResult)) {
             // Attacker did not win - send battle report and end mission
             $this->messageService->sendBattleReportMessageToPlayer($attackerPlayer, $reportId);
-            $this->messageService->sendBattleReportMessageToPlayer($targetMoon->getPlayer(), $reportId);
+            $this->messageService->sendBattleReportMessageToPlayer($targetMoonPlayer, $reportId);
 
             // Mark mission as processed; a return mission is created below if ships survived.
             $mission->processed = 1;
@@ -199,7 +218,7 @@ class MoonDestructionMission extends GameMission
 
         // Attacker won - send battle reports
         $this->messageService->sendBattleReportMessageToPlayer($attackerPlayer, $reportId);
-        $this->messageService->sendBattleReportMessageToPlayer($targetMoon->getPlayer(), $reportId);
+        $this->messageService->sendBattleReportMessageToPlayer($targetMoonPlayer, $reportId);
 
         // Proceed to destruction attempt
         $this->executeDestructionAttempt($mission, $targetMoon, $battleResult->attackerUnitsResult);
@@ -280,6 +299,9 @@ class MoonDestructionMission extends GameMission
     {
         $attackerPlayer = $this->playerServiceFactory->make($mission->user_id, true);
         $defenderPlayer = $targetMoon->getPlayer();
+        if ($defenderPlayer === null) {
+            throw new RuntimeException('Moon Destruction target moon has no owner.');
+        }
         $moonName = $targetMoon->getPlanetName();
         $moonCoords = $targetMoon->getPlanetCoordinates()->asString();
 
@@ -348,6 +370,9 @@ class MoonDestructionMission extends GameMission
     {
         $attackerPlayer = $this->playerServiceFactory->make($mission->user_id, true);
         $defenderPlayer = $targetMoon->getPlayer();
+        if ($defenderPlayer === null) {
+            throw new RuntimeException('Moon Destruction target moon has no owner.');
+        }
         $moonName = $targetMoon->getPlanetName();
         $moonCoords = $targetMoon->getPlanetCoordinates()->asString();
 
@@ -377,6 +402,9 @@ class MoonDestructionMission extends GameMission
     {
         $attackerPlayer = $this->playerServiceFactory->make($mission->user_id, true);
         $defenderPlayer = $targetMoon->getPlayer();
+        if ($defenderPlayer === null) {
+            throw new RuntimeException('Moon Destruction target moon has no owner.');
+        }
         $moonName = $targetMoon->getPlanetName();
         $moonCoords = $targetMoon->getPlanetCoordinates()->asString();
 
@@ -399,12 +427,17 @@ class MoonDestructionMission extends GameMission
 
     private function createBattleReport(PlayerService $attackPlayer, PlanetService $defenderMoon, BattleResult $battleResult): int
     {
+        $defenderPlayer = $defenderMoon->getPlayer();
+        if ($defenderPlayer === null) {
+            throw new RuntimeException('Moon Destruction battle report defender moon has no owner.');
+        }
+
         $report = new BattleReport();
         $report->planet_galaxy = $defenderMoon->getPlanetCoordinates()->galaxy;
         $report->planet_system = $defenderMoon->getPlanetCoordinates()->system;
         $report->planet_position = $defenderMoon->getPlanetCoordinates()->position;
         $report->planet_type = $defenderMoon->getPlanetType()->value;
-        $report->planet_user_id = $defenderMoon->getPlayer()->getId();
+        $report->planet_user_id = $defenderPlayer->getId();
 
         $report->general = [
             'moon_existed' => true,
@@ -423,7 +456,7 @@ class MoonDestructionMission extends GameMission
         ];
 
         $report->defender = [
-            'player_id' => $defenderMoon->getPlayer()->getId(),
+            'player_id' => $defenderPlayer->getId(),
             'resource_loss' => $battleResult->defenderResourceLoss->sum(),
             'units' => $battleResult->defenderUnitsStart->toArray(),
             'weapon_technology' => $battleResult->defenderWeaponLevel,
@@ -473,7 +506,17 @@ class MoonDestructionMission extends GameMission
     protected function processReturn(FleetMission $mission): void
     {
         // Load the target planet
+        if ($mission->planet_id_to === null) {
+            throw new RuntimeException('Moon Destruction return mission has no target planet.');
+        }
         $target_planet = $this->planetServiceFactory->make($mission->planet_id_to, true);
+        if ($target_planet === null) {
+            throw new RuntimeException('Moon Destruction return mission target planet does not exist.');
+        }
+        $targetPlayer = $target_planet->getPlayer();
+        if ($targetPlayer === null) {
+            throw new RuntimeException('Moon Destruction return mission target planet has no owner.');
+        }
 
         // Add back the units to the source planet
         $target_planet->addUnits($this->fleetMissionService->getFleetUnits($mission));
@@ -485,7 +528,7 @@ class MoonDestructionMission extends GameMission
         }
 
         // Send message to player that the return mission has arrived
-        $this->sendFleetReturnMessage($mission, $target_planet->getPlayer());
+        $this->sendFleetReturnMessage($mission, $targetPlayer);
 
         // Mark the return mission as processed
         $mission->processed = 1;

--- a/app/GameMissions/RecycleMission.php
+++ b/app/GameMissions/RecycleMission.php
@@ -17,6 +17,7 @@ use OGame\Models\Resources;
 use OGame\Services\DebrisFieldService;
 use OGame\Services\ObjectService;
 use OGame\Services\PlanetService;
+use RuntimeException;
 
 class RecycleMission extends GameMission
 {
@@ -83,7 +84,20 @@ class RecycleMission extends GameMission
      */
     protected function processArrival(FleetMission $mission): void
     {
+        if ($mission->planet_id_from === null) {
+            throw new RuntimeException('Recycle mission has no origin planet.');
+        }
         $originPlanet = $this->planetServiceFactory->make($mission->planet_id_from, true);
+        if ($originPlanet === null) {
+            throw new RuntimeException('Recycle mission origin planet does not exist.');
+        }
+        $originPlayer = $originPlanet->getPlayer();
+        if ($originPlayer === null) {
+            throw new RuntimeException('Recycle mission origin planet has no owner.');
+        }
+        if ($mission->galaxy_to === null || $mission->system_to === null || $mission->position_to === null) {
+            throw new RuntimeException('Recycle mission has no target coordinate.');
+        }
         $targetCoordinate = new Coordinate($mission->galaxy_to, $mission->system_to, $mission->position_to);
 
         // Load the debris field for the target coordinate.
@@ -105,7 +119,7 @@ class RecycleMission extends GameMission
         }
 
         // Calculate total cargo capacity.
-        $total_cargo_capacity = $harvesterShip->properties->capacity->calculate($originPlanet->getPlayer())->totalValue * $harvesterCount;
+        $total_cargo_capacity = $harvesterShip->properties->capacity->calculate($originPlayer)->totalValue * $harvesterCount;
 
         // Get resources from the debris field and take as much as the harvesters can carry.
         $resourcesToHarvest = $debrisField->getResources();
@@ -118,7 +132,7 @@ class RecycleMission extends GameMission
         }
 
         // Send a message to the player that the mission has arrived and the resources (if any) have been collected.
-        $this->messageService->sendSystemMessageToPlayer($originPlanet->getPlayer(), DebrisFieldHarvest::class, [
+        $this->messageService->sendSystemMessageToPlayer($originPlayer, DebrisFieldHarvest::class, [
             'from' => '[planet]' . $mission->planet_id_from . '[/planet]',
             'to' => '[debrisfield]' . $targetCoordinate->asString(). '[/debrisfield]',
             'coordinates' => '[coordinates]' . $targetCoordinate->asString() . '[/coordinates]',
@@ -154,7 +168,17 @@ class RecycleMission extends GameMission
      */
     protected function processReturn(FleetMission $mission): void
     {
+        if ($mission->planet_id_to === null) {
+            throw new RuntimeException('Recycle return mission has no target planet.');
+        }
         $target_planet = $this->planetServiceFactory->make($mission->planet_id_to, true);
+        if ($target_planet === null) {
+            throw new RuntimeException('Recycle return mission target planet does not exist.');
+        }
+        $targetPlayer = $target_planet->getPlayer();
+        if ($targetPlayer === null) {
+            throw new RuntimeException('Recycle return mission target planet has no owner.');
+        }
 
         // Recycle return trip: add back the units to the source planet.
         $target_planet->addUnits($this->fleetMissionService->getFleetUnits($mission));
@@ -166,7 +190,7 @@ class RecycleMission extends GameMission
         }
 
         // Send message to player that the return mission has arrived.
-        $this->sendFleetReturnMessage($mission, $target_planet->getPlayer());
+        $this->sendFleetReturnMessage($mission, $targetPlayer);
 
         // Mark the return mission as processed
         $mission->processed = 1;

--- a/app/GameMissions/TransportMission.php
+++ b/app/GameMissions/TransportMission.php
@@ -14,6 +14,7 @@ use OGame\Models\FleetMission;
 use OGame\Models\Planet\Coordinate;
 use OGame\Models\Resources;
 use OGame\Services\PlanetService;
+use RuntimeException;
 
 class TransportMission extends GameMission
 {
@@ -58,14 +59,25 @@ class TransportMission extends GameMission
      */
     protected function processArrival(FleetMission $mission): void
     {
+        if ($mission->planet_id_from === null || $mission->planet_id_to === null) {
+            throw new RuntimeException('Transport mission is missing origin or target planet.');
+        }
         $origin_planet = $this->planetServiceFactory->make($mission->planet_id_from, true);
         $target_planet = $this->planetServiceFactory->make($mission->planet_id_to, true);
+        if ($origin_planet === null || $target_planet === null) {
+            throw new RuntimeException('Transport mission origin or target planet does not exist.');
+        }
+        $originPlayer = $origin_planet->getPlayer();
+        $targetPlayer = $target_planet->getPlayer();
+        if ($originPlayer === null || $targetPlayer === null) {
+            throw new RuntimeException('Transport mission origin or target planet has no owner.');
+        }
 
         // Add resources to the target planet
         $target_planet->addResources($this->fleetMissionService->getResources($mission));
 
         // Send a message to the origin player that the mission has arrived
-        $this->messageService->sendSystemMessageToPlayer($origin_planet->getPlayer(), TransportArrived::class, [
+        $this->messageService->sendSystemMessageToPlayer($originPlayer, TransportArrived::class, [
             'from' => '[planet]' . $mission->planet_id_from . '[/planet]',
             'to' => '[planet]' . $mission->planet_id_to . '[/planet]',
             'metal' => (string)$mission->metal,
@@ -73,9 +85,9 @@ class TransportMission extends GameMission
             'deuterium' => (string)$mission->deuterium,
         ]);
 
-        if ($origin_planet->getPlayer()->getId() !== $target_planet->getPlayer()->getId()) {
+        if ($originPlayer->getId() !== $targetPlayer->getId()) {
             // Send a message to the target player that the mission has arrived
-            $this->messageService->sendSystemMessageToPlayer($target_planet->getPlayer(), TransportReceived::class, [
+            $this->messageService->sendSystemMessageToPlayer($targetPlayer, TransportReceived::class, [
                 'from' => '[planet]' . $mission->planet_id_from . '[/planet]',
                 'to' => '[planet]' . $mission->planet_id_to . '[/planet]',
                 'metal' => (string)$mission->metal,
@@ -100,7 +112,17 @@ class TransportMission extends GameMission
     protected function processReturn(FleetMission $mission): void
     {
         // Load the target planet
+        if ($mission->planet_id_to === null) {
+            throw new RuntimeException('Transport return mission has no target planet.');
+        }
         $target_planet = $this->planetServiceFactory->make($mission->planet_id_to, true);
+        if ($target_planet === null) {
+            throw new RuntimeException('Transport return mission target planet does not exist.');
+        }
+        $targetPlayer = $target_planet->getPlayer();
+        if ($targetPlayer === null) {
+            throw new RuntimeException('Transport return mission target planet has no owner.');
+        }
 
         // Transport return trip: add back the units to the source planet.
         $target_planet->addUnits($this->fleetMissionService->getFleetUnits($mission));
@@ -112,7 +134,7 @@ class TransportMission extends GameMission
         }
 
         // Send message to player that the return mission has arrived.
-        $this->sendFleetReturnMessage($mission, $target_planet->getPlayer());
+        $this->sendFleetReturnMessage($mission, $targetPlayer);
 
         // Mark the return mission as processed
         $mission->processed = 1;

--- a/app/Http/Controllers/Admin/DeveloperShortcutsController.php
+++ b/app/Http/Controllers/Admin/DeveloperShortcutsController.php
@@ -199,6 +199,10 @@ class DeveloperShortcutsController extends OGameController
             return redirect()->back()->with('error', 'Invalid action specified');
         }
 
+        if ($planet === null) {
+            return redirect()->back()->with('error', 'No planet exists at ' . $coordinate->asString());
+        }
+
         // Parse each resource value, handling k/m/b suffixes and negative values
         $metal = AppUtil::parseResourceValue($request->input('metal', 0));
         $crystal = AppUtil::parseResourceValue($request->input('crystal', 0));
@@ -393,7 +397,12 @@ class DeveloperShortcutsController extends OGameController
             return redirect()->back()->with('error', 'No planet exists at ' . $coordinate->asString());
         }
 
-        $user = $planet->getPlayer()->getUser();
+        $planetPlayer = $planet->getPlayer();
+        if ($planetPlayer === null) {
+            return redirect()->back()->with('error', 'No player found at ' . $coordinate->asString());
+        }
+
+        $user = $planetPlayer->getUser();
         $amount = (int)AppUtil::parseResourceValue($request->input('dark_matter', 0));
         if ($amount == 0) {
             return redirect()->back()->with('error', 'Dark matter amount cannot be zero');
@@ -425,13 +434,17 @@ class DeveloperShortcutsController extends OGameController
         ]);
 
         $currentUser = $request->user();
+        if ($currentUser === null) {
+            return redirect()->back()->with('error', __('User not found.'));
+        }
+
         $targetUser = User::where('username', $validated['username'])->first();
 
         if (!$targetUser) {
             return redirect()->back()->with('error', __('User not found.'));
         }
 
-        if ($currentUser && $currentUser->id === $targetUser->id) {
+        if ($currentUser->id === $targetUser->id) {
             return redirect()->back()->with('error', __('You cannot impersonate yourself.'));
         }
 

--- a/app/Http/Controllers/Admin/ServerAdministrationController.php
+++ b/app/Http/Controllers/Admin/ServerAdministrationController.php
@@ -137,7 +137,7 @@ class ServerAdministrationController extends OGameController
             ->sortByDesc(fn ($entry) => count($entry['signals']))
             ->values();
 
-        $botSuspects = $allSuspects->reject(fn ($s) => in_array($s['user']->id, $dismissedUserIds, true))->values();
+        $botSuspects = $allSuspects->reject(fn ($s) => in_array($s['user']?->id, $dismissedUserIds, true))->values();
         $stuckMissionsSettings = $this->stuckMissionsSettings();
         $stuckMissions = $this->getStuckFleetMissions($stuckMissionsSettings['min_overdue_hours']);
         $attackBlockUntil = (int) $settingsService->get('attack_block_until', 0);
@@ -151,7 +151,7 @@ class ServerAdministrationController extends OGameController
             'stuckMissionsSettings' => $stuckMissionsSettings,
             'detectionSettings'     => $settings,
             'dismissedIpCount'      => count($dismissedIps),
-            'dismissedSuspectCount' => $allSuspects->filter(fn ($s) => in_array($s['user']->id, $dismissedUserIds, true))->count(),
+            'dismissedSuspectCount' => $allSuspects->filter(fn ($s) => in_array($s['user']?->id, $dismissedUserIds, true))->count(),
             'attackBlockUntil'      => $attackBlockUntil,
             'attackBlockActive'     => $attackBlockUntil > time(),
         ]);

--- a/app/Http/Controllers/AllianceController.php
+++ b/app/Http/Controllers/AllianceController.php
@@ -28,7 +28,7 @@ class AllianceController extends OGameController
         $this->setBodyId('alliance');
 
         $userId = $player->getId();
-        $userAllianceId = auth()->user()->alliance_id;
+        $userAllianceId = $player->getUser()->alliance_id;
 
         $alliance = null;
         $member = null;
@@ -145,7 +145,7 @@ class AllianceController extends OGameController
     public function ajaxOverview(AllianceService $allianceService, PlayerService $player): JsonResponse
     {
         $userId = $player->getId();
-        $userAllianceId = auth()->user()->alliance_id;
+        $userAllianceId = $player->getUser()->alliance_id;
 
         if (!$userAllianceId) {
             return response()->json([
@@ -197,7 +197,7 @@ class AllianceController extends OGameController
     public function ajaxManagement(AllianceService $allianceService, PlayerService $player): JsonResponse
     {
         $userId = $player->getId();
-        $userAllianceId = auth()->user()->alliance_id;
+        $userAllianceId = $player->getUser()->alliance_id;
 
         if (!$userAllianceId) {
             return response()->json([
@@ -254,7 +254,7 @@ class AllianceController extends OGameController
     {
         try {
             $userId = $player->getId();
-            $userAllianceId = auth()->user()->alliance_id;
+            $userAllianceId = $player->getUser()->alliance_id;
 
             if (!$userAllianceId) {
                 return response()->json([
@@ -312,7 +312,7 @@ class AllianceController extends OGameController
     public function ajaxApplications(AllianceService $allianceService, PlayerService $player): JsonResponse
     {
         $userId = $player->getId();
-        $userAllianceId = auth()->user()->alliance_id;
+        $userAllianceId = $player->getUser()->alliance_id;
 
         if (!$userAllianceId) {
             return response()->json([
@@ -367,7 +367,7 @@ class AllianceController extends OGameController
     public function ajaxClasses(AllianceService $allianceService, PlayerService $player): JsonResponse
     {
         $userId = $player->getId();
-        $userAllianceId = auth()->user()->alliance_id;
+        $userAllianceId = $player->getUser()->alliance_id;
 
         if (!$userAllianceId) {
             return response()->json([
@@ -413,7 +413,7 @@ class AllianceController extends OGameController
     public function ajaxNewApplication(Request $request, AllianceService $allianceService, PlayerService $player): JsonResponse
     {
         $allianceId = $request->input('appliedAllyId');
-        $userAllianceId = auth()->user()->alliance_id;
+        $userAllianceId = $player->getUser()->alliance_id;
 
         // User must not already be in an alliance
         if ($userAllianceId) {
@@ -484,7 +484,7 @@ class AllianceController extends OGameController
      */
     public function ajaxHandleApplication(int $alliance_id, AllianceService $allianceService, PlayerService $player): JsonResponse
     {
-        $userAllianceId = auth()->user()->alliance_id;
+        $userAllianceId = $player->getUser()->alliance_id;
 
         // User must not already be in an alliance
         if ($userAllianceId) {
@@ -670,7 +670,10 @@ class AllianceController extends OGameController
 
                 case 'kick_member':
                     $memberUserId = $request->input('member_user_id');
-                    $allianceId = auth()->user()->alliance_id;
+                    $allianceId = $player->getUser()->alliance_id;
+                    if ($allianceId === null) {
+                        throw new Exception(__('t_ingame.alliance.msg_not_in_alliance'));
+                    }
                     $allianceService->kickMember($allianceId, $memberUserId, $userId);
                     $message = __('t_ingame.alliance.msg_kicked');
                     break;
@@ -683,13 +686,19 @@ class AllianceController extends OGameController
                 case 'assign_rank':
                     $memberUserId = $request->input('member_user_id');
                     $rankId = $request->input('rank_id');
-                    $allianceId = auth()->user()->alliance_id;
+                    $allianceId = $player->getUser()->alliance_id;
+                    if ($allianceId === null) {
+                        throw new Exception(__('t_ingame.alliance.msg_not_in_alliance'));
+                    }
                     $allianceService->assignRank($allianceId, $memberUserId, $rankId, $userId);
                     $message = __('t_ingame.alliance.msg_rank_assigned');
                     break;
 
                 case 'update_rank':
-                    $allianceId = auth()->user()->alliance_id;
+                    $allianceId = $player->getUser()->alliance_id;
+                    if ($allianceId === null) {
+                        throw new Exception(__('t_ingame.alliance.msg_not_in_alliance'));
+                    }
                     // Extract rank permissions from request
                     // JavaScript sends params like: rankId_36: 123, rankId_37: 456
                     $rankPermissions = [];
@@ -704,7 +713,10 @@ class AllianceController extends OGameController
                     break;
 
                 case 'update_texts':
-                    $allianceId = auth()->user()->alliance_id;
+                    $allianceId = $player->getUser()->alliance_id;
+                    if ($allianceId === null) {
+                        throw new Exception(__('t_ingame.alliance.msg_not_in_alliance'));
+                    }
                     $allianceService->updateTexts(
                         $allianceId,
                         $userId,
@@ -716,7 +728,10 @@ class AllianceController extends OGameController
                     break;
 
                 case 'update_settings':
-                    $allianceId = auth()->user()->alliance_id;
+                    $allianceId = $player->getUser()->alliance_id;
+                    if ($allianceId === null) {
+                        throw new Exception(__('t_ingame.alliance.msg_not_in_alliance'));
+                    }
                     $allianceService->updateSettings(
                         $allianceId,
                         $userId,
@@ -733,7 +748,10 @@ class AllianceController extends OGameController
                     break;
 
                 case 'update_tag':
-                    $allianceId = auth()->user()->alliance_id;
+                    $allianceId = $player->getUser()->alliance_id;
+                    if ($allianceId === null) {
+                        throw new Exception(__('t_ingame.alliance.msg_not_in_alliance'));
+                    }
                     $allianceService->updateTag(
                         $allianceId,
                         $userId,
@@ -743,7 +761,10 @@ class AllianceController extends OGameController
                     break;
 
                 case 'update_name':
-                    $allianceId = auth()->user()->alliance_id;
+                    $allianceId = $player->getUser()->alliance_id;
+                    if ($allianceId === null) {
+                        throw new Exception(__('t_ingame.alliance.msg_not_in_alliance'));
+                    }
                     $allianceService->updateName(
                         $allianceId,
                         $userId,
@@ -753,7 +774,10 @@ class AllianceController extends OGameController
                     break;
 
                 case 'update_tag_name':
-                    $allianceId = auth()->user()->alliance_id;
+                    $allianceId = $player->getUser()->alliance_id;
+                    if ($allianceId === null) {
+                        throw new Exception(__('t_ingame.alliance.msg_not_in_alliance'));
+                    }
                     $allianceService->updateTag(
                         $allianceId,
                         $userId,
@@ -768,7 +792,10 @@ class AllianceController extends OGameController
                     break;
 
                 case 'disband_alliance':
-                    $allianceId = auth()->user()->alliance_id;
+                    $allianceId = $player->getUser()->alliance_id;
+                    if ($allianceId === null) {
+                        throw new Exception(__('t_ingame.alliance.msg_not_in_alliance'));
+                    }
                     $allianceService->disbandAlliance($allianceId, $userId);
                     $message = __('t_ingame.alliance.msg_disbanded');
                     $redirectUrl = route('alliance.index');
@@ -780,7 +807,10 @@ class AllianceController extends OGameController
                         'request_id' => $request->header('X-Request-ID', uniqid()),
                     ]);
 
-                    $allianceId = auth()->user()->alliance_id;
+                    $allianceId = $player->getUser()->alliance_id;
+                    if ($allianceId === null) {
+                        throw new Exception(__('t_ingame.alliance.msg_not_in_alliance'));
+                    }
 
                     // Support both old (rankIds/broadcastText) and new (recipients/text) parameter names
                     $text = $request->input('text') ?: $request->input('broadcastText');
@@ -856,7 +886,10 @@ class AllianceController extends OGameController
         ]);
 
         try {
-            $allianceId = auth()->user()->alliance_id;
+            $allianceId = $player->getUser()->alliance_id;
+            if ($allianceId === null) {
+                throw new Exception(__('t_ingame.alliance.msg_not_in_alliance'));
+            }
             $allianceService->createRank(
                 $allianceId,
                 $validated['rankName'],
@@ -904,7 +937,7 @@ class AllianceController extends OGameController
 
         try {
             $userId = $player->getId();
-            $userAllianceId = auth()->user()->alliance_id;
+            $userAllianceId = $player->getUser()->alliance_id;
 
             if (!$userAllianceId) {
                 throw new Exception(__('t_ingame.alliance.msg_not_in_alliance'));
@@ -943,7 +976,7 @@ class AllianceController extends OGameController
 
         try {
             $userId = $player->getId();
-            $userAllianceId = auth()->user()->alliance_id;
+            $userAllianceId = $player->getUser()->alliance_id;
 
             if (!$userAllianceId) {
                 throw new Exception(__('t_ingame.alliance.msg_not_in_alliance'));
@@ -957,8 +990,11 @@ class AllianceController extends OGameController
             );
 
             $alliance = $allianceService->getAllianceById($userAllianceId);
+            if ($alliance === null) {
+                throw new Exception(__('t_ingame.alliance.msg_not_in_alliance'));
+            }
             $rankName = $validated['rank_id']
-                ? $alliance->ranks->firstWhere('id', $validated['rank_id'])->rank_name
+                ? $alliance->ranks->firstWhere('id', $validated['rank_id'])?->rank_name
                 : $alliance->newcomer_rank_name;
 
             return response()->json([
@@ -987,7 +1023,7 @@ class AllianceController extends OGameController
     {
         try {
             $userId = $player->getId();
-            $userAllianceId = auth()->user()->alliance_id;
+            $userAllianceId = $player->getUser()->alliance_id;
 
             if (!$userAllianceId) {
                 throw new Exception(__('t_ingame.alliance.msg_not_in_alliance'));
@@ -1003,6 +1039,9 @@ class AllianceController extends OGameController
 
             // Get current alliance to preserve other texts
             $alliance = $allianceService->getAllianceById($userAllianceId);
+            if ($alliance === null) {
+                throw new Exception(__('t_ingame.alliance.msg_not_in_alliance'));
+            }
 
             // Update only the specified text type
             $internalText = $alliance->internal_text;

--- a/app/Http/Controllers/CharacterClassController.php
+++ b/app/Http/Controllers/CharacterClassController.php
@@ -32,6 +32,10 @@ class CharacterClassController extends OGameController
         $this->setBodyId('characterclassselection');
 
         $user = Auth::user();
+        if ($user === null) {
+            abort(403);
+        }
+
         $currentClass = $this->characterClassService->getCharacterClass($user);
         $changeCost = $this->characterClassService->getChangeCost($user);
 
@@ -64,6 +68,13 @@ class CharacterClassController extends OGameController
         ]);
 
         $user = Auth::user();
+        if ($user === null) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Not authenticated',
+            ], 401);
+        }
+
         $classId = (int)$request->input('characterClassId');
         $newClass = CharacterClass::from($classId);
 
@@ -104,6 +115,12 @@ class CharacterClassController extends OGameController
     public function deselectClass(): JsonResponse
     {
         $user = Auth::user();
+        if ($user === null) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Not authenticated',
+            ], 401);
+        }
 
         try {
             $this->characterClassService->deselectClass($user);

--- a/app/Http/Controllers/ChatController.php
+++ b/app/Http/Controllers/ChatController.php
@@ -193,12 +193,14 @@ class ChatController extends OGameController
 
             $message = $chatService->sendDirectMessage($userId, $recipientId, $text, $replyToId);
 
+            $createdAt = $message->created_at;
+
             $response = [
                 'status' => 'OK',
                 'id' => $message->id,
                 'targetId' => $recipientId,
                 'text' => e($message->message),
-                'date' => $message->created_at->timestamp,
+                'date' => $createdAt !== null ? (int) $createdAt->timestamp : 0,
             ];
 
             if ($message->replyTo) {
@@ -220,12 +222,14 @@ class ChatController extends OGameController
 
             $message = $chatService->sendAllianceMessage($userId, $allianceId, $text, $replyToId);
 
+            $createdAt = $message->created_at;
+
             $response = [
                 'status' => 'OK',
                 'id' => $message->id,
                 'targetAssociationId' => $allianceId,
                 'text' => e($message->message),
-                'date' => $message->created_at->timestamp,
+                'date' => $createdAt !== null ? (int) $createdAt->timestamp : 0,
             ];
 
             if ($message->replyTo) {

--- a/app/Http/Controllers/FleetController.php
+++ b/app/Http/Controllers/FleetController.php
@@ -140,7 +140,7 @@ class FleetController extends OGameController
             if ($eventRowViewModel->is_return_trip) {
                 // Origin becomes destination (where fleet is coming from)
                 $eventRowViewModel->origin_planet_name = '';
-                $eventRowViewModel->origin_planet_coords = new Coordinate($row->galaxy_to, $row->system_to, $row->position_to);
+                $eventRowViewModel->origin_planet_coords = new Coordinate((int) $row->galaxy_to, (int) $row->system_to, (int) $row->position_to);
                 $eventRowViewModel->origin_planet_type = PlanetType::from($row->type_to);
                 if ($row->planet_id_to !== null) {
                     $planetToService = $planetServiceFactory->make($row->planet_id_to);
@@ -154,7 +154,7 @@ class FleetController extends OGameController
 
                 // Destination becomes origin (where fleet is going back to)
                 $eventRowViewModel->destination_planet_name = '';
-                $eventRowViewModel->destination_planet_coords = new Coordinate($row->galaxy_from, $row->system_from, $row->position_from);
+                $eventRowViewModel->destination_planet_coords = new Coordinate((int) $row->galaxy_from, (int) $row->system_from, (int) $row->position_from);
                 $eventRowViewModel->destination_planet_type = PlanetType::from($row->type_from);
                 if ($row->planet_id_from !== null) {
                     $planetFromService = $planetServiceFactory->make($row->planet_id_from);
@@ -168,7 +168,7 @@ class FleetController extends OGameController
             } else {
                 // Normal trip - origin is where fleet started, destination is where it's going
                 $eventRowViewModel->origin_planet_name = '';
-                $eventRowViewModel->origin_planet_coords = new Coordinate($row->galaxy_from, $row->system_from, $row->position_from);
+                $eventRowViewModel->origin_planet_coords = new Coordinate((int) $row->galaxy_from, (int) $row->system_from, (int) $row->position_from);
                 $eventRowViewModel->origin_planet_type = PlanetType::from($row->type_from);
                 if ($row->planet_id_from !== null) {
                     $planetFromService = $planetServiceFactory->make($row->planet_id_from);
@@ -181,7 +181,7 @@ class FleetController extends OGameController
                 }
 
                 $eventRowViewModel->destination_planet_name = '';
-                $eventRowViewModel->destination_planet_coords = new Coordinate($row->galaxy_to, $row->system_to, $row->position_to);
+                $eventRowViewModel->destination_planet_coords = new Coordinate((int) $row->galaxy_to, (int) $row->system_to, (int) $row->position_to);
                 $eventRowViewModel->destination_planet_type = PlanetType::from($row->type_to);
 
                 if ($row->planet_id_to !== null) {
@@ -328,9 +328,9 @@ class FleetController extends OGameController
         if ($targetPlanet !== null) {
             $targetPlayer = $targetPlanet->getPlayer();
 
-            $targetPlayerId = $targetPlayer->getId();
+            $targetPlayerId = $targetPlayer?->getId() ?? 99999;
             $targetPlanetName = $targetPlanet->getPlanetName();
-            $targetPlayerName = $targetPlayer->getUsername(false);
+            $targetPlayerName = $targetPlayer?->getUsername(false) ?? 'Deep space';
             $targetCoordinates = $targetPlanet->getPlanetCoordinates();
         } else {
             $targetPlayerId = 99999;
@@ -923,7 +923,7 @@ class FleetController extends OGameController
         // Resolve the target planet owner name
         $targetPlayerName = '';
         $planetServiceFactory = app(PlanetServiceFactory::class);
-        $targetCoordinate = new Coordinate($mission->galaxy_to, $mission->system_to, $mission->position_to);
+        $targetCoordinate = new Coordinate((int) $mission->galaxy_to, (int) $mission->system_to, (int) $mission->position_to);
         $targetPlanetService = $planetServiceFactory->makeForCoordinate($targetCoordinate);
         if ($targetPlanetService !== null) {
             $targetPlayer = $targetPlanetService->getPlayer();

--- a/app/Http/Controllers/FleetEventsController.php
+++ b/app/Http/Controllers/FleetEventsController.php
@@ -220,7 +220,7 @@ class FleetEventsController extends OGameController
             $eventRowViewModel->is_return_trip = !empty($row->parent_id); // If mission has a parent, it is a return trip
 
             $eventRowViewModel->origin_planet_name = '';
-            $eventRowViewModel->origin_planet_coords = new Coordinate($row->galaxy_from, $row->system_from, $row->position_from);
+            $eventRowViewModel->origin_planet_coords = new Coordinate((int) $row->galaxy_from, (int) $row->system_from, (int) $row->position_from);
             $eventRowViewModel->origin_planet_type = PlanetType::from($row->type_from);
             if ($row->planet_id_from !== null) {
                 $planetFromService = $planetServiceFactory->make($row->planet_id_from);
@@ -231,7 +231,7 @@ class FleetEventsController extends OGameController
             }
 
             $eventRowViewModel->destination_planet_name = '';
-            $eventRowViewModel->destination_planet_coords = new Coordinate($row->galaxy_to, $row->system_to, $row->position_to);
+            $eventRowViewModel->destination_planet_coords = new Coordinate((int) $row->galaxy_to, (int) $row->system_to, (int) $row->position_to);
             $eventRowViewModel->destination_planet_type = PlanetType::from($row->type_to);
 
             if ($row->planet_id_to !== null) {
@@ -447,7 +447,7 @@ class FleetEventsController extends OGameController
 
                     // Origin
                     $vm->origin_planet_name = '';
-                    $vm->origin_planet_coords = new Coordinate($row->galaxy_from, $row->system_from, $row->position_from);
+                    $vm->origin_planet_coords = new Coordinate((int) $row->galaxy_from, (int) $row->system_from, (int) $row->position_from);
                     $vm->origin_planet_type = PlanetType::from($row->type_from);
                     if ($row->planet_id_from !== null) {
                         $originPlanet = $planetServiceFactory->make($row->planet_id_from);
@@ -459,7 +459,7 @@ class FleetEventsController extends OGameController
 
                     // Destination
                     $vm->destination_planet_name = '';
-                    $vm->destination_planet_coords = new Coordinate($row->galaxy_to, $row->system_to, $row->position_to);
+                    $vm->destination_planet_coords = new Coordinate((int) $row->galaxy_to, (int) $row->system_to, (int) $row->position_to);
                     $vm->destination_planet_type = PlanetType::from($row->type_to);
                     if ($row->planet_id_to !== null) {
                         $destPlanet = $planetServiceFactory->make($row->planet_id_to);

--- a/app/Http/Controllers/GalaxyController.php
+++ b/app/Http/Controllers/GalaxyController.php
@@ -151,12 +151,14 @@ class GalaxyController extends OGameController
         $availableMissions = $this->getAvailableMissions($galaxy, $system, $position, $planet);
         $planets_array = $this->createPlanetsArray($planet, $availableMissions);
 
+        $planetPlayer = $planet->getPlayer();
+
         return [
             'actions' => $this->getPlanetActions($planet, $galaxy, $system, $position, $phalanxService),
             'availableMissions' => [],
             'galaxy' => $galaxy,
             'planets' => $planets_array,
-            'player' => $this->getPlayerInfo($planet->getPlayer()),
+            'player' => $planetPlayer !== null ? $this->getPlayerInfo($planetPlayer) : [],
             'position' => $position,
             'positionFilters' => '',
             'system' => $system,
@@ -263,7 +265,7 @@ class GalaxyController extends OGameController
             'isDestroyed' => false,
             'planetId' => $moon->getPlanetId(),
             'planetName' => $moon->getPlanetName(),
-            'playerId' => $moon->getPlayer()->getId(),
+            'playerId' => $moon->getPlayer()?->getId(),
             'planetType' => 3,
             'size' => $moon->getPlanetDiameter(),
             'tooltipInfo' => [
@@ -294,9 +296,14 @@ class GalaxyController extends OGameController
             'name' => __('Transport'),
         ];
 
-        if ($planet->getPlayer()->getId() !== $this->playerService->getId()) {
+        $targetPlayer = $planet->getPlayer();
+        if ($targetPlayer === null) {
+            return $availableMissions;
+        }
+
+        if ($targetPlayer->getId() !== $this->playerService->getId()) {
             // Skip aggressive missions (Espionage, Attack) against Legor
-            $isLegor = $planet->getPlayer()->getUsername(false) === 'Legor';
+            $isLegor = $targetPlayer->getUsername(false) === 'Legor';
 
             if (!$isLegor) {
                 // Espionage (only if foreign planet and not Legor).
@@ -319,7 +326,7 @@ class GalaxyController extends OGameController
 
             // Check if target player is a buddy or ally member
             $currentUserId = $this->playerService->getUser()->id;
-            $targetUserId = $planet->getPlayer()->getUser()->id;
+            $targetUserId = $targetPlayer->getUser()->id;
 
             $isBuddy = $this->buddyService->areBuddies($currentUserId, $targetUserId);
 
@@ -379,8 +386,8 @@ class GalaxyController extends OGameController
         // Check if phalanx can be used: must be on moon, target must be planet, not own planet, not admin
         if ($current_planet->isMoon()
             && !$planet->isMoon()
-            && $planet->getPlayer()->getId() !== $this->playerService->getId()
-            && !$planet->getPlayer()->isAdmin()) {
+            && $planet->getPlayer()?->getId() !== $this->playerService->getId()
+            && !$planet->getPlayer()?->isAdmin()) {
             // All basic checks passed, now check phalanx level and range
             $phalanx_level = $current_planet->getObjectLevel('sensor_phalanx');
             if ($phalanx_level > 0) {
@@ -408,8 +415,8 @@ class GalaxyController extends OGameController
         // Check if buddy request can be sent:
         // - Must be foreign planet (not own)
         // - Target player must not be admin (can't send requests to admins)
-        $canBuddyRequest = $planet->getPlayer()->getId() !== $this->playerService->getId()
-            && !$planet->getPlayer()->isAdmin();
+        $canBuddyRequest = $planet->getPlayer()?->getId() !== $this->playerService->getId()
+            && !$planet->getPlayer()?->isAdmin();
 
         // Check if missile attack is possible:
         // - Must be foreign planet (not own)
@@ -417,7 +424,7 @@ class GalaxyController extends OGameController
         $canMissileAttack = false;
         $missileAttackLink = route('galaxy.index');
 
-        if ($planet->getPlayer()->getId() !== $this->playerService->getId()) {
+        if ($planet->getPlayer()?->getId() !== $this->playerService->getId()) {
             $currentPlanet = $this->playerService->planets->current();
             $missileRange = $this->playerService->getMissileRange();
             $targetCoordinate = new Coordinate($galaxy, $system, $position);
@@ -872,7 +879,7 @@ class GalaxyController extends OGameController
         }
 
         // Check if target is own planet
-        if ($currentPlanet->getPlayer()->equals($targetPlanet->getPlayer())) {
+        if ($currentPlanet->getPlayer()?->equals($targetPlanet->getPlayer())) {
             $data['error'] = __('You cannot attack your own planet');
             return view('ingame.galaxy.missileattack', $data);
         }
@@ -886,7 +893,7 @@ class GalaxyController extends OGameController
 
         // Get target info
         $data['target_planet_name'] = $targetPlanet->getPlanetName();
-        $data['target_player_name'] = $targetPlanet->getPlayer()->getUsername();
+        $data['target_player_name'] = $targetPlanet->getPlayer()?->getUsername() ?? '';
 
         // Get ABM count for warning
         $targetAbmCount = $targetPlanet->getObjectAmount('anti_ballistic_missile');
@@ -975,7 +982,7 @@ class GalaxyController extends OGameController
         }
 
         // Check if target is own planet
-        if ($currentPlanet->getPlayer()->equals($targetPlanet->getPlayer())) {
+        if ($currentPlanet->getPlayer()?->equals($targetPlanet->getPlayer())) {
             return response()->json([
                 'success' => false,
                 'error' => __('You cannot attack your own planet'),

--- a/app/Http/Controllers/HighscoreController.php
+++ b/app/Http/Controllers/HighscoreController.php
@@ -151,7 +151,7 @@ class HighscoreController extends OGameController
             $currentAllianceRank = 0;
             $currentAlliancePage = 1;
 
-            $userAllianceId = auth()->user()->alliance_id;
+            $userAllianceId = $player->getUser()->alliance_id;
             if ($userAllianceId) {
                 $currentAllianceRank = $highscoreService->getHighscoreAllianceRank($userAllianceId);
                 if ($currentAllianceRank > 0) {
@@ -173,7 +173,7 @@ class HighscoreController extends OGameController
         $currentAllianceRank = 0;
         $currentAlliancePage = 1;
 
-        $userAllianceId = auth()->user()->alliance_id;
+        $userAllianceId = $player->getUser()->alliance_id;
         if ($userAllianceId) {
             $currentAllianceRank = $highscoreService->getHighscoreAllianceRank($userAllianceId);
             if ($currentAllianceRank > 0) {

--- a/app/Http/Controllers/LanguageController.php
+++ b/app/Http/Controllers/LanguageController.php
@@ -39,9 +39,10 @@ class LanguageController extends OGameController
         session()->put('locale', $locale);
 
         // Persist to DB so the preference survives session expiry / new devices.
-        if (Auth::check()) {
-            Auth::user()->lang = $locale;
-            Auth::user()->save();
+        $user = Auth::user();
+        if ($user !== null) {
+            $user->lang = $locale;
+            $user->save();
         }
 
         // Flush session to the store immediately so the locale key is visible to

--- a/app/Http/Controllers/PhalanxController.php
+++ b/app/Http/Controllers/PhalanxController.php
@@ -98,28 +98,41 @@ class PhalanxController extends OGameController
             return response()->json($response);
         }
 
+        if ($target_planet === null) {
+            $response['is_error'] = true;
+            $response['error_message'] = 'No planet found at these coordinates.';
+            return response()->json($response);
+        }
+
+        $target_player = $target_planet->getPlayer();
+        if ($target_player === null) {
+            $response['is_error'] = true;
+            $response['error_message'] = 'No planet found at these coordinates.';
+            return response()->json($response);
+        }
+
         // Cannot scan moons (OGame rule)
         if ($target_planet->isMoon()) {
             $response['target']['planet_name'] = $target_planet->getPlanetName();
-            $response['target']['player_name'] = $target_planet->getPlayer()->getUsername();
+            $response['target']['player_name'] = $target_player->getUsername();
             $response['is_error'] = true;
             $response['error_message'] = 'Moons cannot be scanned with Sensor Phalanx.';
             return response()->json($response);
         }
 
         // Cannot scan admin planets
-        if ($target_planet->getPlayer()->isAdmin()) {
+        if ($target_player->isAdmin()) {
             $response['target']['planet_name'] = $target_planet->getPlanetName();
-            $response['target']['player_name'] = $target_planet->getPlayer()->getUsername();
+            $response['target']['player_name'] = $target_player->getUsername();
             $response['is_error'] = true;
             $response['error_message'] = 'Administrator planets cannot be scanned.';
             return response()->json($response);
         }
 
         // Cannot scan own planets
-        if ($target_planet->getPlayer()->getId() === $player->getId()) {
+        if ($target_player->getId() === $player->getId()) {
             $response['target']['planet_name'] = $target_planet->getPlanetName();
-            $response['target']['player_name'] = $target_planet->getPlayer()->getUsername();
+            $response['target']['player_name'] = $target_player->getUsername();
             $response['is_error'] = true;
             $response['error_message'] = 'You cannot scan your own planets.';
             return response()->json($response);
@@ -147,7 +160,7 @@ class PhalanxController extends OGameController
                 'system' => $target_coordinate->system,
                 'position' => $target_coordinate->position,
                 'planet_name' => $target_planet->getPlanetName(),
-                'player_name' => $target_planet->getPlayer()->getUsername(),
+                'player_name' => $target_player->getUsername(),
             ],
             'scan_cost' => $phalanxService->getScanCost(),
             'fleet_count' => count($fleet_movements),

--- a/app/Http/Controllers/PlanetAbandonController.php
+++ b/app/Http/Controllers/PlanetAbandonController.php
@@ -20,7 +20,7 @@ class PlanetAbandonController extends OGameController
         return view('ingame.planetabandon.overlay')->with([
             'currentPlanet' => $player->planets->current(),
             'isMoon' => $player->planets->current()->isMoon(),
-            'isCurrentPlanetHomePlanet' => $player->planets->current()->getPlanetId() === $player->planets->first()->getPlanetId(),
+            'isCurrentPlanetHomePlanet' => $player->planets->current()->getPlanetId() === $player->planets->first()?->getPlanetId(),
         ]);
     }
 

--- a/app/Http/Controllers/PlanetMoveController.php
+++ b/app/Http/Controllers/PlanetMoveController.php
@@ -47,7 +47,7 @@ class PlanetMoveController extends OGameController
         }
 
         $planet = $player->planets->current();
-        $user = $planet->getPlayer()->getUser();
+        $user = $player->getUser();
 
         // Validate the player doesn't already have an active move for this planet.
         $activeMove = $planetMoveService->getActiveMoveForPlanet($planet);

--- a/app/Http/Controllers/TechtreeController.php
+++ b/app/Http/Controllers/TechtreeController.php
@@ -456,7 +456,7 @@ class TechtreeController extends OGameController
         // If we're at the beginning, add current object to requirement array as depth 0 (root)
         if ($depth === 1) {
             if ($object->type === GameObjectType::Research) {
-                $object_level = $planet->getPlayer()->getResearchLevel($object->machine_name);
+                $object_level = $planet->getPlayer()?->getResearchLevel($object->machine_name) ?? 0;
             } else {
                 $object_level = $planet->getObjectLevel($object->machine_name);
             }
@@ -472,7 +472,7 @@ class TechtreeController extends OGameController
             $object = ObjectService::getObjectByMachineName($requirement->object_machine_name);
 
             if ($object->type === GameObjectType::Research) {
-                $object_level = $planet->getPlayer()->getResearchLevel($object->machine_name);
+                $object_level = $planet->getPlayer()?->getResearchLevel($object->machine_name) ?? 0;
             } else {
                 $object_level = $planet->getObjectLevel($object->machine_name);
             }

--- a/app/Http/Middleware/Admin.php
+++ b/app/Http/Middleware/Admin.php
@@ -18,7 +18,8 @@ class Admin
      */
     public function handle(Request $request, Closure $next, string|null $guard = null)
     {
-        if (Auth::check() && !Auth::user()->hasRole('admin')) {
+        $user = Auth::user();
+        if ($user !== null && !$user->hasRole('admin')) {
             return redirect('/overview');
         }
 

--- a/app/Http/Middleware/GlobalGame.php
+++ b/app/Http/Middleware/GlobalGame.php
@@ -29,8 +29,13 @@ class GlobalGame
     public function handle(Request $request, Closure $next): mixed
     {
         if (Auth::check()) {
+            $user = $request->user();
+            if ($user === null) {
+                return $next($request);
+            }
+
             // Load current player and make it available as a request singleton via PlayerService.
-            $player = resolve(PlayerService::class, ['player_id' => $request->user()->id]);
+            $player = resolve(PlayerService::class, ['player_id' => $user->id]);
 
             /** @var PlayerService $player */
             app()->instance(PlayerService::class, $player);

--- a/app/Http/Traits/ObjectAjaxTrait.php
+++ b/app/Http/Traits/ObjectAjaxTrait.php
@@ -363,7 +363,8 @@ trait ObjectAjaxTrait
         // Special handling for Interplanetary Missiles to show range based on impulse drive level
         if ($object->machine_name === 'interplanetary_missile') {
             // Use getMissileRange() for consistent formula: (level × 5) - 1
-            $missile_range = $planet->getPlayer()->getMissileRange();
+            $planetPlayer = $planet->getPlayer();
+            $missile_range = $planetPlayer !== null ? $planetPlayer->getMissileRange() : 0;
 
             // Append the specific range value to the description
             $description .= " Your interplanetary missiles have got a coverage of {$missile_range} systems.";

--- a/app/Services/BbCodeParserService.php
+++ b/app/Services/BbCodeParserService.php
@@ -42,7 +42,7 @@ class BbCodeParserService
         ];
 
         foreach ($patterns as $pattern => $replacement) {
-            $html = preg_replace($pattern, $replacement, $html);
+            $html = preg_replace($pattern, $replacement, $html) ?? $html;
         }
 
         // Convert newlines to <br>.

--- a/app/Services/BuddyService.php
+++ b/app/Services/BuddyService.php
@@ -268,7 +268,7 @@ class BuddyService
         }
 
         // Delete the request instead of marking it as rejected
-        return $request->delete();
+        return (bool) $request->delete();
     }
 
     /**
@@ -296,7 +296,7 @@ class BuddyService
             throw new Exception(__('t_buddies.error.already_processed'));
         }
 
-        return $request->delete();
+        return (bool) $request->delete();
     }
 
     /**
@@ -338,7 +338,7 @@ class BuddyService
             ]);
         }
 
-        return $request->delete();
+        return (bool) $request->delete();
     }
 
     /**
@@ -439,7 +439,7 @@ class BuddyService
             throw new Exception(__('t_buddies.error.not_in_ignore_list'));
         }
 
-        return $ignoredPlayer->delete();
+        return (bool) $ignoredPlayer->delete();
     }
 
     /**

--- a/app/Services/BuildingQueueService.php
+++ b/app/Services/BuildingQueueService.php
@@ -155,6 +155,11 @@ class BuildingQueueService
      */
     public function addDowngrade(PlanetService $planet, int $building_id): void
     {
+        $player = $planet->getPlayer();
+        if ($player === null) {
+            throw new Exception('Planet has no owner.');
+        }
+
         $build_queue = $this->retrieveQueue($planet);
 
         // Max amount of buildings that can be in the queue in a given time.
@@ -200,7 +205,7 @@ class BuildingQueueService
         }
 
         // Check if Research Lab is being downgraded while research is in progress
-        if ($building->machine_name === 'research_lab' && $planet->getPlayer()->isResearching()) {
+        if ($building->machine_name === 'research_lab' && $player->isResearching()) {
             throw new Exception('Cannot downgrade Research Lab while research is in progress.');
         }
 
@@ -215,7 +220,7 @@ class BuildingQueueService
         }
 
         // Check if Shipyard is being downgraded while ships/defense are being built
-        if ($building->machine_name === 'shipyard' && $planet->getPlayer()->isBuildingShipsOrDefense()) {
+        if ($building->machine_name === 'shipyard' && $player->isBuildingShipsOrDefense()) {
             throw new Exception('Cannot downgrade Shipyard while ships or defense are being built.');
         }
 
@@ -323,6 +328,11 @@ class BuildingQueueService
      */
     public function start(PlanetService $planet, int $time_start = 0): void
     {
+        $player = $planet->getPlayer();
+        if ($player === null) {
+            throw new Exception('Planet has no owner.');
+        }
+
         // TODO: add unittest for case described above with $time_start.
         $queue_items = BuildingQueue::where([
             ['planet_id', $planet->getPlanetId()],
@@ -384,13 +394,13 @@ class BuildingQueueService
                 }
 
                 // Check if Research Lab is being downgraded while research is in progress
-                if ($object->machine_name === 'research_lab' && $planet->getPlayer()->isResearching()) {
+                if ($object->machine_name === 'research_lab' && $player->isResearching()) {
                     $this->cancel($planet, $queue_item->id, $queue_item->object_id);
                     continue;
                 }
 
                 // Check if Shipyard is being downgraded while ships/defense are being built
-                if ($object->machine_name === 'shipyard' && $planet->getPlayer()->isBuildingShipsOrDefense()) {
+                if ($object->machine_name === 'shipyard' && $player->isBuildingShipsOrDefense()) {
                     $this->cancel($planet, $queue_item->id, $queue_item->object_id);
                     continue;
                 }
@@ -403,7 +413,7 @@ class BuildingQueueService
                 }
 
                 // Sanity check: check if the Research Lab is tried to upgrade when research is in progress
-                if ($object->machine_name === 'research_lab' && $planet->getPlayer()->isResearching()) {
+                if ($object->machine_name === 'research_lab' && $player->isResearching()) {
                     // Error, cancel build queue item.
                     $this->cancel($planet, $queue_item->id, $queue_item->object_id);
                     continue;
@@ -490,8 +500,13 @@ class BuildingQueueService
             // unit queue objects cannot be canceled.
             $this->cancelItemMissingRequirements($planet);
 
+            $player = $planet->getPlayer();
+            if ($player === null) {
+                throw new Exception('Planet has no owner.');
+            }
+
             $research_queue = resolve(ResearchQueueService::class);
-            $research_queue->cancelItemMissingRequirements($planet->getPlayer(), $planet);
+            $research_queue->cancelItemMissingRequirements($player, $planet);
 
             // Set the next queue item to start (if applicable)
             $this->start($planet);

--- a/app/Services/ChatService.php
+++ b/app/Services/ChatService.php
@@ -174,7 +174,16 @@ class ChatService
         foreach ($messages as $message) {
             $partnerId = $message->sender_id === $userId ? $message->recipient_id : $message->sender_id;
 
+            if ($partnerId === null) {
+                continue;
+            }
+
             if (isset($conversations[$partnerId])) {
+                continue;
+            }
+
+            $createdAt = $message->created_at;
+            if ($createdAt === null) {
                 continue;
             }
 
@@ -184,7 +193,7 @@ class ChatService
                 'partner_id' => $partnerId,
                 'partner_name' => $partner->username ?? 'Unknown',
                 'last_message' => $message->message,
-                'last_message_date' => $message->created_at,
+                'last_message_date' => $createdAt,
                 'unread_count' => $unreadCounts[$partnerId] ?? 0,
             ];
         }
@@ -218,8 +227,10 @@ class ChatService
             $key = (string) $message->id;
             $isOwnMessage = $message->sender_id === $currentPlayerId;
 
+            $createdAt = $message->created_at;
+
             $item = [
-                'date' => $message->created_at->timestamp,
+                'date' => $createdAt !== null ? $createdAt->timestamp : 0,
                 'newClass' => '',
                 'playerName' => $message->sender->username,
                 'altClass' => $isOwnMessage ? 'odd' : '',

--- a/app/Services/DarkMatterService.php
+++ b/app/Services/DarkMatterService.php
@@ -47,6 +47,9 @@ class DarkMatterService
         DB::transaction(function () use ($user, $amount, $type, $description) {
             // Lock the user row for update
             $user = User::where('id', $user->id)->lockForUpdate()->first();
+            if ($user === null) {
+                throw new Exception('User not found.');
+            }
 
             // Update balance
             $user->dark_matter += $amount;
@@ -82,6 +85,9 @@ class DarkMatterService
         DB::transaction(function () use ($user, $amount, $type, $description) {
             // Lock the user row for update
             $user = User::where('id', $user->id)->lockForUpdate()->first();
+            if ($user === null) {
+                throw new Exception('User not found.');
+            }
 
             // Check balance
             if ($user->dark_matter < $amount) {
@@ -146,6 +152,9 @@ class DarkMatterService
         DB::transaction(function () use ($user, $regenPeriod, $regenAmount) {
             // Lock the user row for update
             $user = User::where('id', $user->id)->lockForUpdate()->first();
+            if ($user === null) {
+                throw new Exception('User not found.');
+            }
 
             // Check if regeneration is due
             if ($user->dark_matter_last_regen === null) {

--- a/app/Services/FleetMissionService.php
+++ b/app/Services/FleetMissionService.php
@@ -55,7 +55,12 @@ class FleetMissionService
     public function calculateFleetMissionDuration(PlanetService $fromPlanet, Coordinate $to, UnitCollection $units, GameMission|null $mission = null, float $speed_percent = 10): int
     {
         // Get slowest unit speed.
-        $slowest_speed = $units->getSlowestUnitSpeed($fromPlanet->getPlayer());
+        $player = $fromPlanet->getPlayer();
+        if ($player === null) {
+            throw new Exception('Planet has no owner.');
+        }
+
+        $slowest_speed = $units->getSlowestUnitSpeed($player);
         $distance = $this->calculateFleetMissionDistance($fromPlanet, $to);
 
         // Determine which fleet speed to use based on mission type.
@@ -169,6 +174,11 @@ class FleetMissionService
      */
     public function calculateConsumption(PlanetService $fromPlanet, UnitCollection $ships, Coordinate $targetCoordinate, int $holdingHours, float $speedPercent)
     {
+        $player = $fromPlanet->getPlayer();
+        if ($player === null) {
+            throw new Exception('Planet has no owner.');
+        }
+
         $consumption = 0;
         $holdingCosts = 0;
 
@@ -181,7 +191,7 @@ class FleetMissionService
             $shipAmount = $shipEntry->amount; // Amount of ships
 
             // Calculate the speed of the ship
-            $ship_speed = $ship->properties->speed->calculate($fromPlanet->getPlayer())->totalValue;
+            $ship_speed = $ship->properties->speed->calculate($player)->totalValue;
 
             if (!empty($shipAmount)) {
                 $shipSpeedValue = 35000 / $speedValue * sqrt($distance * 10 / $ship_speed);
@@ -205,7 +215,7 @@ class FleetMissionService
 
         // Apply General class deuterium consumption reduction (-50%)
         $characterClassService = app(CharacterClassService::class);
-        $consumptionMultiplier = $characterClassService->getDeuteriumConsumptionMultiplier($fromPlanet->getPlayer()->getUser());
+        $consumptionMultiplier = $characterClassService->getDeuteriumConsumptionMultiplier($player->getUser());
         $consumption = (int)($consumption * $consumptionMultiplier);
 
         return $consumption;
@@ -505,15 +515,21 @@ class FleetMissionService
     public function getFleetMissionByParentId(int $parent_id, bool $only_active = true): FleetMission
     {
         if ($only_active) {
-            return $this->model
+            $mission = $this->model
                 ->where('parent_id', $parent_id)
                 ->where('processed', 0)
                 ->first();
         } else {
-            return $this->model
+            $mission = $this->model
                 ->where('parent_id', $parent_id)
                 ->first();
         }
+
+        if ($mission === null) {
+            throw new Exception('Fleet mission not found.');
+        }
+
+        return $mission;
     }
 
     /**
@@ -614,16 +630,31 @@ class FleetMissionService
     {
         $planetServiceFactory = app(PlanetServiceFactory::class);
 
+        if ($mission->planet_id_from === null || $mission->planet_id_to === null) {
+            throw new Exception('Fleet mission is missing origin or target planet.');
+        }
+
         $origin_planet = $planetServiceFactory->make($mission->planet_id_from, true);
         $target_planet = $planetServiceFactory->make($mission->planet_id_to, true);
 
+        if ($origin_planet === null || $target_planet === null) {
+            throw new Exception('Origin or target planet not found.');
+        }
+
+        $origin_player = $origin_planet->getPlayer();
+        $target_player = $target_planet->getPlayer();
+
+        if ($origin_player === null || $target_player === null) {
+            throw new Exception('Origin or target planet has no owner.');
+        }
+
         // Send message to sender (Fleet Command)
-        $this->messageService->sendSystemMessageToPlayer($origin_planet->getPlayer(), AcsDefendArrivalSender::class, [
+        $this->messageService->sendSystemMessageToPlayer($origin_player, AcsDefendArrivalSender::class, [
             'to' => '[planet]' . $mission->planet_id_to . '[/planet]',
         ]);
 
         // Send message to host/target (Space Monitoring)
-        $this->messageService->sendSystemMessageToPlayer($target_planet->getPlayer(), AcsDefendArrivalHost::class, [
+        $this->messageService->sendSystemMessageToPlayer($target_player, AcsDefendArrivalHost::class, [
             'to' => '[planet]' . $mission->planet_id_to . '[/planet]',
         ]);
     }

--- a/app/Services/JumpGateService.php
+++ b/app/Services/JumpGateService.php
@@ -351,10 +351,15 @@ class JumpGateService
      */
     public function hasUnprocessedArrivedFleet(PlanetService $moon): bool
     {
+        $player = $moon->getPlayer();
+        if ($player === null) {
+            throw new Exception('Moon has no owner.');
+        }
+
         return FleetMission::where('planet_id_to', $moon->getPlanetId())
             ->where('processed', 0)
             ->where('time_arrival', '<=', Date::now()->timestamp)
-            ->where('user_id', '!=', $moon->getPlayer()->getId())
+            ->where('user_id', '!=', $player->getId())
             ->exists();
     }
 }

--- a/app/Services/NoteService.php
+++ b/app/Services/NoteService.php
@@ -3,6 +3,7 @@
 namespace OGame\Services;
 
 use OGame\Models\Note;
+use RuntimeException;
 
 /**
  * Class NoteService.
@@ -80,6 +81,10 @@ class NoteService
         $note = Note::where('id', $noteId)
             ->where('user_id', $this->player->getId())
             ->first();
+
+        if ($note === null) {
+            throw new RuntimeException('Note not found.');
+        }
 
         $note->update($data);
 

--- a/app/Services/ObjectService.php
+++ b/app/Services/ObjectService.php
@@ -354,6 +354,10 @@ class ObjectService
     public static function objectCharacterClassMet(string $machine_name, PlanetService $planet): bool
     {
         $player = $planet->getPlayer();
+        if ($player === null) {
+            throw new Exception('Planet has no owner.');
+        }
+
         $user = $player->getUser();
         $characterClassService = app(CharacterClassService::class);
 
@@ -570,7 +574,12 @@ class ObjectService
             if ($object->type === GameObjectType::Building || $object->type === GameObjectType::Station) {
                 $current_level = $planet->getObjectLevel($object->machine_name);
             } else {
-                $current_level = $planet->getPlayer()->getResearchLevel($object->machine_name);
+                $player = $planet->getPlayer();
+                if ($player === null) {
+                    throw new Exception('Planet has no owner.');
+                }
+
+                $current_level = $player->getResearchLevel($object->machine_name);
             }
 
             $price = self::getObjectRawPrice($machine_name, $current_level + 1);
@@ -790,8 +799,13 @@ class ObjectService
                 $object = self::getObjectByMachineName($requirement->object_machine_name);
 
                 if ($object->type === GameObjectType::Research) {
+                    $player = $planet->getPlayer();
+                    if ($player === null) {
+                        throw new Exception('Planet has no owner.');
+                    }
+
                     // Check if requirements are met with existing technology.
-                    if ($planet->getPlayer()->getResearchLevel($requirement->object_machine_name) < $requirement->level) {
+                    if ($player->getResearchLevel($requirement->object_machine_name) < $requirement->level) {
                         return true;
                     }
                 } else {
@@ -827,8 +841,13 @@ class ObjectService
                 }
 
                 if ($object->type === GameObjectType::Research) {
+                    $player = $planet->getPlayer();
+                    if ($player === null) {
+                        throw new Exception('Planet has no owner.');
+                    }
+
                     // Check if the requirements are met by the items in the research queue.
-                    if (!$planet->getPlayer()->isResearchingTech($requirement->object_machine_name, $requirement->level)) {
+                    if (!$player->isResearchingTech($requirement->object_machine_name, $requirement->level)) {
                         return true;
                     }
                 } else {
@@ -859,7 +878,12 @@ class ObjectService
         $current_level = 0;
 
         if ($object->type === GameObjectType::Research) {
-            $current_level = $planet->getPlayer()->getResearchLevel($object->machine_name);
+            $player = $planet->getPlayer();
+            if ($player === null) {
+                throw new Exception('Planet has no owner.');
+            }
+
+            $current_level = $player->getResearchLevel($object->machine_name);
         } else {
             $current_level = $planet->getObjectLevel($object->machine_name);
         }
@@ -882,15 +906,20 @@ class ObjectService
      */
     private static function hasPreviousLevelsInQueue(int $target_level, GameObject $object, PlanetService $planet): bool
     {
+        $player = $planet->getPlayer();
+        if ($player === null) {
+            throw new Exception('Planet has no owner.');
+        }
+
         // Check prior levels from queues.
         if ($object->type === GameObjectType::Research) {
-            $current_level = $planet->getPlayer()->getResearchLevel($object->machine_name);
+            $current_level = $player->getResearchLevel($object->machine_name);
         } else {
             $current_level = $planet->getObjectLevel($object->machine_name);
         }
 
         for ($i = $current_level + 1; $i < $target_level; $i++) {
-            if (!$planet->isBuildingObject($object->machine_name, $i) && !$planet->getPlayer()->isResearchingTech($object->machine_name, $i)) {
+            if (!$planet->isBuildingObject($object->machine_name, $i) && !$player->isResearchingTech($object->machine_name, $i)) {
                 return false;
             }
         }
@@ -990,7 +1019,12 @@ class ObjectService
                             // Get the current level of the requiring object
                             $requiring_object_level = 0;
                             if ($checkObject->type === GameObjectType::Research) {
-                                $requiring_object_level = $planet->getPlayer()->getResearchLevel($checkObject->machine_name);
+                                $player = $planet->getPlayer();
+                                if ($player === null) {
+                                    throw new Exception('Planet has no owner.');
+                                }
+
+                                $requiring_object_level = $player->getResearchLevel($checkObject->machine_name);
                             } else {
                                 $requiring_object_level = $planet->getObjectLevel($checkObject->machine_name);
                             }

--- a/app/Services/PlanetListService.php
+++ b/app/Services/PlanetListService.php
@@ -148,7 +148,12 @@ class PlanetListService
         }
 
         // No valid current planet set, return first planet instead.
-        return $this->first();
+        $firstPlanet = $this->first();
+        if ($firstPlanet === null) {
+            throw new Exception('Player has no planets.');
+        }
+
+        return $firstPlanet;
     }
 
     /**

--- a/app/Services/PlanetMoveService.php
+++ b/app/Services/PlanetMoveService.php
@@ -12,6 +12,7 @@ use OGame\Models\FleetMission;
 use OGame\Models\Planet;
 use OGame\Models\Planet\Coordinate;
 use OGame\Models\PlanetMove;
+use RuntimeException;
 
 class PlanetMoveService
 {
@@ -32,7 +33,10 @@ class PlanetMoveService
             return 0;
         }
 
-        return (int) max(0, ((int) $lastMove->updated_at->timestamp + 86400) - (int) Date::now()->timestamp);
+        $updatedAt = $lastMove->updated_at;
+        $updatedTimestamp = $updatedAt !== null ? (int) $updatedAt->timestamp : 0;
+
+        return (int) max(0, ($updatedTimestamp + 86400) - (int) Date::now()->timestamp);
     }
 
     /**
@@ -100,6 +104,10 @@ class PlanetMoveService
 
         // Load the planet being moved.
         $planet = $planetServiceFactory->make($move->planet_id);
+        if ($planet === null) {
+            $this->cancelMove($move);
+            return false;
+        }
 
         // Re-validate no active building queue.
         $buildingQueue = $buildingQueueService->retrieveQueueItems($planet);
@@ -130,7 +138,12 @@ class PlanetMoveService
         }
 
         // Re-validate DM affordability.
-        $user = $planet->getPlayer()->getUser();
+        $planetPlayer = $planet->getPlayer();
+        if ($planetPlayer === null) {
+            $this->cancelMove($move);
+            return false;
+        }
+        $user = $planetPlayer->getUser();
         $cost = (int) $settingsService->get('planet_relocation_cost', 240000);
         if (!$darkMatterService->canAfford($user, $cost)) {
             $this->cancelMove($move);
@@ -142,6 +155,10 @@ class PlanetMoveService
 
         // Save old coordinates before updating.
         $planetModel = Planet::find($move->planet_id);
+        if ($planetModel === null) {
+            $this->cancelMove($move);
+            return false;
+        }
         $oldCoordinate = new Coordinate($planetModel->galaxy, $planetModel->system, $planetModel->planet);
 
         // Move planet coordinates and recalculate temperature.
@@ -158,6 +175,9 @@ class PlanetMoveService
         if ($planet->hasMoon()) {
             $moon = $planet->moon();
             $moonModel = Planet::find($moon->getPlanetId());
+            if ($moonModel === null) {
+                throw new RuntimeException('Moon model not found for relocated planet.');
+            }
             $moonModel->galaxy = $move->target_galaxy;
             $moonModel->system = $move->target_system;
             $moonModel->planet = $move->target_position;
@@ -205,7 +225,7 @@ class PlanetMoveService
             $planetIds[] = $planet->moon()->getPlanetId();
         }
         FleetMission::whereIn('planet_id_to', $planetIds)
-            ->where('user_id', '!=', $planet->getPlayer()->getId())
+            ->where('user_id', '!=', $planetPlayer->getId())
             ->where('processed', 0)
             ->update(['planet_id_to' => null]);
 
@@ -214,7 +234,7 @@ class PlanetMoveService
 
         // Send success message to the player.
         $messageService = resolve(MessageService::class);
-        $messageService->sendSystemMessageToPlayer($planet->getPlayer(), PlanetRelocationSuccess::class, [
+        $messageService->sendSystemMessageToPlayer($planetPlayer, PlanetRelocationSuccess::class, [
             'planet_name' => $planet->getPlanetName(),
             'old_coordinates' => $oldCoordinate->asString(),
             'new_coordinates' => $targetCoordinate->asString(),
@@ -234,9 +254,14 @@ class PlanetMoveService
         FleetMissionService $fleetMissionService,
         SettingsService $settingsService,
     ): void {
+        $planetPlayer = $planet->getPlayer();
+        if ($planetPlayer === null) {
+            throw new RuntimeException('Planet has no owner for ship transfer mission.');
+        }
+
         // Calculate flight duration using a simple distance formula.
         $distance = $this->calculateCoordinateDistance($oldCoordinate, $newCoordinate);
-        $slowestSpeed = $shipUnits->getSlowestUnitSpeed($planet->getPlayer());
+        $slowestSpeed = $shipUnits->getSlowestUnitSpeed($planetPlayer);
         $fleetSpeed = $settingsService->fleetSpeedPeaceful();
         $duration = (int) max(round((35000 / 10 * sqrt($distance * 10 / $slowestSpeed) + 10) / $fleetSpeed), 1);
 
@@ -244,7 +269,7 @@ class PlanetMoveService
 
         // Create the fleet mission record directly (bypasses GameMission::start()).
         $mission = new FleetMission();
-        $mission->user_id = $planet->getPlayer()->getId();
+        $mission->user_id = $planetPlayer->getId();
         $mission->planet_id_from = $planet->getPlanetId();
         $mission->planet_id_to = $planet->getPlanetId();
         $mission->galaxy_from = $oldCoordinate->galaxy;

--- a/app/Services/PlanetService.php
+++ b/app/Services/PlanetService.php
@@ -70,7 +70,7 @@ class PlanetService
         // but this can be fine for unittests or when creating a new planet.
         if ($planet !== null) {
             $this->planet = $planet;
-        } elseif ($planet_id !== 0) {
+        } elseif ($planet_id !== null && $planet_id !== 0) {
             $this->loadByPlanetId($planet_id);
         }
 
@@ -268,8 +268,9 @@ class PlanetService
         PlanetMove::where('planet_id', $this->planet->id)->delete();
 
         // Update the player's current planet if it is the planet being abandoned.
-        if ($this->getPlayer()->getCurrentPlanetId() === $this->planet->id) {
-            $this->getPlayer()->setCurrentPlanetId(0);
+        $player = $this->getPlayer();
+        if ($player !== null && $player->getCurrentPlanetId() === $this->planet->id) {
+            $player->setCurrentPlanetId(0);
         }
 
         // TODO: add feature test to check that abandoning a planet works correctly in various scenarios.
@@ -1022,13 +1023,18 @@ class PlanetService
     {
         $research_lab_level = $this->getObjectLevel('research_lab');
 
+        $player = $this->getPlayer();
+        if ($player === null) {
+            throw new RuntimeException('Planet has no owner.');
+        }
+
         // The Intergalactic Research Network technology enables multiple research labs
         // across different planets to collaborate, significantly reducing research times.
-        $irn_level = $this->getPlayer()->getResearchLevel('intergalactic_research_network');
+        $irn_level = $player->getResearchLevel('intergalactic_research_network');
         if ($irn_level > 0) {
             // Get the research lab levels of all planets in the player's possession.
             $research_lab_levels = [];
-            foreach ($this->getPlayer()->planets->allPlanets() as $planet) {
+            foreach ($player->planets->allPlanets() as $planet) {
                 // Check if the object's requirements are met on the planet;
                 // otherwise, the planet's research lab cannot be included in the research network.
                 if (!ObjectService::objectRequirementsMet($machine_name, $planet)) {
@@ -1360,9 +1366,14 @@ class PlanetService
             return false;
         }
 
+        $player = $this->getPlayer();
+        if ($player === null) {
+            throw new RuntimeException('Planet has no owner.');
+        }
+
         // Access all players planets and see if there is a moon with the same coordinates
         // as this planet.
-        if ($this->getPlayer()->planets->getMoonByCoordinates($this->getPlanetCoordinates()) !== null) {
+        if ($player->planets->getMoonByCoordinates($this->getPlanetCoordinates()) !== null) {
             return true;
         }
 
@@ -1376,7 +1387,12 @@ class PlanetService
      */
     public function moon(): PlanetService
     {
-        $moon = $this->getPlayer()->planets->getMoonByCoordinates($this->getPlanetCoordinates());
+        $player = $this->getPlayer();
+        if ($player === null) {
+            throw new RuntimeException('Planet has no owner.');
+        }
+
+        $moon = $player->planets->getMoonByCoordinates($this->getPlanetCoordinates());
 
         if ($moon === null) {
             throw new RuntimeException('No moon found for this planet.');
@@ -1414,9 +1430,14 @@ class PlanetService
             return false;
         }
 
+        $player = $this->getPlayer();
+        if ($player === null) {
+            throw new RuntimeException('Planet has no owner.');
+        }
+
         // Access all players planets and see if there is a moon with the same coordinates
         // as this planet.
-        if ($this->getPlayer()->planets->getPlanetByCoordinates($this->getPlanetCoordinates()) !== null) {
+        if ($player->planets->getPlanetByCoordinates($this->getPlanetCoordinates()) !== null) {
             return true;
         }
 
@@ -1430,7 +1451,12 @@ class PlanetService
      */
     public function planet(): PlanetService
     {
-        $moon = $this->getPlayer()->planets->getPlanetByCoordinates($this->getPlanetCoordinates());
+        $player = $this->getPlayer();
+        if ($player === null) {
+            throw new RuntimeException('Planet has no owner.');
+        }
+
+        $moon = $player->planets->getPlanetByCoordinates($this->getPlanetCoordinates());
 
         if ($moon === null) {
             throw new RuntimeException('No planet found for this moon.');
@@ -1453,7 +1479,12 @@ class PlanetService
     public function updateBuildingQueue(bool $save_planet = true): void
     {
         // Skip building queue processing if player is in vacation mode
-        if ($this->getPlayer()->isInVacationMode()) {
+        $player = $this->getPlayer();
+        if ($player === null) {
+            throw new RuntimeException('Planet has no owner.');
+        }
+
+        if ($player->isInVacationMode()) {
             return;
         }
 
@@ -1556,7 +1587,12 @@ class PlanetService
     public function updateUnitQueue(bool $save_planet = true): void
     {
         // Skip unit queue processing if player is in vacation mode
-        if ($this->getPlayer()->isInVacationMode()) {
+        $player = $this->getPlayer();
+        if ($player === null) {
+            throw new RuntimeException('Planet has no owner.');
+        }
+
+        if ($player->isInVacationMode()) {
             return;
         }
 
@@ -1906,7 +1942,12 @@ class PlanetService
         }
 
         // Players in vacation mode have zero basic income.
-        if ($this->getPlayer()->isInVacationMode()) {
+        $player = $this->getPlayer();
+        if ($player === null) {
+            throw new RuntimeException('Planet has no owner.');
+        }
+
+        if ($player->isInVacationMode()) {
             return new Resources(0, 0, 0, 0);
         }
 

--- a/app/Services/PlayerService.php
+++ b/app/Services/PlayerService.php
@@ -97,6 +97,10 @@ class PlayerService
     {
         // Fetch user from model
         $user = User::with('highscore')->where('id', $id)->first();
+        if ($user === null) {
+            throw new RuntimeException('User not found.');
+        }
+
         $this->user = $user;
 
         // Fetch user tech from model
@@ -481,7 +485,12 @@ class PlayerService
     {
         if (!$this->user->planet_current) {
             // If no current planet is set, return the first planet of the player.
-            return $this->planets->first()->getPlanetId();
+            $firstPlanet = $this->planets->first();
+            if ($firstPlanet === null) {
+                throw new RuntimeException('Player has no planets.');
+            }
+
+            return $firstPlanet->getPlanetId();
         }
 
         return $this->user->planet_current;

--- a/app/Services/ResearchQueueService.php
+++ b/app/Services/ResearchQueueService.php
@@ -162,12 +162,17 @@ class ResearchQueueService
      */
     public function retrieveQueue(PlanetService $planet): ResearchQueueListViewModel
     {
+        $player = $planet->getPlayer();
+        if ($player === null) {
+            throw new Exception('Planet has no owner.');
+        }
+
         // Fetch queue items from model
         $queue_items = $this->model
             ->join('planets', 'research_queues.planet_id', '=', 'planets.id')
             ->join('users', 'planets.user_id', '=', 'users.id')
             ->where([
-                ['users.id', $planet->getPlayer()->getId()],
+                ['users.id', $player->getId()],
                 ['research_queues.processed', 0],
                 ['research_queues.canceled', 0],
             ])
@@ -180,7 +185,7 @@ class ResearchQueueService
         $list = [];
         foreach ($queue_items as $item) {
             $object = ObjectService::getResearchObjectById($item->object_id);
-            $planetService = $planet->getPlayer()->planets->getById($item['planet_id']);
+            $planetService = $player->planets->getById($item['planet_id']);
             $time_countdown = $item->time_end - (int)Date::now()->timestamp;
             if ($time_countdown < 0) {
                 $time_countdown = 0;
@@ -212,6 +217,11 @@ class ResearchQueueService
      */
     public function retrieveQueueForPlanet(PlanetService $planet): ResearchQueueListViewModel
     {
+        $player = $planet->getPlayer();
+        if ($player === null) {
+            throw new Exception('Planet has no owner.');
+        }
+
         // Fetch queue items from model scoped to this specific planet.
         $queue_items = $this->model
             ->where([
@@ -227,7 +237,7 @@ class ResearchQueueService
         $list = [];
         foreach ($queue_items as $item) {
             $object = ObjectService::getResearchObjectById($item->object_id);
-            $planetService = $planet->getPlayer()->planets->getById($item['planet_id']);
+            $planetService = $player->planets->getById($item['planet_id']);
             $time_countdown = $item->time_end - (int)Date::now()->timestamp;
             if ($time_countdown < 0) {
                 $time_countdown = 0;

--- a/app/Services/WreckFieldService.php
+++ b/app/Services/WreckFieldService.php
@@ -142,6 +142,10 @@ class WreckFieldService
      */
     public function getCoordinates(): Coordinate
     {
+        if ($this->wreckField === null) {
+            throw new Exception('No wreck field loaded.');
+        }
+
         return new Coordinate($this->wreckField->galaxy, $this->wreckField->system, $this->wreckField->planet);
     }
 

--- a/database/migrations/2024_05_17_213750_add_roles.php
+++ b/database/migrations/2024_05_17_213750_add_roles.php
@@ -28,6 +28,9 @@ return new class () extends Migration {
         if (!$legorExists && !$planetExists) {
             // Get admin role ID
             $adminRole = Role::where('name', 'admin')->first();
+            if ($adminRole === null) {
+                throw new RuntimeException('Admin role not found.');
+            }
 
             // Insert Legor user with ID 1
             $legorId = DB::table('users')->insertGetId([
@@ -91,6 +94,9 @@ return new class () extends Migration {
 
         if ($firstUserId !== null) {
             $adminRole = Role::where('name', 'admin')->first();
+            if ($adminRole === null) {
+                throw new RuntimeException('Admin role not found.');
+            }
             $adminRoleId = (int) $adminRole->id;
 
             // Assign admin role

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -19,7 +19,7 @@ parameters:
         - resources/
 
     # Level 9 is the highest level
-    level: 7
+    level: 8
 
     phpVersion: 80500
     ignoreErrors:

--- a/tests/AccountTestCase.php
+++ b/tests/AccountTestCase.php
@@ -106,7 +106,11 @@ abstract class AccountTestCase extends TestCase
     public function reloadApplication(): void
     {
         $this->refreshApplication();
-        $this->be(User::find($this->currentUserId));
+        $user = User::find($this->currentUserId);
+        if ($user === null) {
+            $this->fail('Current user not found.');
+        }
+        $this->be($user);
     }
 
     /**
@@ -207,7 +211,7 @@ abstract class AccountTestCase extends TestCase
         $this->assertNotEmpty($planetId);
 
         $this->currentUserId = (int)$playerId;
-        $this->currentUsername = $playerName;
+        $this->currentUsername = (string)$playerName;
         $this->currentPlanetId = (int)$planetId;
 
         // Initialize the player service with factory.
@@ -301,7 +305,11 @@ abstract class AccountTestCase extends TestCase
             // Create and return a new PlanetService instance for the found planet.
             try {
                 $planetServiceFactory =  resolve(PlanetServiceFactory::class);
-                return $planetServiceFactory->make($planet_id[0]);
+                $foundPlanet = $planetServiceFactory->make($planet_id[0]);
+                if ($foundPlanet === null) {
+                    $this->fail('Failed to create planet service for planet id: ' . $planet_id[0]);
+                }
+                return $foundPlanet;
             } catch (Exception $e) {
                 $this->fail('Failed to create planet service for planet id: ' . $planet_id[0] . '. Error: ' . $e->getMessage());
             }
@@ -319,6 +327,9 @@ abstract class AccountTestCase extends TestCase
         // First get a nearby foreign planet to obtain its player
         $foreignPlanet = $this->getNearbyForeignPlanet();
         $foreignPlayer = $foreignPlanet->getPlayer();
+        if ($foreignPlayer === null) {
+            $this->fail('Foreign planet has no owner.');
+        }
 
         // Get a random empty coordinate near the current planet
         $coordinate = $this->getNearbyEmptyCoordinate();
@@ -388,7 +399,11 @@ abstract class AccountTestCase extends TestCase
             // Create and return a new PlanetService instance for the found planet.
             try {
                 $planetServiceFactory =  resolve(PlanetServiceFactory::class);
-                return $planetServiceFactory->make($planet_id[0]);
+                $foundPlanet = $planetServiceFactory->make($planet_id[0]);
+                if ($foundPlanet === null) {
+                    $this->fail('Failed to create planet service for planet id: ' . $planet_id[0]);
+                }
+                return $foundPlanet;
             } catch (Exception $e) {
                 $this->fail('Failed to create planet service for planet id: ' . $planet_id[0] . '. Error: ' . $e->getMessage());
             }
@@ -475,7 +490,11 @@ abstract class AccountTestCase extends TestCase
     {
         // Update current users planet buildings to allow for research by mutating database.
         try {
-            $this->planetService->getPlayer()->setResearchLevel($machine_name, $object_level);
+            $player = $this->planetService->getPlayer();
+            if ($player === null) {
+                $this->fail('Current planet has no owner.');
+            }
+            $player->setResearchLevel($machine_name, $object_level);
         } catch (Exception $e) {
             $this->fail('Failed to set research level for player. Error: ' . $e->getMessage());
         }
@@ -939,7 +958,11 @@ abstract class AccountTestCase extends TestCase
      */
     protected function switchToSecondPlanet(): void
     {
-        $response = $this->get('/overview?cp=' . $this->secondPlanetService->getPlanetId());
+        $secondPlanetService = $this->secondPlanetService;
+        if ($secondPlanetService === null) {
+            $this->fail('Second planet service is not initialized.');
+        }
+        $response = $this->get('/overview?cp=' . $secondPlanetService->getPlanetId());
         $response->assertStatus(200);
     }
 

--- a/tests/Feature/AdminAttackBlockTest.php
+++ b/tests/Feature/AdminAttackBlockTest.php
@@ -16,7 +16,11 @@ class AdminAttackBlockTest extends AccountTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->artisan('ogamex:admin:assign-role', ['username' => auth()->user()->username]);
+        $user = auth()->user();
+        if ($user === null) {
+            $this->fail('No authenticated user found.');
+        }
+        $this->artisan('ogamex:admin:assign-role', ['username' => $user->username]);
     }
 
     /**

--- a/tests/Feature/AdminStuckFleetMissionTest.php
+++ b/tests/Feature/AdminStuckFleetMissionTest.php
@@ -46,9 +46,21 @@ class AdminStuckFleetMissionTest extends AccountTestCase
         parent::tearDown();
     }
 
+    /**
+     * Returns the currently authenticated user's username.
+     */
+    private function currentUsername(): string
+    {
+        $user = auth()->user();
+        if ($user === null) {
+            $this->fail('Not authenticated.');
+        }
+        return $user->username;
+    }
+
     public function testAdminCanSeeBrokenOverdueMissionInServerAdministration(): void
     {
-        $this->artisan('ogamex:admin:assign-role', ['username' => auth()->user()->username]);
+        $this->artisan('ogamex:admin:assign-role', ['username' => $this->currentUsername()]);
 
         $victim = $this->createTrackedSecondaryUser();
         $returnMission = $this->createBrokenReturnMission($victim['user_id'], $victim['homeworld_id']);
@@ -64,7 +76,7 @@ class AdminStuckFleetMissionTest extends AccountTestCase
 
     public function testAdminCanRecoverBrokenReturnMissionToVictimHomeworld(): void
     {
-        $this->artisan('ogamex:admin:assign-role', ['username' => auth()->user()->username]);
+        $this->artisan('ogamex:admin:assign-role', ['username' => $this->currentUsername()]);
 
         $victim = $this->createTrackedSecondaryUser();
         $returnMission = $this->createBrokenReturnMission($victim['user_id'], $victim['homeworld_id']);
@@ -90,7 +102,7 @@ class AdminStuckFleetMissionTest extends AccountTestCase
 
     public function testAdminCanProcessOverdueMissionWithMissingDestination(): void
     {
-        $this->artisan('ogamex:admin:assign-role', ['username' => auth()->user()->username]);
+        $this->artisan('ogamex:admin:assign-role', ['username' => $this->currentUsername()]);
 
         $victim = $this->createTrackedSecondaryUser();
         $outboundMission = $this->createMissingDestinationOutboundMission($victim['user_id'], $victim['homeworld_id']);

--- a/tests/Feature/AdminTest.php
+++ b/tests/Feature/AdminTest.php
@@ -24,7 +24,11 @@ class AdminTest extends AccountTestCase
     public function testNormalUserAdminAccessDenied(): void
     {
         // Remove the admin role from the current user if it has it.
-        $this->artisan('ogamex:admin:remove-role', ['username' => auth()->user()->username]);
+        $authUser = auth()->user();
+        if ($authUser === null) {
+            $this->fail('Not authenticated.');
+        }
+        $this->artisan('ogamex:admin:remove-role', ['username' => $authUser->username]);
 
         // Verify that on overview page the admin bar doesn't show up.
         $response = $this->get('/overview');
@@ -44,7 +48,11 @@ class AdminTest extends AccountTestCase
     public function testAdminUserAdminAccessGranted(): void
     {
         // Create a new user and assign the admin role
-        $this->artisan('ogamex:admin:assign-role', ['username' => auth()->user()->username]);
+        $authUser = auth()->user();
+        if ($authUser === null) {
+            $this->fail('Not authenticated.');
+        }
+        $this->artisan('ogamex:admin:assign-role', ['username' => $authUser->username]);
 
         // Verify that on overview page the admin bar shows up.
         $response = $this->get('/overview');

--- a/tests/Feature/AllianceDepotSupplyRocketTest.php
+++ b/tests/Feature/AllianceDepotSupplyRocketTest.php
@@ -122,6 +122,9 @@ class AllianceDepotSupplyRocketTest extends AccountTestCase
         ]);
         $this->trackPlanet($buddyPlanet);
         $buddyPlanetService = $planetServiceFactory->make($buddyPlanet->id, true);
+        if ($buddyPlanetService === null) {
+            $this->fail('Buddy planet service is null.');
+        }
 
         // Add buddy relationship first
         $buddyService = resolve(BuddyService::class);
@@ -177,6 +180,9 @@ class AllianceDepotSupplyRocketTest extends AccountTestCase
 
         // Get deuterium before (from buddy's planet now, reload to get current values)
         $buddyPlanetService = $planetServiceFactory->make($buddyPlanetService->getPlanetId(), true);
+        if ($buddyPlanetService === null) {
+            $this->fail('Buddy planet service is null.');
+        }
         $deuteriumBefore = $buddyPlanetService->deuterium()->get();
 
         // Buddy sends supply rocket to extend hold time by 2 hours
@@ -191,6 +197,9 @@ class AllianceDepotSupplyRocketTest extends AccountTestCase
 
         // Assert deuterium was deducted from buddy's planet (10 light fighters * 2 deut/hour * 2 hours = 40)
         $buddyPlanetService = $planetServiceFactory->make($buddyPlanetService->getPlanetId(), true);
+        if ($buddyPlanetService === null) {
+            $this->fail('Buddy planet service is null.');
+        }
         $deuteriumAfter = $buddyPlanetService->deuterium()->get();
         $this->assertEquals(40, $deuteriumBefore - $deuteriumAfter, 'Should deduct 40 deuterium from buddy planet');
 
@@ -222,6 +231,9 @@ class AllianceDepotSupplyRocketTest extends AccountTestCase
         ]);
         $this->trackPlanet($buddyPlanet);
         $buddyPlanetService = $planetServiceFactory->make($buddyPlanet->id, true);
+        if ($buddyPlanetService === null) {
+            $this->fail('Buddy planet service is null.');
+        }
 
         // Add buddy relationship
         $buddyService = resolve(BuddyService::class);
@@ -273,6 +285,8 @@ class AllianceDepotSupplyRocketTest extends AccountTestCase
             ->whereNull('parent_id')
             ->first();
 
+        $this->assertNotNull($outboundMission, 'Outbound mission should exist');
+
         // Try to send supply rocket (5 cruisers * 30 deut/hour * 1 hour = 150 deuterium needed)
         $response = $this->post('/ajax/alliance-depot/send-supply-rocket', [
             'fleet_mission_id' => $outboundMission->id,
@@ -308,6 +322,9 @@ class AllianceDepotSupplyRocketTest extends AccountTestCase
         ]);
         $this->trackPlanet($buddyPlanet);
         $buddyPlanetService = $planetServiceFactory->make($buddyPlanet->id, true);
+        if ($buddyPlanetService === null) {
+            $this->fail('Buddy planet service is null.');
+        }
 
         // Add buddy relationship
         $buddyService = resolve(BuddyService::class);
@@ -360,6 +377,8 @@ class AllianceDepotSupplyRocketTest extends AccountTestCase
             ->where('planet_id_to', $buddyPlanetService->getPlanetId())
             ->whereNull('parent_id')
             ->first();
+
+        $this->assertNotNull($outboundMission, 'Outbound mission should exist');
 
         // Try to send supply rocket
         $response = $this->post('/ajax/alliance-depot/send-supply-rocket', [
@@ -427,6 +446,9 @@ class AllianceDepotSupplyRocketTest extends AccountTestCase
         ]);
         $this->trackPlanet($buddyPlanet);
         $buddyPlanetService = $planetServiceFactory->make($buddyPlanet->id, true);
+        if ($buddyPlanetService === null) {
+            $this->fail('Buddy planet service is null.');
+        }
 
         $buddyService = resolve(BuddyService::class);
         $request = $buddyService->sendRequest($this->currentUserId, $buddyUser->id);
@@ -490,7 +512,11 @@ class AllianceDepotSupplyRocketTest extends AccountTestCase
         $this->assertEquals(14400 + 7200, $outboundMission->time_holding, 'Hold time should be extended to 6 hours');
 
         // Switch back to original user (fleet owner)
-        $this->be(User::find($this->currentUserId));
+        $currentUser = User::find($this->currentUserId);
+        if ($currentUser === null) {
+            $this->fail('Current user not found.');
+        }
+        $this->be($currentUser);
 
         // Try to recall the fleet (should succeed)
         $response = $this->post('/ajax/fleet/dispatch/recall-fleet', [
@@ -533,6 +559,9 @@ class AllianceDepotSupplyRocketTest extends AccountTestCase
         ]);
         $this->trackPlanet($allianceMemberPlanet);
         $allianceMemberPlanetService = $planetServiceFactory->make($allianceMemberPlanet->id, true);
+        if ($allianceMemberPlanetService === null) {
+            $this->fail('Alliance member planet service is null.');
+        }
 
         // Add alliance member to alliance (bypass cooldown for testing)
         /** @phpstan-ignore assign.propertyType */
@@ -596,6 +625,9 @@ class AllianceDepotSupplyRocketTest extends AccountTestCase
 
         // Get deuterium before (from alliance member's planet now, reload to get current values)
         $allianceMemberPlanetService = $planetServiceFactory->make($allianceMemberPlanetService->getPlanetId(), true);
+        if ($allianceMemberPlanetService === null) {
+            $this->fail('Alliance member planet service is null.');
+        }
         $deuteriumBefore = $allianceMemberPlanetService->deuterium()->get();
 
         // Alliance member sends supply rocket to extend hold time by 2 hours
@@ -610,6 +642,9 @@ class AllianceDepotSupplyRocketTest extends AccountTestCase
 
         // Assert deuterium was deducted from alliance member's planet (10 light fighters * 2 deut/hour * 2 hours = 40)
         $allianceMemberPlanetService = $planetServiceFactory->make($allianceMemberPlanetService->getPlanetId(), true);
+        if ($allianceMemberPlanetService === null) {
+            $this->fail('Alliance member planet service is null.');
+        }
         $deuteriumAfter = $allianceMemberPlanetService->deuterium()->get();
         $this->assertEquals(40, $deuteriumBefore - $deuteriumAfter, 'Should deduct 40 deuterium from alliance member planet');
 

--- a/tests/Feature/AllianceTest.php
+++ b/tests/Feature/AllianceTest.php
@@ -72,6 +72,9 @@ class AllianceTest extends AccountTestCase
 
         // Verify user's alliance_id is updated
         $user = User::find($this->currentUserId);
+        if ($user === null) {
+            $this->fail('User not found.');
+        }
         $this->assertEquals($alliance->id, $user->alliance_id);
     }
 
@@ -266,6 +269,9 @@ class AllianceTest extends AccountTestCase
         $member = AllianceMember::where('alliance_id', $alliance->id)
             ->where('user_id', $newMember->id)
             ->first();
+        if ($member === null) {
+            $this->fail('Alliance member not found.');
+        }
         $this->assertEquals($rank->id, $member->rank_id);
     }
 
@@ -359,6 +365,9 @@ class AllianceTest extends AccountTestCase
 
         // Verify user's alliance_id cleared
         $user = User::find($this->currentUserId);
+        if ($user === null) {
+            $this->fail('User not found.');
+        }
         $this->assertNull($user->alliance_id);
     }
 
@@ -428,6 +437,9 @@ class AllianceTest extends AccountTestCase
 
         // Verify members' alliance_id cleared
         $user = User::find($this->currentUserId);
+        if ($user === null) {
+            $this->fail('User not found.');
+        }
         $this->assertNull($user->alliance_id);
         $member->refresh();
         $this->assertNull($member->alliance_id);
@@ -447,6 +459,9 @@ class AllianceTest extends AccountTestCase
         $founderMember = AllianceMember::where('alliance_id', $alliance->id)
             ->where('user_id', $this->currentUserId)
             ->first();
+        if ($founderMember === null) {
+            $this->fail('Founder member not found.');
+        }
 
         // Test all permissions
         $this->assertTrue($founderMember->hasPermission(AllianceRank::PERMISSION_SEE_APPLICATIONS));
@@ -485,6 +500,9 @@ class AllianceTest extends AccountTestCase
         $allianceMember = AllianceMember::where('alliance_id', $alliance->id)
             ->where('user_id', $member->id)
             ->first();
+        if ($allianceMember === null) {
+            $this->fail('Alliance member not found.');
+        }
 
         // Test permissions
         $this->assertTrue($allianceMember->hasPermission(AllianceRank::PERMISSION_SEE_MEMBERS));

--- a/tests/Feature/BanTest.php
+++ b/tests/Feature/BanTest.php
@@ -41,11 +41,23 @@ class BanTest extends AccountTestCase
     }
 
     /**
+     * Returns the currently authenticated user's username.
+     */
+    private function currentUsername(): string
+    {
+        $user = auth()->user();
+        if ($user === null) {
+            $this->fail('Not authenticated.');
+        }
+        return $user->username;
+    }
+
+    /**
      * Test that an admin can ban a player with a timed duration.
      */
     public function testBanPlayerWithDuration(): void
     {
-        $this->artisan('ogamex:admin:assign-role', ['username' => auth()->user()->username]);
+        $this->artisan('ogamex:admin:assign-role', ['username' => $this->currentUsername()]);
 
         $target = $this->createTrackedUser();
 
@@ -73,7 +85,7 @@ class BanTest extends AccountTestCase
      */
     public function testBanPlayerPermanently(): void
     {
-        $this->artisan('ogamex:admin:assign-role', ['username' => auth()->user()->username]);
+        $this->artisan('ogamex:admin:assign-role', ['username' => $this->currentUsername()]);
 
         $target = $this->createTrackedUser();
 
@@ -99,7 +111,7 @@ class BanTest extends AccountTestCase
      */
     public function testAdminCannotBeBanned(): void
     {
-        $this->artisan('ogamex:admin:assign-role', ['username' => auth()->user()->username]);
+        $this->artisan('ogamex:admin:assign-role', ['username' => $this->currentUsername()]);
 
         $targetAdmin = $this->createTrackedUser();
         $this->artisan('ogamex:admin:assign-role', ['username' => $targetAdmin->username]);
@@ -123,7 +135,7 @@ class BanTest extends AccountTestCase
      */
     public function testUnbanPlayer(): void
     {
-        $this->artisan('ogamex:admin:assign-role', ['username' => auth()->user()->username]);
+        $this->artisan('ogamex:admin:assign-role', ['username' => $this->currentUsername()]);
 
         $target = $this->createTrackedUser();
         Ban::create(['user_id' => $target->id, 'reason' => 'Some violation', 'banned_until' => null, 'canceled' => false]);
@@ -145,7 +157,7 @@ class BanTest extends AccountTestCase
      */
     public function testVacationModeRemainsAfterUnban(): void
     {
-        $this->artisan('ogamex:admin:assign-role', ['username' => auth()->user()->username]);
+        $this->artisan('ogamex:admin:assign-role', ['username' => $this->currentUsername()]);
 
         $target = $this->createTrackedUser();
         Ban::create(['user_id' => $target->id, 'reason' => 'Some violation', 'banned_until' => null, 'canceled' => false]);

--- a/tests/Feature/ChatTest.php
+++ b/tests/Feature/ChatTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use OGame\Models\Alliance;
 use OGame\Models\User;
 use OGame\Services\AllianceService;
 use OGame\Services\BuddyService;
@@ -16,7 +17,7 @@ class ChatTest extends AccountTestCase
     /**
      * Create an alliance for the current user via the AllianceService.
      */
-    private function createAllianceForCurrentUser(): \OGame\Models\Alliance
+    private function createAllianceForCurrentUser(): Alliance
     {
         $allianceService = resolve(AllianceService::class);
         $tag = 'CT' . substr(md5(uniqid((string) mt_rand(), true)), 0, 5);
@@ -192,9 +193,15 @@ class ChatTest extends AccountTestCase
         $conversation = $chatService->getConversation($this->currentUserId, $otherUser->id);
 
         $this->assertCount(3, $conversation);
-        $this->assertEquals('Message 1', $conversation[0]->message);
-        $this->assertEquals('Message 2', $conversation[1]->message);
-        $this->assertEquals('Message 3', $conversation[2]->message);
+        $message0 = $conversation[0];
+        $message1 = $conversation[1];
+        $message2 = $conversation[2];
+        if ($message0 === null || $message1 === null || $message2 === null) {
+            $this->fail('Conversation message missing.');
+        }
+        $this->assertEquals('Message 1', $message0->message);
+        $this->assertEquals('Message 2', $message1->message);
+        $this->assertEquals('Message 3', $message2->message);
     }
 
     /**
@@ -314,6 +321,9 @@ class ChatTest extends AccountTestCase
 
         // Verify conversation data structure
         $user1Conv = collect($conversations)->firstWhere('partner_id', $user1->id);
+        if ($user1Conv === null) {
+            $this->fail('Conversation not found.');
+        }
         $this->assertEquals($user1->username, $user1Conv['partner_name']);
         $this->assertEquals('Hello user1', $user1Conv['last_message']);
     }

--- a/tests/Feature/ExpeditionDiscovererCombatReductionTest.php
+++ b/tests/Feature/ExpeditionDiscovererCombatReductionTest.php
@@ -4,7 +4,9 @@ namespace Tests\Feature;
 
 use Exception;
 use OGame\Enums\CharacterClass;
+use OGame\GameMissions\ExpeditionMission;
 use OGame\GameMissions\Models\ExpeditionOutcomeType;
+use OGame\Models\FleetMission;
 use OGame\Models\Resources;
 use OGame\Services\SettingsService;
 use ReflectionClass;
@@ -62,11 +64,16 @@ class ExpeditionDiscovererCombatReductionTest extends FleetDispatchTestCase
      */
     protected function tearDown(): void
     {
+        $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('Player not found.');
+        }
+
         // Delete any test missions we created
-        \OGame\Models\FleetMission::where('user_id', $this->planetService->getPlayer()->getUser()->id)->delete();
+        FleetMission::where('user_id', $player->getUser()->id)->delete();
 
         // Reset character class
-        $user = $this->planetService->getPlayer()->getUser();
+        $user = $player->getUser();
         $user->character_class = null;
         $user->save();
 
@@ -97,11 +104,15 @@ class ExpeditionDiscovererCombatReductionTest extends FleetDispatchTestCase
         $settingsService->set('expedition_weight_merchant', 0);
 
         // Create a test mission for Discoverer
-        $user = $this->planetService->getPlayer()->getUser();
+        $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('Player not found.');
+        }
+        $user = $player->getUser();
         $user->character_class = CharacterClass::DISCOVERER->value;
         $user->save();
 
-        $discovererMission = new \OGame\Models\FleetMission();
+        $discovererMission = new FleetMission();
         $discovererMission->user_id = $user->id;
         $discovererMission->mission_type = 15;
         $discovererMission->save();
@@ -110,7 +121,7 @@ class ExpeditionDiscovererCombatReductionTest extends FleetDispatchTestCase
         $totalIterations = 1000;
         $discovererCombatCount = 0;
 
-        $expeditionMission = resolve(\OGame\GameMissions\ExpeditionMission::class);
+        $expeditionMission = resolve(ExpeditionMission::class);
         $reflection = new ReflectionClass($expeditionMission);
         $method = $reflection->getMethod('selectRandomOutcome');
         $method->setAccessible(true);
@@ -129,7 +140,7 @@ class ExpeditionDiscovererCombatReductionTest extends FleetDispatchTestCase
         $user->character_class = CharacterClass::COLLECTOR->value;
         $user->save();
 
-        $collectorMission = new \OGame\Models\FleetMission();
+        $collectorMission = new FleetMission();
         $collectorMission->user_id = $user->id;
         $collectorMission->mission_type = 15;
         $collectorMission->save();
@@ -195,7 +206,11 @@ class ExpeditionDiscovererCombatReductionTest extends FleetDispatchTestCase
         $this->basicSetup();
 
         // Set player as Discoverer
-        $user = $this->planetService->getPlayer()->getUser();
+        $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('Player not found.');
+        }
+        $user = $player->getUser();
         $user->character_class = CharacterClass::DISCOVERER->value;
         $user->save();
 
@@ -213,7 +228,7 @@ class ExpeditionDiscovererCombatReductionTest extends FleetDispatchTestCase
         $settingsService->set('expedition_weight_merchant', 0);
 
         // Create a test mission
-        $mission = new \OGame\Models\FleetMission();
+        $mission = new FleetMission();
         $mission->user_id = $user->id;
         $mission->mission_type = 15;
         $mission->save();
@@ -227,7 +242,7 @@ class ExpeditionDiscovererCombatReductionTest extends FleetDispatchTestCase
             'nothing' => 0,
         ];
 
-        $expeditionMission = resolve(\OGame\GameMissions\ExpeditionMission::class);
+        $expeditionMission = resolve(ExpeditionMission::class);
         $reflection = new ReflectionClass($expeditionMission);
         $method = $reflection->getMethod('selectRandomOutcome');
         $method->setAccessible(true);

--- a/tests/Feature/FacilitiesWreckFieldTest.php
+++ b/tests/Feature/FacilitiesWreckFieldTest.php
@@ -87,6 +87,9 @@ class FacilitiesWreckFieldTest extends AccountTestCase
             ->where('system', $coords->system)
             ->where('planet', $coords->position)
             ->first();
+        if ($wreckField === null) {
+            $this->fail('Wreck field not found.');
+        }
 
         $this->assertEquals('repairing', $wreckField->status);
         $this->assertNotNull($wreckField->repair_started_at);
@@ -229,6 +232,9 @@ class FacilitiesWreckFieldTest extends AccountTestCase
             ->where('system', $coords->system)
             ->where('planet', $coords->position)
             ->first();
+        if ($wreckField === null) {
+            $this->fail('Wreck field not found.');
+        }
 
         $this->assertEquals('burned', $wreckField->status);
     }

--- a/tests/Feature/FactoryTest.php
+++ b/tests/Feature/FactoryTest.php
@@ -3,7 +3,9 @@
 namespace Tests\Feature;
 
 use DB;
+use Illuminate\Support\Collection;
 use OGame\Factories\PlanetServiceFactory;
+use OGame\Factories\PlayerServiceFactory;
 use OGame\Models\Planet;
 use Tests\AccountTestCase;
 
@@ -32,7 +34,7 @@ class FactoryTest extends AccountTestCase
         }
 
         // Get the player service factory.
-        $playerServiceFactory =  resolve(\OGame\Factories\PlayerServiceFactory::class);
+        $playerServiceFactory =  resolve(PlayerServiceFactory::class);
 
         // Load the first user.
         $playerService1 = $playerServiceFactory->make($playerIds[0]);
@@ -64,22 +66,36 @@ class FactoryTest extends AccountTestCase
 
         // Load the first planet.
         $planetService1 = $planetServiceFactory->make($planet1->id);
+        if ($planetService1 === null) {
+            $this->fail('First planet service could not be loaded.');
+        }
         $this->assertEquals($planet1->id, $planetService1->getPlanetId());
-        $this->assertEquals($playerIds[0], $planetService1->getPlayer()->getId());
+        $player1 = $planetService1->getPlayer();
+        if ($player1 === null) {
+            $this->fail('First planet player could not be loaded.');
+        }
+        $this->assertEquals($playerIds[0], $player1->getId());
 
         // Load the second planet.
         $planetService2 = $planetServiceFactory->make($planet2->id);
+        if ($planetService2 === null) {
+            $this->fail('Second planet service could not be loaded.');
+        }
         $this->assertEquals($planet2->id, $planetService2->getPlanetId());
-        $this->assertEquals($playerIds[1], $planetService2->getPlayer()->getId());
+        $player2 = $planetService2->getPlayer();
+        if ($player2 === null) {
+            $this->fail('Second planet player could not be loaded.');
+        }
+        $this->assertEquals($playerIds[1], $player2->getId());
     }
 
     /**
      * Create users with planets and wait for planet creation to complete.
      *
      * @param int $count Number of users to create
-     * @return \Illuminate\Support\Collection<int, int>
+     * @return Collection<int, int>
      */
-    private function getPlayerIdsWithPlanets(int $count): \Illuminate\Support\Collection
+    private function getPlayerIdsWithPlanets(int $count): Collection
     {
         $playerIds = collect();
 

--- a/tests/Feature/FleetDispatch/FleetDispatchAcsAttackTest.php
+++ b/tests/Feature/FleetDispatch/FleetDispatchAcsAttackTest.php
@@ -167,6 +167,46 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         $this->planetAddResources(new Resources(0, 0, 1000000, 0));
     }
 
+    private function targetPlanet(): PlanetService
+    {
+        $planet = $this->targetPlanet;
+        if ($planet === null) {
+            $this->fail('targetPlanet is not initialized.');
+        }
+
+        return $planet;
+    }
+
+    private function allyPlanet(): PlanetService
+    {
+        $planet = $this->allyPlanet;
+        if ($planet === null) {
+            $this->fail('allyPlanet is not initialized.');
+        }
+
+        return $planet;
+    }
+
+    private function targetUser(): User
+    {
+        $user = $this->targetUser;
+        if ($user === null) {
+            $this->fail('targetUser is not initialized.');
+        }
+
+        return $user;
+    }
+
+    private function allyUser(): User
+    {
+        $user = $this->allyUser;
+        if ($user === null) {
+            $this->fail('allyUser is not initialized.');
+        }
+
+        return $user;
+    }
+
     /**
      * Create a target player (defender) with resources on their planet.
      */
@@ -181,7 +221,7 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         $this->targetUser = $targetUser;
 
         // Give the target some resources to loot
-        $this->targetPlanet->addResources(new Resources(100000, 100000, 100000, 0));
+        $this->targetPlanet()->addResources(new Resources(100000, 100000, 100000, 0));
 
         return $targetUser;
     }
@@ -197,11 +237,11 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         // Place ally in same system as the target to minimize travel time
         // (avoids exceeding the 30% delay limit when joining a union).
         // Find an empty slot in the target's system outside the allocator range (4-12).
-        $targetGalaxy  = $this->targetPlanet->getPlanetCoordinates()->galaxy;
-        $targetSystem  = $this->targetPlanet->getPlanetCoordinates()->system;
+        $targetGalaxy  = $this->targetPlanet()->getPlanetCoordinates()->galaxy;
+        $targetSystem  = $this->targetPlanet()->getPlanetCoordinates()->system;
         // Prefer positions close to the target (13-15) to minimize same-system travel distance.
         // Fall back to positions 1-3 if 13-15 are exhausted in this system.
-        $targetPosition = $this->targetPlanet->getPlanetCoordinates()->position;
+        $targetPosition = $this->targetPlanet()->getPlanetCoordinates()->position;
         $preferredOrder = array_filter([13, 14, 15, 1, 2, 3], fn ($p) => $p !== $targetPosition);
         $allyPosition = collect(array_values($preferredOrder))->first(
             fn ($p) => !Planet::where('galaxy', $targetGalaxy)->where('system', $targetSystem)->where('planet', $p)->exists()
@@ -219,8 +259,8 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         $this->allyUser = $allyUser;
 
         // Give ally some ships and fuel
-        $this->allyPlanet->addUnit('light_fighter', 30);
-        $this->allyPlanet->addResources(new Resources(0, 0, 1000000, 0));
+        $this->allyPlanet()->addUnit('light_fighter', 30);
+        $this->allyPlanet()->addResources(new Resources(0, 0, 1000000, 0));
 
         // Create buddy relationship between current player and ally
         $buddyService = resolve(BuddyService::class);
@@ -241,13 +281,16 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         // Send attack fleet to target
         $unitCollection = new UnitCollection();
         $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 10);
-        $this->dispatchFleet($this->targetPlanet->getPlanetCoordinates(), $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet);
+        $this->dispatchFleet($this->targetPlanet()->getPlanetCoordinates(), $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet);
 
         // Get the fleet mission
         $fleetMissionService = resolve(FleetMissionService::class);
         $activeMissions = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer();
         $this->assertCount(1, $activeMissions);
         $mission = $activeMissions->first();
+        if ($mission === null) {
+            $this->fail('No active mission found.');
+        }
         $this->assertEquals(1, $mission->mission_type, 'Mission should be type 1 (Attack) before union creation');
 
         // Create union via API
@@ -277,27 +320,30 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         // Send attack fleet to target
         $unitCollection = new UnitCollection();
         $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 10);
-        $this->dispatchFleet($this->targetPlanet->getPlanetCoordinates(), $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet);
+        $this->dispatchFleet($this->targetPlanet()->getPlanetCoordinates(), $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet);
 
         // Get the fleet mission
         $fleetMissionService = resolve(FleetMissionService::class);
         $mission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($mission === null) {
+            $this->fail('No active mission found.');
+        }
 
         // Create union with ally invited
         $response = $this->post('/ajax/fleet/union/create', [
             'fleetID' => $mission->id,
             'groupname' => 'TestUnion',
-            'unionUsers' => $this->currentUsername . ';' . $this->allyUser->username,
+            'unionUsers' => $this->currentUsername . ';' . $this->allyUser()->username,
             '_token' => csrf_token(),
         ]);
         $response->assertStatus(200);
 
         // Verify invite record was created
-        $invite = FleetUnionInvite::where('user_id', $this->allyUser->id)->first();
+        $invite = FleetUnionInvite::where('user_id', $this->allyUser()->id)->first();
         $this->assertNotNull($invite, 'Invite record should be created for the ally');
 
         // Verify invite message was sent to ally (check body contains sender name and "invited you")
-        $allyPlayerService = resolve(PlayerService::class, ['player_id' => $this->allyUser->id]);
+        $allyPlayerService = resolve(PlayerService::class, ['player_id' => $this->allyUser()->id]);
         $this->assertMessageReceivedAndContainsDatabase($allyPlayerService, [
             'invited you to mission',
             $this->currentUsername,
@@ -316,15 +362,18 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         // Send attack and create union with ally
         $unitCollection = new UnitCollection();
         $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 10);
-        $this->dispatchFleet($this->targetPlanet->getPlanetCoordinates(), $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet);
+        $this->dispatchFleet($this->targetPlanet()->getPlanetCoordinates(), $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet);
 
         $fleetMissionService = resolve(FleetMissionService::class);
         $mission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($mission === null) {
+            $this->fail('No active mission found.');
+        }
 
         $response = $this->post('/ajax/fleet/union/create', [
             'fleetID' => $mission->id,
             'groupname' => 'TestUnion',
-            'unionUsers' => $this->allyUser->username,
+            'unionUsers' => $this->allyUser()->username,
             '_token' => csrf_token(),
         ]);
         $response->assertStatus(200);
@@ -333,7 +382,7 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
 
         // Verify invite record exists
         $invite = FleetUnionInvite::where('fleet_union_id', $mission->union_id)
-            ->where('user_id', $this->allyUser->id)
+            ->where('user_id', $this->allyUser()->id)
             ->first();
         $this->assertNotNull($invite, 'Invite record should exist for the invited ally');
 
@@ -356,15 +405,18 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         // Send attack and create union
         $unitCollection = new UnitCollection();
         $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 10);
-        $this->dispatchFleet($this->targetPlanet->getPlanetCoordinates(), $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet);
+        $this->dispatchFleet($this->targetPlanet()->getPlanetCoordinates(), $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet);
 
         $fleetMissionService = resolve(FleetMissionService::class);
         $mission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($mission === null) {
+            $this->fail('No active mission found.');
+        }
 
         $this->post('/ajax/fleet/union/create', [
             'fleetID' => $mission->id,
             'groupname' => 'TestUnion',
-            'unionUsers' => $this->allyUser->username,
+            'unionUsers' => $this->allyUser()->username,
             '_token' => csrf_token(),
         ]);
         $mission->refresh();
@@ -387,10 +439,13 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         // Send attack and create union (invite nobody)
         $unitCollection = new UnitCollection();
         $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 10);
-        $this->dispatchFleet($this->targetPlanet->getPlanetCoordinates(), $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet);
+        $this->dispatchFleet($this->targetPlanet()->getPlanetCoordinates(), $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet);
 
         $fleetMissionService = resolve(FleetMissionService::class);
         $mission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($mission === null) {
+            $this->fail('No active mission found.');
+        }
 
         $this->post('/ajax/fleet/union/create', [
             'fleetID' => $mission->id,
@@ -403,9 +458,9 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         // Now check the available unions API as the ally (who was NOT invited)
         // The ally is a buddy but should NOT see the union without explicit invite
         $response = $this->get('/ajax/fleet/union/available?' . http_build_query([
-            'galaxy' => $this->targetPlanet->getPlanetCoordinates()->galaxy,
-            'system' => $this->targetPlanet->getPlanetCoordinates()->system,
-            'position' => $this->targetPlanet->getPlanetCoordinates()->position,
+            'galaxy' => $this->targetPlanet()->getPlanetCoordinates()->galaxy,
+            'system' => $this->targetPlanet()->getPlanetCoordinates()->system,
+            'position' => $this->targetPlanet()->getPlanetCoordinates()->position,
             'planet_type' => PlanetType::Planet->value,
         ]));
         $response->assertStatus(200);
@@ -427,21 +482,24 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         $this->createAllyPlayer();
 
         // Give target some defenses
-        $this->targetPlanet->addUnit('rocket_launcher', 5);
+        $this->targetPlanet()->addUnit('rocket_launcher', 5);
 
         // Send initiator attack fleet
         $unitCollection = new UnitCollection();
         $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 20);
-        $this->dispatchFleet($this->targetPlanet->getPlanetCoordinates(), $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet);
+        $this->dispatchFleet($this->targetPlanet()->getPlanetCoordinates(), $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet);
 
         // Get mission and create union
         $fleetMissionService = resolve(FleetMissionService::class);
         $initiatorMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($initiatorMission === null) {
+            $this->fail('No initiator mission found.');
+        }
 
         $this->post('/ajax/fleet/union/create', [
             'fleetID' => $initiatorMission->id,
             'groupname' => 'BattleUnion',
-            'unionUsers' => $this->allyUser->username,
+            'unionUsers' => $this->allyUser()->username,
             '_token' => csrf_token(),
         ]);
         $initiatorMission->refresh();
@@ -451,10 +509,10 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         $allyFleet = new UnitCollection();
         $allyFleet->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 15);
 
-        $allyFleetMissionService = resolve(FleetMissionService::class, ['player' => $this->allyPlanet->getPlayer()]);
+        $allyFleetMissionService = resolve(FleetMissionService::class, ['player' => $this->allyPlanet()->getPlayer()]);
         $allyMission = $allyFleetMissionService->createNewFromPlanet(
-            $this->allyPlanet,
-            $this->targetPlanet->getPlanetCoordinates(),
+            $this->allyPlanet(),
+            $this->targetPlanet()->getPlanetCoordinates(),
             PlanetType::Planet,
             1, // Attack
             $allyFleet,
@@ -466,6 +524,9 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         // Join the union
         $fleetUnionService = resolve(FleetUnionService::class);
         $union = FleetUnion::find($unionId);
+        if ($union === null) {
+            $this->fail('Union not found.');
+        }
         $fleetUnionService->joinUnion($union, $allyMission);
 
         // Verify both missions are in the union
@@ -487,7 +548,7 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
 
         // Verify both attackers participated: initiator sent 20 + ally sent 15 = 35 light fighters
         // (but may include additional units depending on test state, so check minimum)
-        $attackerStartUnits = $battleReport->attacker['units'];
+        $attackerStartUnits = $battleReport->attacker['units'] ?? [];
         $totalAttackerUnits = array_sum($attackerStartUnits);
         $this->assertGreaterThanOrEqual(35, $totalAttackerUnits, 'Both fleets should participate in battle (at least 20 + 15 light fighters)');
     }
@@ -504,16 +565,19 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         // Send initiator fleet
         $unitCollection = new UnitCollection();
         $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 20);
-        $this->dispatchFleet($this->targetPlanet->getPlanetCoordinates(), $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet);
+        $this->dispatchFleet($this->targetPlanet()->getPlanetCoordinates(), $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet);
 
         $fleetMissionService = resolve(FleetMissionService::class);
         $initiatorMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($initiatorMission === null) {
+            $this->fail('No initiator mission found.');
+        }
 
         // Create union
         $this->post('/ajax/fleet/union/create', [
             'fleetID' => $initiatorMission->id,
             'groupname' => 'ReturnTestUnion',
-            'unionUsers' => $this->allyUser->username,
+            'unionUsers' => $this->allyUser()->username,
             '_token' => csrf_token(),
         ]);
         $initiatorMission->refresh();
@@ -523,10 +587,10 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         $allyFleet = new UnitCollection();
         $allyFleet->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 15);
 
-        $allyFleetMissionService = resolve(FleetMissionService::class, ['player' => $this->allyPlanet->getPlayer()]);
+        $allyFleetMissionService = resolve(FleetMissionService::class, ['player' => $this->allyPlanet()->getPlayer()]);
         $allyMission = $allyFleetMissionService->createNewFromPlanet(
-            $this->allyPlanet,
-            $this->targetPlanet->getPlanetCoordinates(),
+            $this->allyPlanet(),
+            $this->targetPlanet()->getPlanetCoordinates(),
             PlanetType::Planet,
             1,
             $allyFleet,
@@ -537,6 +601,9 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
 
         $fleetUnionService = resolve(FleetUnionService::class);
         $union = FleetUnion::find($unionId);
+        if ($union === null) {
+            $this->fail('Union not found.');
+        }
         $fleetUnionService->joinUnion($union, $allyMission);
 
         // Advance to arrival
@@ -569,7 +636,7 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
             $this->assertEquals($this->currentUserId, $initiatorReturn->user_id, 'Initiator return should belong to initiator');
         }
         if ($hasAllyReturn) {
-            $this->assertEquals($this->allyUser->id, $allyReturn->user_id, 'Ally return should belong to ally');
+            $this->assertEquals($this->allyUser()->id, $allyReturn->user_id, 'Ally return should belong to ally');
         }
     }
 
@@ -584,10 +651,13 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         // Send attack fleet
         $unitCollection = new UnitCollection();
         $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 10);
-        $this->dispatchFleet($this->targetPlanet->getPlanetCoordinates(), $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet);
+        $this->dispatchFleet($this->targetPlanet()->getPlanetCoordinates(), $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet);
 
         $fleetMissionService = resolve(FleetMissionService::class);
         $mission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($mission === null) {
+            $this->fail('No active mission found.');
+        }
 
         $this->post('/ajax/fleet/union/create', [
             'fleetID' => $mission->id,
@@ -624,16 +694,19 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         // Send attack and create union with ally
         $unitCollection = new UnitCollection();
         $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 10);
-        $this->dispatchFleet($this->targetPlanet->getPlanetCoordinates(), $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet);
+        $this->dispatchFleet($this->targetPlanet()->getPlanetCoordinates(), $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet);
 
         $fleetMissionService = resolve(FleetMissionService::class);
         $mission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($mission === null) {
+            $this->fail('No active mission found.');
+        }
 
         // Create union with ally
         $this->post('/ajax/fleet/union/create', [
             'fleetID' => $mission->id,
             'groupname' => 'DupeTest',
-            'unionUsers' => $this->allyUser->username,
+            'unionUsers' => $this->allyUser()->username,
             '_token' => csrf_token(),
         ]);
         $mission->refresh();
@@ -643,13 +716,13 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         $this->post('/ajax/fleet/union/create', [
             'fleetID' => $mission->id,
             'groupname' => 'DupeTest',
-            'unionUsers' => $this->allyUser->username,
+            'unionUsers' => $this->allyUser()->username,
             '_token' => csrf_token(),
         ]);
 
         // Verify only one invite record exists
         $inviteCount = FleetUnionInvite::where('fleet_union_id', $unionId)
-            ->where('user_id', $this->allyUser->id)
+            ->where('user_id', $this->allyUser()->id)
             ->count();
         $this->assertEquals(1, $inviteCount, 'Should have exactly one invite record, not duplicates');
     }
@@ -666,16 +739,19 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         // Send initiator fleet
         $unitCollection = new UnitCollection();
         $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 20);
-        $this->dispatchFleet($this->targetPlanet->getPlanetCoordinates(), $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet);
+        $this->dispatchFleet($this->targetPlanet()->getPlanetCoordinates(), $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet);
 
         $fleetMissionService = resolve(FleetMissionService::class);
         $initiatorMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($initiatorMission === null) {
+            $this->fail('No initiator mission found.');
+        }
 
         // Create union
         $this->post('/ajax/fleet/union/create', [
             'fleetID' => $initiatorMission->id,
             'groupname' => 'RecallSlotTest',
-            'unionUsers' => $this->allyUser->username,
+            'unionUsers' => $this->allyUser()->username,
             '_token' => csrf_token(),
         ]);
         $initiatorMission->refresh();
@@ -685,10 +761,10 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         $allyFleet = new UnitCollection();
         $allyFleet->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 15);
 
-        $allyFleetMissionService = resolve(FleetMissionService::class, ['player' => $this->allyPlanet->getPlayer()]);
+        $allyFleetMissionService = resolve(FleetMissionService::class, ['player' => $this->allyPlanet()->getPlayer()]);
         $allyMission = $allyFleetMissionService->createNewFromPlanet(
-            $this->allyPlanet,
-            $this->targetPlanet->getPlanetCoordinates(),
+            $this->allyPlanet(),
+            $this->targetPlanet()->getPlanetCoordinates(),
             PlanetType::Planet,
             1,
             $allyFleet,
@@ -699,6 +775,9 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
 
         $fleetUnionService = resolve(FleetUnionService::class);
         $union = FleetUnion::find($unionId);
+        if ($union === null) {
+            $this->fail('Union not found.');
+        }
         $fleetUnionService->joinUnion($union, $allyMission);
 
         // Verify ally is slot 2
@@ -711,7 +790,11 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         $this->reloadApplication();
 
         // Recall ally's fleet: switch to ally user context
-        $this->be(User::find($this->allyUser->id));
+        $allyUserModel = User::find($this->allyUser()->id);
+        if ($allyUserModel === null) {
+            $this->fail('Ally user not found.');
+        }
+        $this->be($allyUserModel);
         $response = $this->post('/ajax/fleet/dispatch/recall-fleet', [
             'fleet_mission_id' => $allyMission->id,
             '_token' => csrf_token(),
@@ -727,11 +810,10 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         // Verify a return mission was created for the ally
         $allyReturn = FleetMission::where('parent_id', $allyMission->id)->where('canceled', 0)->first();
         $this->assertNotNull($allyReturn, 'Ally should have a return mission');
-        $this->assertEquals($this->allyUser->id, $allyReturn->user_id, 'Return mission should belong to ally');
+        $this->assertEquals($this->allyUser()->id, $allyReturn->user_id, 'Return mission should belong to ally');
 
         // Verify union still exists with initiator as slot 1
         $union->refresh();
-        $this->assertNotNull($union, 'Union should still exist');
         $initiatorMission->refresh();
         $this->assertEquals(1, $initiatorMission->union_slot, 'Initiator should still be slot 1');
         $this->assertEquals($unionId, $initiatorMission->union_id, 'Initiator should still be in the union');
@@ -750,16 +832,19 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         // Send initiator fleet
         $unitCollection = new UnitCollection();
         $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 20);
-        $this->dispatchFleet($this->targetPlanet->getPlanetCoordinates(), $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet);
+        $this->dispatchFleet($this->targetPlanet()->getPlanetCoordinates(), $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet);
 
         $fleetMissionService = resolve(FleetMissionService::class);
         $initiatorMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($initiatorMission === null) {
+            $this->fail('No initiator mission found.');
+        }
 
         // Create union
         $this->post('/ajax/fleet/union/create', [
             'fleetID' => $initiatorMission->id,
             'groupname' => 'InitiatorRecallTest',
-            'unionUsers' => $this->allyUser->username,
+            'unionUsers' => $this->allyUser()->username,
             '_token' => csrf_token(),
         ]);
         $initiatorMission->refresh();
@@ -769,10 +854,10 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         $allyFleet = new UnitCollection();
         $allyFleet->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 15);
 
-        $allyFleetMissionService = resolve(FleetMissionService::class, ['player' => $this->allyPlanet->getPlayer()]);
+        $allyFleetMissionService = resolve(FleetMissionService::class, ['player' => $this->allyPlanet()->getPlayer()]);
         $allyMission = $allyFleetMissionService->createNewFromPlanet(
-            $this->allyPlanet,
-            $this->targetPlanet->getPlanetCoordinates(),
+            $this->allyPlanet(),
+            $this->targetPlanet()->getPlanetCoordinates(),
             PlanetType::Planet,
             1,
             $allyFleet,
@@ -783,6 +868,9 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
 
         $fleetUnionService = resolve(FleetUnionService::class);
         $union = FleetUnion::find($unionId);
+        if ($union === null) {
+            $this->fail('Union not found.');
+        }
         $fleetUnionService->joinUnion($union, $allyMission);
 
         // Verify initial state: initiator = slot 1, ally = slot 2, union owned by initiator
@@ -814,14 +902,18 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         $allyMission->refresh();
         $union->refresh();
         $this->assertEquals(1, $allyMission->union_slot, 'Ally should now be slot 1 (new initiator)');
-        $this->assertEquals($this->allyUser->id, $union->user_id, 'Union ownership should transfer to ally');
+        $this->assertEquals($this->allyUser()->id, $union->user_id, 'Union ownership should transfer to ally');
 
         // Verify battle still processes at arrival (ally as slot 1).
         // The ally's mission goes from ally planet → target planet, so we need to trigger
         // processing from the target's perspective (the target planet is the destination).
         $this->travelTo(Date::createFromTimestamp($allyMission->time_arrival + 10));
         $this->refreshApplication();
-        $this->be(User::find($this->targetUser->id));
+        $targetUserModel = User::find($this->targetUser()->id);
+        if ($targetUserModel === null) {
+            $this->fail('Target user not found.');
+        }
+        $this->be($targetUserModel);
         $this->get('/overview');
 
         $battleReport = BattleReport::orderBy('id', 'desc')->first();
@@ -843,24 +935,27 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         $this->createAllyPlayer();
 
         // Give ally impulse drive for faster natural speed
-        $allyPlayerService = resolve(PlayerService::class, ['player_id' => $this->allyUser->id]);
+        $allyPlayerService = resolve(PlayerService::class, ['player_id' => $this->allyUser()->id]);
         $allyPlayerService->setResearchLevel('impulse_drive', 5);
         $allyPlayerService->setResearchLevel('combustion_drive', 5);
 
         // Send initiator fleet (slower)
         $unitCollection = new UnitCollection();
         $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 10);
-        $this->dispatchFleet($this->targetPlanet->getPlanetCoordinates(), $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet);
+        $this->dispatchFleet($this->targetPlanet()->getPlanetCoordinates(), $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet);
 
         $fleetMissionService = resolve(FleetMissionService::class);
         $initiatorMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($initiatorMission === null) {
+            $this->fail('No initiator mission found.');
+        }
         $initiatorOutboundDuration = $initiatorMission->time_arrival - $initiatorMission->time_departure;
 
         // Create union
         $this->post('/ajax/fleet/union/create', [
             'fleetID' => $initiatorMission->id,
             'groupname' => 'SpeedTest',
-            'unionUsers' => $this->allyUser->username,
+            'unionUsers' => $this->allyUser()->username,
             '_token' => csrf_token(),
         ]);
         $initiatorMission->refresh();
@@ -871,10 +966,10 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         $allyFleet = new UnitCollection();
         $allyFleet->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 10);
 
-        $allyFleetMissionService = resolve(FleetMissionService::class, ['player' => $this->allyPlanet->getPlayer()]);
+        $allyFleetMissionService = resolve(FleetMissionService::class, ['player' => $this->allyPlanet()->getPlayer()]);
         $allyMission = $allyFleetMissionService->createNewFromPlanet(
-            $this->allyPlanet,
-            $this->targetPlanet->getPlanetCoordinates(),
+            $this->allyPlanet(),
+            $this->targetPlanet()->getPlanetCoordinates(),
             PlanetType::Planet,
             1,
             $allyFleet,
@@ -889,6 +984,9 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         // Join union — ally's arrival should be pushed out to match the union's time
         $fleetUnionService = resolve(FleetUnionService::class);
         $union = FleetUnion::find($unionId);
+        if ($union === null) {
+            $this->fail('Union not found.');
+        }
         $fleetUnionService->joinUnion($union, $allyMission);
         $allyMission->refresh();
 
@@ -903,7 +1001,11 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         $this->reloadApplication();
 
         // Recall ally's fleet
-        $this->be(User::find($this->allyUser->id));
+        $allyUserModel = User::find($this->allyUser()->id);
+        if ($allyUserModel === null) {
+            $this->fail('Ally user not found.');
+        }
+        $this->be($allyUserModel);
         $response = $this->post('/ajax/fleet/dispatch/recall-fleet', [
             'fleet_mission_id' => $allyMission->id,
             '_token' => csrf_token(),
@@ -932,16 +1034,19 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         // Send initiator fleet
         $unitCollection = new UnitCollection();
         $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 20);
-        $this->dispatchFleet($this->targetPlanet->getPlanetCoordinates(), $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet);
+        $this->dispatchFleet($this->targetPlanet()->getPlanetCoordinates(), $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet);
 
         $fleetMissionService = resolve(FleetMissionService::class);
         $initiatorMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($initiatorMission === null) {
+            $this->fail('No initiator mission found.');
+        }
 
         // Create union
         $this->post('/ajax/fleet/union/create', [
             'fleetID' => $initiatorMission->id,
             'groupname' => 'ProcessTest',
-            'unionUsers' => $this->allyUser->username,
+            'unionUsers' => $this->allyUser()->username,
             '_token' => csrf_token(),
         ]);
         $initiatorMission->refresh();
@@ -951,10 +1056,10 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         $allyFleet = new UnitCollection();
         $allyFleet->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 10);
 
-        $allyFleetMissionService = resolve(FleetMissionService::class, ['player' => $this->allyPlanet->getPlayer()]);
+        $allyFleetMissionService = resolve(FleetMissionService::class, ['player' => $this->allyPlanet()->getPlayer()]);
         $allyMission = $allyFleetMissionService->createNewFromPlanet(
-            $this->allyPlanet,
-            $this->targetPlanet->getPlanetCoordinates(),
+            $this->allyPlanet(),
+            $this->targetPlanet()->getPlanetCoordinates(),
             PlanetType::Planet,
             1,
             $allyFleet,
@@ -965,6 +1070,9 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
 
         $fleetUnionService = resolve(FleetUnionService::class);
         $union = FleetUnion::find($unionId);
+        if ($union === null) {
+            $this->fail('Union not found.');
+        }
         $fleetUnionService->joinUnion($union, $allyMission);
 
         // Record battle report count before arrival
@@ -1001,31 +1109,34 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         $unitCollection = new UnitCollection();
         $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 20);
         $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('small_cargo'), 10);
-        $this->dispatchFleet($this->targetPlanet->getPlanetCoordinates(), $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet);
+        $this->dispatchFleet($this->targetPlanet()->getPlanetCoordinates(), $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet);
 
         $fleetMissionService = resolve(FleetMissionService::class);
         $initiatorMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($initiatorMission === null) {
+            $this->fail('No initiator mission found.');
+        }
 
         // Create union
         $this->post('/ajax/fleet/union/create', [
             'fleetID' => $initiatorMission->id,
             'groupname' => 'LootTest',
-            'unionUsers' => $this->allyUser->username,
+            'unionUsers' => $this->allyUser()->username,
             '_token' => csrf_token(),
         ]);
         $initiatorMission->refresh();
         $unionId = $initiatorMission->union_id;
 
         // Ally joins with cargo ships too
-        $this->allyPlanet->addUnit('small_cargo', 20);
+        $this->allyPlanet()->addUnit('small_cargo', 20);
         $allyFleet = new UnitCollection();
         $allyFleet->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 15);
         $allyFleet->addUnit(ObjectService::getUnitObjectByMachineName('small_cargo'), 10);
 
-        $allyFleetMissionService = resolve(FleetMissionService::class, ['player' => $this->allyPlanet->getPlayer()]);
+        $allyFleetMissionService = resolve(FleetMissionService::class, ['player' => $this->allyPlanet()->getPlayer()]);
         $allyMission = $allyFleetMissionService->createNewFromPlanet(
-            $this->allyPlanet,
-            $this->targetPlanet->getPlanetCoordinates(),
+            $this->allyPlanet(),
+            $this->targetPlanet()->getPlanetCoordinates(),
             PlanetType::Planet,
             1,
             $allyFleet,
@@ -1036,6 +1147,9 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
 
         $fleetUnionService = resolve(FleetUnionService::class);
         $union = FleetUnion::find($unionId);
+        if ($union === null) {
+            $this->fail('Union not found.');
+        }
         $fleetUnionService->joinUnion($union, $allyMission);
 
         // Advance to arrival
@@ -1057,7 +1171,7 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
 
         // Verify return missions go to correct owners
         $this->assertEquals($this->currentUserId, $initiatorReturn->user_id, 'Initiator return should belong to initiator');
-        $this->assertEquals($this->allyUser->id, $allyReturn->user_id, 'Ally return should belong to ally');
+        $this->assertEquals($this->allyUser()->id, $allyReturn->user_id, 'Ally return should belong to ally');
 
         // Verify outbound missions are processed
         $initiatorMission->refresh();
@@ -1078,23 +1192,26 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         $this->createAllyPlayer();
 
         // Give ally higher drive tech so they are naturally faster
-        $allyPlayerService = resolve(PlayerService::class, ['player_id' => $this->allyUser->id]);
+        $allyPlayerService = resolve(PlayerService::class, ['player_id' => $this->allyUser()->id]);
         $allyPlayerService->setResearchLevel('impulse_drive', 5);
         $allyPlayerService->setResearchLevel('combustion_drive', 5);
 
         // Send initiator fleet (slower, no drive tech upgrades)
         $unitCollection = new UnitCollection();
         $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 20);
-        $this->dispatchFleet($this->targetPlanet->getPlanetCoordinates(), $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet);
+        $this->dispatchFleet($this->targetPlanet()->getPlanetCoordinates(), $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet);
 
         $fleetMissionService = resolve(FleetMissionService::class);
         $initiatorMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($initiatorMission === null) {
+            $this->fail('No initiator mission found.');
+        }
 
         // Create union
         $this->post('/ajax/fleet/union/create', [
             'fleetID' => $initiatorMission->id,
             'groupname' => 'NaturalSpeedTest',
-            'unionUsers' => $this->allyUser->username,
+            'unionUsers' => $this->allyUser()->username,
             '_token' => csrf_token(),
         ]);
         $initiatorMission->refresh();
@@ -1104,10 +1221,10 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         $allyFleet = new UnitCollection();
         $allyFleet->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 10);
 
-        $allyFleetMissionService = resolve(FleetMissionService::class, ['player' => $this->allyPlanet->getPlayer()]);
+        $allyFleetMissionService = resolve(FleetMissionService::class, ['player' => $this->allyPlanet()->getPlayer()]);
         $allyMission = $allyFleetMissionService->createNewFromPlanet(
-            $this->allyPlanet,
-            $this->targetPlanet->getPlanetCoordinates(),
+            $this->allyPlanet(),
+            $this->targetPlanet()->getPlanetCoordinates(),
             PlanetType::Planet,
             1,
             $allyFleet,
@@ -1122,6 +1239,9 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         // Join union — ally's arrival gets pushed out to match the slower initiator
         $fleetUnionService = resolve(FleetUnionService::class);
         $union = FleetUnion::find($unionId);
+        if ($union === null) {
+            $this->fail('Union not found.');
+        }
         $fleetUnionService->joinUnion($union, $allyMission);
         $allyMission->refresh();
 
@@ -1147,16 +1267,16 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         $this->assertLessThan($allySyncedDuration, $allyReturnDuration, 'Return duration should be less than synced outbound duration (natural speed is faster)');
 
         // Verify it matches the recalculated natural duration for surviving ships
-        $allyPlayerServiceForCalc = resolve(PlayerService::class, ['player_id' => $this->allyUser->id]);
+        $allyPlayerServiceForCalc = resolve(PlayerService::class, ['player_id' => $this->allyUser()->id]);
         $planetServiceFactory = resolve(PlanetServiceFactory::class);
-        $originPlanet = $planetServiceFactory->makeForPlayer($allyPlayerServiceForCalc, $allyMission->planet_id_from);
+        $originPlanet = $planetServiceFactory->makeForPlayer($allyPlayerServiceForCalc, (int) $allyMission->planet_id_from);
 
         // Get surviving units from the return mission
         $survivingUnits = $allyFleetMissionService->getFleetUnits($allyReturn);
 
         $expectedNaturalDuration = $allyFleetMissionService->calculateFleetMissionDuration(
             $originPlanet,
-            $this->targetPlanet->getPlanetCoordinates(),
+            $this->targetPlanet()->getPlanetCoordinates(),
             $survivingUnits,
             resolve(AttackMission::class),
             10
@@ -1178,16 +1298,19 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         // Send initiator fleet
         $unitCollection = new UnitCollection();
         $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 5);
-        $this->dispatchFleet($this->targetPlanet->getPlanetCoordinates(), $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet);
+        $this->dispatchFleet($this->targetPlanet()->getPlanetCoordinates(), $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet);
 
         $fleetMissionService = resolve(FleetMissionService::class);
         $initiatorMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($initiatorMission === null) {
+            $this->fail('No initiator mission found.');
+        }
 
         // Create union
         $this->post('/ajax/fleet/union/create', [
             'fleetID' => $initiatorMission->id,
             'groupname' => 'FullUnionTest',
-            'unionUsers' => $this->allyUser->username,
+            'unionUsers' => $this->allyUser()->username,
             '_token' => csrf_token(),
         ]);
         $initiatorMission->refresh();
@@ -1195,16 +1318,23 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
 
         // Set max_fleets to 1 so the union is already full (initiator occupies the only slot)
         $union = FleetUnion::find($unionId);
+        if ($union === null) {
+            $this->fail('Union not found.');
+        }
         $union->max_fleets = 1;
         $union->save();
 
         // Switch to ally and try to send a fleet to join the full union
-        $this->be(User::find($this->allyUser->id));
+        $allyUserModel = User::find($this->allyUser()->id);
+        if ($allyUserModel === null) {
+            $this->fail('Ally user not found.');
+        }
+        $this->be($allyUserModel);
 
         $response = $this->post('/ajax/fleet/dispatch/send-fleet', [
-            'galaxy' => $this->targetPlanet->getPlanetCoordinates()->galaxy,
-            'system' => $this->targetPlanet->getPlanetCoordinates()->system,
-            'position' => $this->targetPlanet->getPlanetCoordinates()->position,
+            'galaxy' => $this->targetPlanet()->getPlanetCoordinates()->galaxy,
+            'system' => $this->targetPlanet()->getPlanetCoordinates()->system,
+            'position' => $this->targetPlanet()->getPlanetCoordinates()->position,
             'type' => PlanetType::Planet->value,
             'metal' => 0,
             'crystal' => 0,
@@ -1242,16 +1372,19 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         // Send initiator fleet
         $unitCollection = new UnitCollection();
         $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 10);
-        $this->dispatchFleet($this->targetPlanet->getPlanetCoordinates(), $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet);
+        $this->dispatchFleet($this->targetPlanet()->getPlanetCoordinates(), $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet);
 
         $fleetMissionService = resolve(FleetMissionService::class);
         $initiatorMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($initiatorMission === null) {
+            $this->fail('No initiator mission found.');
+        }
 
         // Create union
         $this->post('/ajax/fleet/union/create', [
             'fleetID' => $initiatorMission->id,
             'groupname' => 'TimingSyncTest',
-            'unionUsers' => $this->allyUser->username,
+            'unionUsers' => $this->allyUser()->username,
             '_token' => csrf_token(),
         ]);
         $initiatorMission->refresh();
@@ -1263,6 +1396,9 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         $initiatorMission->time_arrival = $baseArrivalTime;
         $initiatorMission->save();
         $union = FleetUnion::find($unionId);
+        if ($union === null) {
+            $this->fail('Union not found.');
+        }
         $union->time_arrival = $baseArrivalTime;
         $union->save();
 
@@ -1270,10 +1406,10 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         $allyFleet = new UnitCollection();
         $allyFleet->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 10);
 
-        $allyFleetMissionService = resolve(FleetMissionService::class, ['player' => $this->allyPlanet->getPlayer()]);
+        $allyFleetMissionService = resolve(FleetMissionService::class, ['player' => $this->allyPlanet()->getPlayer()]);
         $allyMission = $allyFleetMissionService->createNewFromPlanet(
-            $this->allyPlanet,
-            $this->targetPlanet->getPlanetCoordinates(),
+            $this->allyPlanet(),
+            $this->targetPlanet()->getPlanetCoordinates(),
             PlanetType::Planet,
             1,
             $allyFleet,
@@ -1319,10 +1455,13 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
 
         $unitCollection = new UnitCollection();
         $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 10);
-        $this->dispatchFleet($this->targetPlanet->getPlanetCoordinates(), $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet);
+        $this->dispatchFleet($this->targetPlanet()->getPlanetCoordinates(), $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet);
 
         $fleetMissionService = resolve(FleetMissionService::class);
         $mission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($mission === null) {
+            $this->fail('No active mission found.');
+        }
 
         $settingsService = resolve(SettingsService::class);
         $settingsService->set('alliance_combat_system_on', 0);
@@ -1372,10 +1511,13 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         // Send attack and create a union while ACS is on
         $unitCollection = new UnitCollection();
         $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 10);
-        $this->dispatchFleet($this->targetPlanet->getPlanetCoordinates(), $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet);
+        $this->dispatchFleet($this->targetPlanet()->getPlanetCoordinates(), $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet);
 
         $fleetMissionService = resolve(FleetMissionService::class);
         $mission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($mission === null) {
+            $this->fail('No active mission found.');
+        }
 
         $this->post('/ajax/fleet/union/create', [
             'fleetID' => $mission->id,
@@ -1391,9 +1533,9 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
 
         $lightFighterObj = ObjectService::getUnitObjectByMachineName('light_fighter');
         $response = $this->post('/ajax/fleet/dispatch/check-target', [
-            'galaxy' => $this->targetPlanet->getPlanetCoordinates()->galaxy,
-            'system' => $this->targetPlanet->getPlanetCoordinates()->system,
-            'position' => $this->targetPlanet->getPlanetCoordinates()->position,
+            'galaxy' => $this->targetPlanet()->getPlanetCoordinates()->galaxy,
+            'system' => $this->targetPlanet()->getPlanetCoordinates()->system,
+            'position' => $this->targetPlanet()->getPlanetCoordinates()->position,
             'type' => PlanetType::Planet->value,
             'mission' => 1,
             'union' => $unionId,
@@ -1432,7 +1574,7 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
 
         // Set exact defender resources for deterministic loot calculation.
         DB::table('planets')
-            ->where('id', $this->targetPlanet->getPlanetId())
+            ->where('id', $this->targetPlanet()->getPlanetId())
             ->update(['metal' => 22000, 'crystal' => 0, 'deuterium' => 0]);
 
         // Give initiator planet metal to carry as cargo and add 2 large cargoes.
@@ -1441,7 +1583,7 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         $initiatorFleet = new UnitCollection();
         $initiatorFleet->addUnit(ObjectService::getUnitObjectByMachineName('large_cargo'), 2);
         $this->dispatchFleet(
-            $this->targetPlanet->getPlanetCoordinates(),
+            $this->targetPlanet()->getPlanetCoordinates(),
             $initiatorFleet,
             new Resources(1000, 0, 0, 0),
             PlanetType::Planet
@@ -1449,27 +1591,30 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
 
         $fleetMissionService = resolve(FleetMissionService::class);
         $initiatorMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($initiatorMission === null) {
+            $this->fail('No initiator mission found.');
+        }
 
         // Create union and invite ally.
         $this->post('/ajax/fleet/union/create', [
             'fleetID' => $initiatorMission->id,
             'groupname' => 'LootDistTest',
-            'unionUsers' => $this->allyUser->username,
+            'unionUsers' => $this->allyUser()->username,
             '_token' => csrf_token(),
         ]);
         $initiatorMission->refresh();
         $unionId = $initiatorMission->union_id;
 
         // Give ally planet metal to carry and add 1 small cargo (different type from initiator).
-        $this->allyPlanet->addResources(new Resources(1000, 0, 0, 0));
-        $this->allyPlanet->addUnit('small_cargo', 1);
+        $this->allyPlanet()->addResources(new Resources(1000, 0, 0, 0));
+        $this->allyPlanet()->addUnit('small_cargo', 1);
         $allyFleet = new UnitCollection();
         $allyFleet->addUnit(ObjectService::getUnitObjectByMachineName('small_cargo'), 1);
 
-        $allyFleetMissionService = resolve(FleetMissionService::class, ['player' => $this->allyPlanet->getPlayer()]);
+        $allyFleetMissionService = resolve(FleetMissionService::class, ['player' => $this->allyPlanet()->getPlayer()]);
         $allyMission = $allyFleetMissionService->createNewFromPlanet(
-            $this->allyPlanet,
-            $this->targetPlanet->getPlanetCoordinates(),
+            $this->allyPlanet(),
+            $this->targetPlanet()->getPlanetCoordinates(),
             PlanetType::Planet,
             1,
             $allyFleet,
@@ -1480,6 +1625,9 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
 
         $fleetUnionService = resolve(FleetUnionService::class);
         $union = FleetUnion::find($unionId);
+        if ($union === null) {
+            $this->fail('Union not found.');
+        }
         $fleetUnionService->joinUnion($union, $allyMission);
 
         // Advance time past arrival and trigger fleet processing.
@@ -1541,14 +1689,14 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         $this->createAllyPlayer();
 
         DB::table('planets')
-            ->where('id', $this->targetPlanet->getPlanetId())
+            ->where('id', $this->targetPlanet()->getPlanetId())
             ->update(['metal' => 22500, 'crystal' => 0, 'deuterium' => 0]);
 
         $this->planetAddUnit('small_cargo', 1);
         $initiatorFleet = new UnitCollection();
         $initiatorFleet->addUnit(ObjectService::getUnitObjectByMachineName('small_cargo'), 1);
         $this->dispatchFleet(
-            $this->targetPlanet->getPlanetCoordinates(),
+            $this->targetPlanet()->getPlanetCoordinates(),
             $initiatorFleet,
             new Resources(0, 0, 0, 0),
             PlanetType::Planet
@@ -1556,28 +1704,34 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
 
         $fleetMissionService = resolve(FleetMissionService::class);
         $initiatorMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($initiatorMission === null) {
+            $this->fail('No initiator mission found.');
+        }
 
         $this->post('/ajax/fleet/union/create', [
             'fleetID' => $initiatorMission->id,
             'groupname' => 'CapacityBonusTest',
-            'unionUsers' => $this->allyUser->username,
+            'unionUsers' => $this->allyUser()->username,
             '_token' => csrf_token(),
         ]);
         $initiatorMission->refresh();
         $unionId = $initiatorMission->union_id;
 
-        $allyPlayer = $this->allyPlanet->getPlayer();
+        $allyPlayer = $this->allyPlanet()->getPlayer();
+        if ($allyPlayer === null) {
+            $this->fail('Ally planet has no player.');
+        }
         $allyPlayer->getUser()->character_class = CharacterClass::COLLECTOR->value;
         $allyPlayer->getUser()->save();
 
-        $this->allyPlanet->addUnit('small_cargo', 1);
+        $this->allyPlanet()->addUnit('small_cargo', 1);
         $allyFleet = new UnitCollection();
         $allyFleet->addUnit(ObjectService::getUnitObjectByMachineName('small_cargo'), 1);
 
         $allyFleetMissionService = resolve(FleetMissionService::class, ['player' => $allyPlayer]);
         $allyMission = $allyFleetMissionService->createNewFromPlanet(
-            $this->allyPlanet,
-            $this->targetPlanet->getPlanetCoordinates(),
+            $this->allyPlanet(),
+            $this->targetPlanet()->getPlanetCoordinates(),
             PlanetType::Planet,
             1,
             $allyFleet,
@@ -1588,6 +1742,9 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
 
         $fleetUnionService = resolve(FleetUnionService::class);
         $union = FleetUnion::find($unionId);
+        if ($union === null) {
+            $this->fail('Union not found.');
+        }
         $fleetUnionService->joinUnion($union, $allyMission);
 
         $arrivalTime = max($initiatorMission->time_arrival, $allyMission->time_arrival);
@@ -1635,14 +1792,14 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         $this->createAllyPlayer();
 
         DB::table('planets')
-            ->where('id', $this->targetPlanet->getPlanetId())
+            ->where('id', $this->targetPlanet()->getPlanetId())
             ->update(['metal' => 2, 'crystal' => 2, 'deuterium' => 0]);
 
         $this->planetAddUnit('small_cargo', 1);
         $initiatorFleet = new UnitCollection();
         $initiatorFleet->addUnit(ObjectService::getUnitObjectByMachineName('small_cargo'), 1);
         $this->dispatchFleet(
-            $this->targetPlanet->getPlanetCoordinates(),
+            $this->targetPlanet()->getPlanetCoordinates(),
             $initiatorFleet,
             new Resources(0, 0, 0, 0),
             PlanetType::Planet
@@ -1650,24 +1807,27 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
 
         $fleetMissionService = resolve(FleetMissionService::class);
         $initiatorMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($initiatorMission === null) {
+            $this->fail('No initiator mission found.');
+        }
 
         $this->post('/ajax/fleet/union/create', [
             'fleetID' => $initiatorMission->id,
             'groupname' => 'RoundingTest',
-            'unionUsers' => $this->allyUser->username,
+            'unionUsers' => $this->allyUser()->username,
             '_token' => csrf_token(),
         ]);
         $initiatorMission->refresh();
         $unionId = $initiatorMission->union_id;
 
-        $this->allyPlanet->addUnit('small_cargo', 1);
+        $this->allyPlanet()->addUnit('small_cargo', 1);
         $allyFleet = new UnitCollection();
         $allyFleet->addUnit(ObjectService::getUnitObjectByMachineName('small_cargo'), 1);
 
-        $allyFleetMissionService = resolve(FleetMissionService::class, ['player' => $this->allyPlanet->getPlayer()]);
+        $allyFleetMissionService = resolve(FleetMissionService::class, ['player' => $this->allyPlanet()->getPlayer()]);
         $allyMission = $allyFleetMissionService->createNewFromPlanet(
-            $this->allyPlanet,
-            $this->targetPlanet->getPlanetCoordinates(),
+            $this->allyPlanet(),
+            $this->targetPlanet()->getPlanetCoordinates(),
             PlanetType::Planet,
             1,
             $allyFleet,
@@ -1678,6 +1838,9 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
 
         $fleetUnionService = resolve(FleetUnionService::class);
         $union = FleetUnion::find($unionId);
+        if ($union === null) {
+            $this->fail('Union not found.');
+        }
         $fleetUnionService->joinUnion($union, $allyMission);
 
         $arrivalTime = max($initiatorMission->time_arrival, $allyMission->time_arrival);
@@ -1730,7 +1893,7 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         $this->createAllyPlayer();
 
         DB::table('planets')
-            ->where('id', $this->targetPlanet->getPlanetId())
+            ->where('id', $this->targetPlanet()->getPlanetId())
             ->update(['metal' => 2000, 'crystal' => 0, 'deuterium' => 0]);
 
         $this->planetAddResources(new Resources(5000, 0, 0, 0));
@@ -1738,7 +1901,7 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         $initiatorFleet = new UnitCollection();
         $initiatorFleet->addUnit(ObjectService::getUnitObjectByMachineName('small_cargo'), 1);
         $this->dispatchFleet(
-            $this->targetPlanet->getPlanetCoordinates(),
+            $this->targetPlanet()->getPlanetCoordinates(),
             $initiatorFleet,
             new Resources(4900, 0, 0, 0),
             PlanetType::Planet
@@ -1746,24 +1909,27 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
 
         $fleetMissionService = resolve(FleetMissionService::class);
         $initiatorMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($initiatorMission === null) {
+            $this->fail('No initiator mission found.');
+        }
 
         $this->post('/ajax/fleet/union/create', [
             'fleetID' => $initiatorMission->id,
             'groupname' => 'CapacityInvariantTest',
-            'unionUsers' => $this->allyUser->username,
+            'unionUsers' => $this->allyUser()->username,
             '_token' => csrf_token(),
         ]);
         $initiatorMission->refresh();
         $unionId = $initiatorMission->union_id;
 
-        $this->allyPlanet->addUnit('small_cargo', 1);
+        $this->allyPlanet()->addUnit('small_cargo', 1);
         $allyFleet = new UnitCollection();
         $allyFleet->addUnit(ObjectService::getUnitObjectByMachineName('small_cargo'), 1);
 
-        $allyFleetMissionService = resolve(FleetMissionService::class, ['player' => $this->allyPlanet->getPlayer()]);
+        $allyFleetMissionService = resolve(FleetMissionService::class, ['player' => $this->allyPlanet()->getPlayer()]);
         $allyMission = $allyFleetMissionService->createNewFromPlanet(
-            $this->allyPlanet,
-            $this->targetPlanet->getPlanetCoordinates(),
+            $this->allyPlanet(),
+            $this->targetPlanet()->getPlanetCoordinates(),
             PlanetType::Planet,
             1,
             $allyFleet,
@@ -1774,6 +1940,9 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
 
         $fleetUnionService = resolve(FleetUnionService::class);
         $union = FleetUnion::find($unionId);
+        if ($union === null) {
+            $this->fail('Union not found.');
+        }
         $fleetUnionService->joinUnion($union, $allyMission);
 
         $arrivalTime = max($initiatorMission->time_arrival, $allyMission->time_arrival);
@@ -1826,7 +1995,7 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         $this->createAllyPlayer();
 
         DB::table('planets')
-            ->where('id', $this->targetPlanet->getPlanetId())
+            ->where('id', $this->targetPlanet()->getPlanetId())
             ->update(['metal' => 12000, 'crystal' => 0, 'deuterium' => 0]);
 
         $this->planetAddResources(new Resources(5000, 0, 0, 0));
@@ -1834,7 +2003,7 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         $initiatorFleet = new UnitCollection();
         $initiatorFleet->addUnit(ObjectService::getUnitObjectByMachineName('small_cargo'), 1);
         $this->dispatchFleet(
-            $this->targetPlanet->getPlanetCoordinates(),
+            $this->targetPlanet()->getPlanetCoordinates(),
             $initiatorFleet,
             new Resources(4900, 0, 0, 0),
             PlanetType::Planet
@@ -1842,24 +2011,27 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
 
         $fleetMissionService = resolve(FleetMissionService::class);
         $initiatorMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($initiatorMission === null) {
+            $this->fail('No initiator mission found.');
+        }
 
         $this->post('/ajax/fleet/union/create', [
             'fleetID' => $initiatorMission->id,
             'groupname' => 'LeaveLootTest',
-            'unionUsers' => $this->allyUser->username,
+            'unionUsers' => $this->allyUser()->username,
             '_token' => csrf_token(),
         ]);
         $initiatorMission->refresh();
         $unionId = $initiatorMission->union_id;
 
-        $this->allyPlanet->addUnit('small_cargo', 1);
+        $this->allyPlanet()->addUnit('small_cargo', 1);
         $allyFleet = new UnitCollection();
         $allyFleet->addUnit(ObjectService::getUnitObjectByMachineName('small_cargo'), 1);
 
-        $allyFleetMissionService = resolve(FleetMissionService::class, ['player' => $this->allyPlanet->getPlayer()]);
+        $allyFleetMissionService = resolve(FleetMissionService::class, ['player' => $this->allyPlanet()->getPlayer()]);
         $allyMission = $allyFleetMissionService->createNewFromPlanet(
-            $this->allyPlanet,
-            $this->targetPlanet->getPlanetCoordinates(),
+            $this->allyPlanet(),
+            $this->targetPlanet()->getPlanetCoordinates(),
             PlanetType::Planet,
             1,
             $allyFleet,
@@ -1870,6 +2042,9 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
 
         $fleetUnionService = resolve(FleetUnionService::class);
         $union = FleetUnion::find($unionId);
+        if ($union === null) {
+            $this->fail('Union not found.');
+        }
         $fleetUnionService->joinUnion($union, $allyMission);
 
         $arrivalTime = max($initiatorMission->time_arrival, $allyMission->time_arrival);
@@ -1896,9 +2071,13 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         );
 
         $planetServiceFactory = resolve(PlanetServiceFactory::class);
+        $targetPlayer = $this->targetPlanet()->getPlayer();
+        if ($targetPlayer === null) {
+            $this->fail('Target planet has no player.');
+        }
         $refreshedTargetPlanet = $planetServiceFactory->makeForPlayer(
-            $this->targetPlanet->getPlayer(),
-            $this->targetPlanet->getPlanetId()
+            $targetPlayer,
+            $this->targetPlanet()->getPlanetId()
         );
         $this->assertEquals(
             12000 - $actualLootTaken,
@@ -1927,13 +2106,13 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
 
         // Give both planets enough cruisers (cruiser has no prerequisites in test env)
         $this->planetAddUnit('cruiser', $initiatorCruiserCount);
-        $this->allyPlanet->addUnit('cruiser', $allyCruiserCount);
+        $this->allyPlanet()->addUnit('cruiser', $allyCruiserCount);
 
         // Dispatch initiator fleet
         $unitCollection = new UnitCollection();
         $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('cruiser'), $initiatorCruiserCount);
         $this->dispatchFleet(
-            $this->targetPlanet->getPlanetCoordinates(),
+            $this->targetPlanet()->getPlanetCoordinates(),
             $unitCollection,
             new Resources(0, 0, 0, 0),
             PlanetType::Planet
@@ -1941,12 +2120,15 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
 
         $fleetMissionService = resolve(FleetMissionService::class);
         $initiatorMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($initiatorMission === null) {
+            $this->fail('No initiator mission found.');
+        }
 
         // Create union
         $this->post('/ajax/fleet/union/create', [
             'fleetID' => $initiatorMission->id,
             'groupname' => 'AliasRegressionUnion',
-            'unionUsers' => $this->allyUser->username,
+            'unionUsers' => $this->allyUser()->username,
             '_token' => csrf_token(),
         ]);
         $initiatorMission->refresh();
@@ -1957,10 +2139,10 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
         $allyFleet = new UnitCollection();
         $allyFleet->addUnit(ObjectService::getUnitObjectByMachineName('cruiser'), $allyCruiserCount);
 
-        $allyFleetMissionService = resolve(FleetMissionService::class, ['player' => $this->allyPlanet->getPlayer()]);
+        $allyFleetMissionService = resolve(FleetMissionService::class, ['player' => $this->allyPlanet()->getPlayer()]);
         $allyMission = $allyFleetMissionService->createNewFromPlanet(
-            $this->allyPlanet,
-            $this->targetPlanet->getPlanetCoordinates(),
+            $this->allyPlanet(),
+            $this->targetPlanet()->getPlanetCoordinates(),
             PlanetType::Planet,
             1,
             $allyFleet,
@@ -1971,6 +2153,9 @@ class FleetDispatchAcsAttackTest extends FleetDispatchTestCase
 
         $fleetUnionService = resolve(FleetUnionService::class);
         $union = FleetUnion::find($unionId);
+        if ($union === null) {
+            $this->fail('Union not found.');
+        }
         $fleetUnionService->joinUnion($union, $allyMission);
 
         // Advance to arrival and trigger mission processing

--- a/tests/Feature/FleetDispatch/FleetDispatchAcsDefendTest.php
+++ b/tests/Feature/FleetDispatch/FleetDispatchAcsDefendTest.php
@@ -8,7 +8,6 @@ use OGame\GameObjects\Models\Units\UnitCollection;
 use OGame\Models\AllianceMember;
 use OGame\Models\Enums\PlanetType;
 use OGame\Models\FleetMission;
-use OGame\Models\Message;
 use OGame\Models\Planet;
 use OGame\Models\Resources;
 use OGame\Models\User;
@@ -227,12 +226,52 @@ class FleetDispatchAcsDefendTest extends FleetDispatchTestCase
      */
     protected function sendMissionToBuddyPlanet(UnitCollection $units, Resources $resources, bool $assertStatus = true): PlanetService
     {
-        if ($this->buddyPlanet === null) {
+        $buddyPlanet = $this->buddyPlanet;
+        if ($buddyPlanet === null) {
             throw new RuntimeException('Must call createBuddyPlayer() before sendMissionToBuddyPlanet()');
         }
 
-        $this->dispatchFleet($this->buddyPlanet->getPlanetCoordinates(), $units, $resources, PlanetType::Planet, 0, $assertStatus);
-        return $this->buddyPlanet;
+        $this->dispatchFleet($buddyPlanet->getPlanetCoordinates(), $units, $resources, PlanetType::Planet, 0, $assertStatus);
+        return $buddyPlanet;
+    }
+
+    /**
+     * Get the buddy planet, failing the test if it is not set.
+     */
+    private function getBuddyPlanet(): PlanetService
+    {
+        $buddyPlanet = $this->buddyPlanet;
+        if ($buddyPlanet === null) {
+            $this->fail('Buddy planet is null.');
+        }
+
+        return $buddyPlanet;
+    }
+
+    /**
+     * Get the alliance member planet, failing the test if it is not set.
+     */
+    private function getAllianceMemberPlanet(): PlanetService
+    {
+        $allianceMemberPlanet = $this->allianceMemberPlanet;
+        if ($allianceMemberPlanet === null) {
+            $this->fail('Alliance member planet is null.');
+        }
+
+        return $allianceMemberPlanet;
+    }
+
+    /**
+     * Get the non-affiliated player planet, failing the test if it is not set.
+     */
+    private function getOtherPlanet(): PlanetService
+    {
+        $otherPlanet = $this->otherPlanet;
+        if ($otherPlanet === null) {
+            $this->fail('Other planet is null.');
+        }
+
+        return $otherPlanet;
     }
 
     /**
@@ -267,7 +306,7 @@ class FleetDispatchAcsDefendTest extends FleetDispatchTestCase
 
         $unitCollection = new UnitCollection();
         $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 1);
-        $this->checkTargetFleet($this->buddyPlanet->getPlanetCoordinates(), $unitCollection, PlanetType::Planet, true);
+        $this->checkTargetFleet($this->getBuddyPlanet()->getPlanetCoordinates(), $unitCollection, PlanetType::Planet, true);
     }
 
     /**
@@ -357,6 +396,9 @@ class FleetDispatchAcsDefendTest extends FleetDispatchTestCase
         // Refresh planet service after mission arrival
         $planetServiceFactory = resolve(PlanetServiceFactory::class);
         $foreignPlanet = $planetServiceFactory->make($foreignPlanet->getPlanetId());
+        if ($foreignPlanet === null) {
+            $this->fail('Foreign planet reload failed.');
+        }
 
         // Assert sender received message from "Fleet Command"
         $this->assertMessageReceivedAndContains('fleets', 'other', [
@@ -366,7 +408,11 @@ class FleetDispatchAcsDefendTest extends FleetDispatchTestCase
         ]);
 
         // Assert host received arrival message
-        $this->assertMessageReceivedAndContainsDatabase($foreignPlanet->getPlayer(), [
+        $foreignPlayer = $foreignPlanet->getPlayer();
+        if ($foreignPlayer === null) {
+            $this->fail('Foreign planet player is null.');
+        }
+        $this->assertMessageReceivedAndContainsDatabase($foreignPlayer, [
             'A fleet has arrived',
             $foreignPlanet->getPlanetName(),
         ]);
@@ -409,7 +455,11 @@ class FleetDispatchAcsDefendTest extends FleetDispatchTestCase
         $activeMissions = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer();
         $this->assertCount(1, $activeMissions, 'No active fleet mission found.');
 
-        $fleetMissionId = $activeMissions->first()->id;
+        $firstMission = $activeMissions->first();
+        if ($firstMission === null) {
+            $this->fail('No active fleet mission found.');
+        }
+        $fleetMissionId = $firstMission->id;
 
         // Cancel/recall the mission.
         $response = $this->post('/ajax/fleet/dispatch/recall-fleet', [
@@ -436,8 +486,8 @@ class FleetDispatchAcsDefendTest extends FleetDispatchTestCase
         $buddyUser = $this->createBuddyPlayer();
 
         // Get buddy's planet starting resources
-        $startingMetal = $this->buddyPlanet->metal()->get();
-        $startingCrystal = $this->buddyPlanet->crystal()->get();
+        $startingMetal = $this->getBuddyPlanet()->metal()->get();
+        $startingCrystal = $this->getBuddyPlanet()->crystal()->get();
 
         // Send fleet with resources to buddy's planet.
         $unitCollection = new UnitCollection();
@@ -454,8 +504,15 @@ class FleetDispatchAcsDefendTest extends FleetDispatchTestCase
 
         // Refresh planet services after mission completion
         $planetServiceFactory = resolve(PlanetServiceFactory::class);
-        $buddyPlanetReloaded = $planetServiceFactory->make($this->buddyPlanet->getPlanetId());
-        $this->planetService = $planetServiceFactory->make($this->planetService->getPlanetId());
+        $buddyPlanetReloaded = $planetServiceFactory->make($this->getBuddyPlanet()->getPlanetId());
+        if ($buddyPlanetReloaded === null) {
+            $this->fail('Buddy planet reload failed.');
+        }
+        $reloadedPlanet = $planetServiceFactory->make($this->planetService->getPlanetId());
+        if ($reloadedPlanet === null) {
+            $this->fail('Planet reload failed.');
+        }
+        $this->planetService = $reloadedPlanet;
 
         // Assert that buddy's planet did NOT receive the resources
         $this->assertEquals($startingMetal, $buddyPlanetReloaded->metal()->get(), 'Resources were incorrectly delivered to target planet.');
@@ -486,7 +543,7 @@ class FleetDispatchAcsDefendTest extends FleetDispatchTestCase
         // Send fleet with resources and 10 hour hold time
         $unitCollection = new UnitCollection();
         $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('small_cargo'), 2);
-        $this->dispatchFleet($this->buddyPlanet->getPlanetCoordinates(), $unitCollection, new Resources(800, 600, 0, 0), PlanetType::Planet, 10);
+        $this->dispatchFleet($this->getBuddyPlanet()->getPlanetCoordinates(), $unitCollection, new Resources(800, 600, 0, 0), PlanetType::Planet, 10);
 
         // Wait until fleet arrives and is holding (but not long enough to return)
         $this->travel(5)->hours();
@@ -497,7 +554,11 @@ class FleetDispatchAcsDefendTest extends FleetDispatchTestCase
         $activeMissions = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer();
         $this->assertGreaterThan(0, $activeMissions->count(), 'No active fleet missions found');
 
-        $fleetMissionId = $activeMissions->first()->id;
+        $firstMission = $activeMissions->first();
+        if ($firstMission === null) {
+            $this->fail('No active fleet mission found.');
+        }
+        $fleetMissionId = $firstMission->id;
 
         // Recall the mission
         $response = $this->post('/ajax/fleet/dispatch/recall-fleet', [
@@ -512,7 +573,11 @@ class FleetDispatchAcsDefendTest extends FleetDispatchTestCase
 
         // Reload planet and check resources
         $planetServiceFactory = resolve(PlanetServiceFactory::class);
-        $this->planetService = $planetServiceFactory->make($this->planetService->getPlanetId());
+        $reloadedPlanet = $planetServiceFactory->make($this->planetService->getPlanetId());
+        if ($reloadedPlanet === null) {
+            $this->fail('Planet reload failed.');
+        }
+        $this->planetService = $reloadedPlanet;
         $finalMetal = $this->planetService->metal()->get();
         $finalCrystal = $this->planetService->crystal()->get();
 
@@ -550,8 +615,8 @@ class FleetDispatchAcsDefendTest extends FleetDispatchTestCase
         $attackerUser = User::factory()->create();
         self::$allCreatedBuddyUserIds[] = $attackerUser->id;
 
-        $buddyGalaxy  = $this->buddyPlanet->getPlanetCoordinates()->galaxy;
-        $buddySystem  = $this->buddyPlanet->getPlanetCoordinates()->system;
+        $buddyGalaxy  = $this->getBuddyPlanet()->getPlanetCoordinates()->galaxy;
+        $buddySystem  = $this->getBuddyPlanet()->getPlanetCoordinates()->system;
         $attackerPosition = collect([13, 14, 15, 1, 2, 3])->first(
             fn ($p) => !Planet::where('galaxy', $buddyGalaxy)->where('system', $buddySystem)->where('planet', $p)->exists()
         );
@@ -582,7 +647,7 @@ class FleetDispatchAcsDefendTest extends FleetDispatchTestCase
 
         $fleetMissionService->createNewFromPlanet(
             $attackerPlanetService,
-            $this->buddyPlanet->getPlanetCoordinates(),
+            $this->getBuddyPlanet()->getPlanetCoordinates(),
             PlanetType::Planet,
             1,
             $attackUnits,
@@ -595,7 +660,11 @@ class FleetDispatchAcsDefendTest extends FleetDispatchTestCase
         $this->get('/overview');
 
         // Reload our planet
-        $this->planetService = $planetServiceFactory->make($this->planetService->getPlanetId());
+        $reloadedPlanet = $planetServiceFactory->make($this->planetService->getPlanetId());
+        if ($reloadedPlanet === null) {
+            $this->fail('Planet reload failed.');
+        }
+        $this->planetService = $reloadedPlanet;
 
         // Check that some resources returned (proportional to surviving ships)
         $finalMetal = $this->planetService->metal()->get();
@@ -634,8 +703,8 @@ class FleetDispatchAcsDefendTest extends FleetDispatchTestCase
         $attackerUser = User::factory()->create();
         self::$allCreatedBuddyUserIds[] = $attackerUser->id;
 
-        $buddyGalaxy  = $this->buddyPlanet->getPlanetCoordinates()->galaxy;
-        $buddySystem  = $this->buddyPlanet->getPlanetCoordinates()->system;
+        $buddyGalaxy  = $this->getBuddyPlanet()->getPlanetCoordinates()->galaxy;
+        $buddySystem  = $this->getBuddyPlanet()->getPlanetCoordinates()->system;
         $attackerPosition = collect([13, 14, 15, 1, 2, 3])->first(
             fn ($p) => !Planet::where('galaxy', $buddyGalaxy)->where('system', $buddySystem)->where('planet', $p)->exists()
         );
@@ -666,7 +735,7 @@ class FleetDispatchAcsDefendTest extends FleetDispatchTestCase
 
         $fleetMissionService->createNewFromPlanet(
             $attackerPlanetService,
-            $this->buddyPlanet->getPlanetCoordinates(),
+            $this->getBuddyPlanet()->getPlanetCoordinates(),
             PlanetType::Planet,
             1,
             $attackUnits,
@@ -691,10 +760,14 @@ class FleetDispatchAcsDefendTest extends FleetDispatchTestCase
         $buddyUser = $this->createBuddyPlayer();
 
         // Store target coordinates
-        $buddyCoordinates = $this->buddyPlanet->getPlanetCoordinates();
+        $buddyCoordinates = $this->getBuddyPlanet()->getPlanetCoordinates();
 
         // Activate vacation mode for buddy player
-        $this->buddyPlanet->getPlayer()->activateVacationMode();
+        $buddyPlayer = $this->getBuddyPlanet()->getPlayer();
+        if ($buddyPlayer === null) {
+            $this->fail('Buddy planet player is null.');
+        }
+        $buddyPlayer->activateVacationMode();
         $this->reloadApplication();
 
         // Try to send ACS Defend fleet - should fail
@@ -713,6 +786,9 @@ class FleetDispatchAcsDefendTest extends FleetDispatchTestCase
 
         // Put current player in vacation mode
         $currentUser = User::find($this->currentUserId);
+        if ($currentUser === null) {
+            $this->fail('Current user not found.');
+        }
         $currentUser->vacation_mode = true;
         $currentUser->save();
 
@@ -741,7 +817,7 @@ class FleetDispatchAcsDefendTest extends FleetDispatchTestCase
         $fleetMissionService = app(FleetMissionService::class);
         $mission = $fleetMissionService->createNewFromPlanet(
             $this->planetService,
-            $this->buddyPlanet->getPlanetCoordinates(),
+            $this->getBuddyPlanet()->getPlanetCoordinates(),
             PlanetType::Planet,
             5, // ACS Defend
             $units,
@@ -804,7 +880,7 @@ class FleetDispatchAcsDefendTest extends FleetDispatchTestCase
         $fleetMissionService = app(FleetMissionService::class);
         $mission = $fleetMissionService->createNewFromPlanet(
             $this->planetService,
-            $this->buddyPlanet->getPlanetCoordinates(),
+            $this->getBuddyPlanet()->getPlanetCoordinates(),
             PlanetType::Planet,
             5, // ACS Defend
             $units,
@@ -826,7 +902,11 @@ class FleetDispatchAcsDefendTest extends FleetDispatchTestCase
             'Fleet is stopping',
             'Fleet Command',
         ]);
-        $this->assertMessageReceivedAndContainsDatabase($this->buddyPlanet->getPlayer(), [
+        $buddyPlayer = $this->getBuddyPlanet()->getPlayer();
+        if ($buddyPlayer === null) {
+            $this->fail('Buddy planet player is null.');
+        }
+        $this->assertMessageReceivedAndContainsDatabase($buddyPlayer, [
             'A fleet has arrived',
         ]);
 
@@ -870,7 +950,7 @@ class FleetDispatchAcsDefendTest extends FleetDispatchTestCase
         $fleetMissionService = app(FleetMissionService::class);
         $mission = $fleetMissionService->createNewFromPlanet(
             $this->planetService,
-            $this->buddyPlanet->getPlanetCoordinates(),
+            $this->getBuddyPlanet()->getPlanetCoordinates(),
             PlanetType::Planet,
             5, // ACS Defend
             $units,
@@ -900,7 +980,11 @@ class FleetDispatchAcsDefendTest extends FleetDispatchTestCase
             'Fleet is stopping',
             'Fleet Command',
         ]);
-        $this->assertMessageReceivedAndContainsDatabase($this->buddyPlanet->getPlayer(), [
+        $buddyPlayer = $this->getBuddyPlanet()->getPlayer();
+        if ($buddyPlayer === null) {
+            $this->fail('Buddy planet player is null.');
+        }
+        $this->assertMessageReceivedAndContainsDatabase($buddyPlayer, [
             'A fleet has arrived',
         ]);
     }
@@ -931,7 +1015,7 @@ class FleetDispatchAcsDefendTest extends FleetDispatchTestCase
         $fleetMissionService = app(FleetMissionService::class);
         $mission = $fleetMissionService->createNewFromPlanet(
             $this->planetService,
-            $this->buddyPlanet->getPlanetCoordinates(),
+            $this->getBuddyPlanet()->getPlanetCoordinates(),
             PlanetType::Planet,
             5, // ACS Defend
             $units,
@@ -993,7 +1077,7 @@ class FleetDispatchAcsDefendTest extends FleetDispatchTestCase
         $fleetMissionService = app(FleetMissionService::class);
         $mission = $fleetMissionService->createNewFromPlanet(
             $this->planetService,
-            $this->buddyPlanet->getPlanetCoordinates(),
+            $this->getBuddyPlanet()->getPlanetCoordinates(),
             PlanetType::Planet,
             5, // ACS Defend
             $units,
@@ -1061,13 +1145,16 @@ class FleetDispatchAcsDefendTest extends FleetDispatchTestCase
         // Send ACS Defend with 1 hour hold time
         $units = new UnitCollection();
         $units->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 2);
-        $this->dispatchFleet($this->buddyPlanet->getPlanetCoordinates(), $units, new Resources(0, 0, 0, 0), PlanetType::Planet, 1);
+        $this->dispatchFleet($this->getBuddyPlanet()->getPlanetCoordinates(), $units, new Resources(0, 0, 0, 0), PlanetType::Planet, 1);
 
         // Get the real mission record
         $fleetMissionService = resolve(FleetMissionService::class);
         $activeMissions = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer();
         $this->assertCount(1, $activeMissions, 'No active fleet mission found.');
         $mission = $activeMissions->first();
+        if ($mission === null) {
+            $this->fail('No active fleet mission found.');
+        }
         $realMissionId = $mission->id;
 
         // Advance time into the hold period (physical arrival + 10 seconds)
@@ -1117,7 +1204,7 @@ class FleetDispatchAcsDefendTest extends FleetDispatchTestCase
 
         $unitCollection = new UnitCollection();
         $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 1);
-        $this->checkTargetFleet($this->allianceMemberPlanet->getPlanetCoordinates(), $unitCollection, PlanetType::Planet, true);
+        $this->checkTargetFleet($this->getAllianceMemberPlanet()->getPlanetCoordinates(), $unitCollection, PlanetType::Planet, true);
     }
 
     /**
@@ -1130,7 +1217,7 @@ class FleetDispatchAcsDefendTest extends FleetDispatchTestCase
 
         $unitCollection = new UnitCollection();
         $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 1);
-        $this->checkTargetFleet($this->otherPlanet->getPlanetCoordinates(), $unitCollection, PlanetType::Planet, false);
+        $this->checkTargetFleet($this->getOtherPlanet()->getPlanetCoordinates(), $unitCollection, PlanetType::Planet, false);
     }
 
     /**
@@ -1148,7 +1235,7 @@ class FleetDispatchAcsDefendTest extends FleetDispatchTestCase
         // Send fleet to alliance member's planet.
         $unitCollection = new UnitCollection();
         $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 2);
-        $this->dispatchFleet($this->allianceMemberPlanet->getPlanetCoordinates(), $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet, 2);
+        $this->dispatchFleet($this->getAllianceMemberPlanet()->getPlanetCoordinates(), $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet, 2);
 
         // Verify units were deducted
         $response = $this->get('/shipyard');

--- a/tests/Feature/FleetDispatch/FleetDispatchAttackTest.php
+++ b/tests/Feature/FleetDispatch/FleetDispatchAttackTest.php
@@ -18,6 +18,7 @@ use OGame\Models\Resources;
 use OGame\Services\DebrisFieldService;
 use OGame\Services\FleetMissionService;
 use OGame\Services\ObjectService;
+use OGame\Services\PlayerService;
 use OGame\Services\SettingsService;
 use Tests\FleetDispatchTestCase;
 
@@ -68,10 +69,23 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
         $this->planetAddResources(new Resources(0, 0, 1000000, 0));
     }
 
+    /**
+     * Get the current planet's player, failing the test if it is null.
+     */
+    private function planetPlayer(): PlayerService
+    {
+        $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('Planet has no player.');
+        }
+
+        return $player;
+    }
+
     protected function messageCheckMissionArrival(): void
     {
         // Assert that attacker has received a message (either battle_report or fleet_lost_contact).
-        $messageAttacker = Message::where('user_id', $this->planetService->getPlayer()->getId())
+        $messageAttacker = Message::where('user_id', $this->planetPlayer()->getId())
         ->whereIn('key', ['battle_report', 'fleet_lost_contact'])
         ->orderByDesc('id')
         ->first();
@@ -179,14 +193,18 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
         $response->assertStatus(200);
 
         // Get message of attacker from database (either battle_report or fleet_lost_contact).
-        $messageAttacker = Message::where('user_id', $this->planetService->getPlayer()->getId())
+        $messageAttacker = Message::where('user_id', $this->planetPlayer()->getId())
             ->whereIn('key', ['battle_report', 'fleet_lost_contact'])
             ->orderByDesc('id')
             ->first();
         $this->assertNotNull($messageAttacker, 'Attacker has not received a message after combat.');
 
         // Assert that defender also received a message with the same battle report ID.
-        $messageDefender = Message::where('user_id', $foreignPlanet->getPlayer()->getId())->orderByDesc('id')->first();
+        $foreignPlanetPlayer = $foreignPlanet->getPlayer();
+        if ($foreignPlanetPlayer === null) {
+            $this->fail('Foreign planet has no player.');
+        }
+        $messageDefender = Message::where('user_id', $foreignPlanetPlayer->getId())->orderByDesc('id')->first();
         if ($messageDefender) {
             $messageDefender = $messageDefender instanceof Message ? $messageDefender : new Message($messageDefender->getAttributes());
             if ($messageAttacker->battle_report_id !== null) {
@@ -237,11 +255,15 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
         ]);
 
         // Get battle report message of attacker from database.
-        $messageAttacker = Message::where('user_id', $this->planetService->getPlayer()->getId())->where('key', 'battle_report')->orderByDesc('id')->first();
+        $messageAttacker = Message::where('user_id', $this->planetPlayer()->getId())->where('key', 'battle_report')->orderByDesc('id')->first();
         $this->assertNotNull($messageAttacker, 'Attacker has not received a battle report after combat.');
 
         // Assert that defender also received a message with the same battle report ID.
-        $messageDefender = Message::where('user_id', $foreignMoon->getPlayer()->getId())->orderByDesc('id')->first();
+        $foreignMoonPlayer = $foreignMoon->getPlayer();
+        if ($foreignMoonPlayer === null) {
+            $this->fail('Foreign moon has no player.');
+        }
+        $messageDefender = Message::where('user_id', $foreignMoonPlayer->getId())->orderByDesc('id')->first();
         if ($messageDefender) {
             $messageDefender = $messageDefender instanceof Message ? $messageDefender : new Message($messageDefender->getAttributes());
             $this->assertEquals($messageAttacker->battle_report_id, $messageDefender->battle_report_id, 'Defender has not received the same battle report as attacker.');
@@ -291,9 +313,13 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
             'Actual loot should be lower than the theoretical 6 000 because the fleet is nearly full'
         );
 
+        $foreignPlanetPlayer = $foreignPlanet->getPlayer();
+        if ($foreignPlanetPlayer === null) {
+            $this->fail('Foreign planet has no player.');
+        }
         $planetServiceFactory = resolve(PlanetServiceFactory::class);
         $refreshedForeignPlanet = $planetServiceFactory->makeForPlayer(
-            $foreignPlanet->getPlayer(),
+            $foreignPlanetPlayer,
             $foreignPlanet->getPlanetId()
         );
         $this->assertEquals(
@@ -327,6 +353,9 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
         // Get just dispatched fleet mission ID from database.
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($fleetMission === null) {
+            $this->fail('No active fleet mission found.');
+        }
         $fleetMissionId = $fleetMission->id;
 
         // Get time it takes for the fleet to travel to the second planet.
@@ -347,6 +376,9 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
 
         // Assert that the fleet mission is processed.
         $fleetMission = $fleetMissionService->getFleetMissionById($fleetMissionId, false);
+        if ($fleetMission === null) {
+            $this->fail('Fleet mission not found.');
+        }
         $this->assertTrue($fleetMission->processed == 1, 'Fleet mission is not processed after fleet has arrived at destination.');
 
         // Check that message has been received by calling extended method
@@ -357,8 +389,13 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
         // Assert that a return trip has been launched by checking the active missions for the current planet.
         $this->assertCount(1, $activeMissions, 'No return trip launched after fleet with deployment mission has arrived at destination.');
 
+        $returnActiveMission = $activeMissions->first();
+        if ($returnActiveMission === null) {
+            $this->fail('No return trip mission found.');
+        }
+
         // Advance time by amount of minutes it takes for the return trip to arrive.
-        $this->travelTo(Date::createFromTimestamp($activeMissions->first()->time_arrival));
+        $this->travelTo(Date::createFromTimestamp($returnActiveMission->time_arrival));
 
         // Do a request to trigger the update logic.
         $response = $this->get('/overview');
@@ -367,12 +404,16 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
         // Assert that the return trip is processed and that the stolen resources mentioned in the
         // battle report are present on the return trip. Return deuterium can be higher because the
         // fleet mission payload also includes surviving mission fuel.
-        $fleetMission = $fleetMissionService->getFleetMissionById($activeMissions->first()->id, false);
+        $fleetMission = $fleetMissionService->getFleetMissionById($returnActiveMission->id, false);
+        if ($fleetMission === null) {
+            $this->fail('Fleet mission not found.');
+        }
         $this->assertTrue($fleetMission->processed == 1, 'Return trip is not processed after fleet has arrived back at origin planet.');
 
         // Get most recent battle report ID from the database.
         $battleReport = BattleReport::orderBy('id', 'desc')->first();
-        $battleReportResources = new Resources($battleReport->loot['metal'], $battleReport->loot['crystal'], $battleReport->loot['deuterium'], 0);
+        $this->assertNotNull($battleReport, 'Battle report was not created.');
+        $battleReportResources = new Resources($battleReport->loot['metal'] ?? 0, $battleReport->loot['crystal'] ?? 0, $battleReport->loot['deuterium'] ?? 0, 0);
 
         $this->assertEquals($battleReportResources->metal->get(), $fleetMission->metal, 'Return trip metal should match looted metal in the battle report.');
         $this->assertEquals($battleReportResources->crystal->get(), $fleetMission->crystal, 'Return trip crystal should match looted crystal in the battle report.');
@@ -436,11 +477,17 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
         // Get just dispatched fleet mission ID from database.
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($fleetMission === null) {
+            $this->fail('No active fleet mission found.');
+        }
         $fleetMissionId = $fleetMission->id;
 
         // Advance time by 5 seconds.
         $this->travel(5)->seconds();
         $fleetParentTime = Date::getTestNow();
+        if ($fleetParentTime === null) {
+            $this->fail('Test now time is not set.');
+        }
 
         // Cancel the mission
         $response = $this->post('/ajax/fleet/dispatch/recall-fleet', [
@@ -451,6 +498,9 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
 
         // Assert that the original mission is now canceled.
         $fleetMission = $fleetMissionService->getFleetMissionById($fleetMissionId, false);
+        if ($fleetMission === null) {
+            $this->fail('Fleet mission not found.');
+        }
         $this->assertTrue($fleetMission->canceled == 1, 'Fleet mission is not canceled after fleet recall is requested.');
 
         // Assert that only the return trip is now visible.
@@ -462,8 +512,14 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
 
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($fleetMission === null) {
+            $this->fail('No active fleet mission found.');
+        }
         $fleetMissionId = $fleetMission->id;
         $fleetMission = $fleetMissionService->getFleetMissionById($fleetMissionId, false);
+        if ($fleetMission === null) {
+            $this->fail('Fleet mission not found.');
+        }
 
         // Assert that the return trip arrival time is exactly 10 seconds  after the cancelation time.
         // Because the return trip should take exactly as long as the original trip has traveled until it was canceled.
@@ -481,6 +537,9 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
 
         // Assert that the return trip is processed.
         $fleetMission = $fleetMissionService->getFleetMissionById($fleetMissionId, false);
+        if ($fleetMission === null) {
+            $this->fail('Fleet mission not found.');
+        }
         $this->assertTrue($fleetMission->processed == 1, 'Return trip is not processed after fleet has arrived back at origin planet.');
 
         // Assert that the units have been returned to the origin planet.
@@ -511,6 +570,9 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
         // Get just dispatched fleet mission ID from database.
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($fleetMission === null) {
+            $this->fail('No active fleet mission found.');
+        }
         $fleetMissionId = $fleetMission->id;
 
         // Advance time by 10 seconds
@@ -621,6 +683,9 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
         // Get just dispatched fleet mission ID from database.
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($fleetMission === null) {
+            $this->fail('No active fleet mission found.');
+        }
         $fleetMissionId = $fleetMission->id;
 
         // Get time it takes for the fleet to travel to the second planet.
@@ -638,6 +703,9 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
 
         // Assert that the fleet mission is processed.
         $fleetMission = $fleetMissionService->getFleetMissionById($fleetMissionId, false);
+        if ($fleetMission === null) {
+            $this->fail('Fleet mission not found.');
+        }
         $this->assertTrue($fleetMission->processed == 1, 'Fleet mission is not processed after fleet has arrived at destination.');
 
         // Check that combat message has been received to ensure battle has taken place.
@@ -704,7 +772,11 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
 
         // Set foreign planet player's computer level to +1 to ensure we don't run into max fleet slots restriction
         // in case they were already sending a mission and at max slots.
-        $foreignPlanet->getPlayer()->setResearchLevel('computer_technology', $foreignPlanet->getPlayer()->getResearchLevel('computer_technology') + 1);
+        $foreignPlanetPlayer = $foreignPlanet->getPlayer();
+        if ($foreignPlanetPlayer === null) {
+            $this->fail('Foreign planet has no player.');
+        }
+        $foreignPlanetPlayer->setResearchLevel('computer_technology', $foreignPlanetPlayer->getResearchLevel('computer_technology') + 1);
 
         // Launch attack from foreign planet to the current players second planet.
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $foreignPlanet->getPlayer()]);
@@ -721,6 +793,9 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
 
         // Assert that the fleet mission is processed.
         $fleetMission = $fleetMissionService->getFleetMissionById($fleetMission->id, false);
+        if ($fleetMission === null) {
+            $this->fail('Fleet mission not found.');
+        }
         $this->assertTrue($fleetMission->processed === 1, 'Fleet mission is not processed associated with players second (not-selected) planet.');
     }
 
@@ -751,6 +826,9 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
         // Get just dispatched fleet mission ID from database.
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($fleetMission === null) {
+            $this->fail('No active fleet mission found.');
+        }
         $fleetMissionId = $fleetMission->id;
 
         // Get time it takes for the fleet to travel to the second planet.
@@ -768,6 +846,9 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
 
         // Assert that the fleet mission is processed.
         $fleetMission = $fleetMissionService->getFleetMissionById($fleetMissionId, false);
+        if ($fleetMission === null) {
+            $this->fail('Fleet mission not found.');
+        }
         $this->assertTrue($fleetMission->processed == 1, 'Fleet mission is not processed after fleet has arrived at destination.');
 
         // Get the battle report
@@ -776,7 +857,7 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
 
         // Assert that the battle report contains debris field information
         $this->assertNotEmpty($battleReport->debris, 'Battle report does not contain debris field information.');
-        $this->assertGreaterThan(0, $battleReport->debris['metal'] + $battleReport->debris['crystal'] + $battleReport->debris['deuterium'], 'Debris field in battle report is empty.');
+        $this->assertGreaterThan(0, ($battleReport->debris['metal'] ?? 0) + ($battleReport->debris['crystal'] ?? 0) + ($battleReport->debris['deuterium'] ?? 0), 'Debris field in battle report is empty.');
 
         // Assert that a debris field was actually created in the database
         $debrisFieldService = resolve(DebrisFieldService::class);
@@ -784,9 +865,9 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
         $this->assertTrue($debrisFieldExists, 'Debris field was not created in the database.');
 
         $debrisResources = $debrisFieldService->getResources();
-        $this->assertEquals($battleReport->debris['metal'], $debrisResources->metal->get(), 'Debris field metal in database does not match battle report.');
-        $this->assertEquals($battleReport->debris['crystal'], $debrisResources->crystal->get(), 'Debris field crystal in database does not match battle report.');
-        $this->assertEquals($battleReport->debris['deuterium'], $debrisResources->deuterium->get(), 'Debris field deuterium in database does not match battle report.');
+        $this->assertEquals(($battleReport->debris['metal'] ?? 0), $debrisResources->metal->get(), 'Debris field metal in database does not match battle report.');
+        $this->assertEquals(($battleReport->debris['crystal'] ?? 0), $debrisResources->crystal->get(), 'Debris field crystal in database does not match battle report.');
+        $this->assertEquals(($battleReport->debris['deuterium'] ?? 0), $debrisResources->deuterium->get(), 'Debris field deuterium in database does not match battle report.');
     }
 
     /**
@@ -820,6 +901,9 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
         // Get fleet mission
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($fleetMission === null) {
+            $this->fail('No active fleet mission found.');
+        }
         $fleetMissionId = $fleetMission->id;
 
         // Calculate fleet mission duration
@@ -837,6 +921,9 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
 
         // Assert that the fleet mission is processed without errors
         $fleetMission = $fleetMissionService->getFleetMissionById($fleetMissionId, false);
+        if ($fleetMission === null) {
+            $this->fail('Fleet mission not found.');
+        }
         $this->assertTrue($fleetMission->processed == 1, 'Large-scale fleet mission was not processed successfully.');
 
         // Get the battle report
@@ -845,7 +932,7 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
 
         // Assert that the battle report contains debris field information
         $this->assertNotEmpty($battleReport->debris, 'Battle report does not contain debris field information for large-scale attack.');
-        $this->assertGreaterThan(0, $battleReport->debris['metal'] + $battleReport->debris['crystal'] + $battleReport->debris['deuterium'], 'Debris field in battle report is empty for large-scale attack.');
+        $this->assertGreaterThan(0, ($battleReport->debris['metal'] ?? 0) + ($battleReport->debris['crystal'] ?? 0) + ($battleReport->debris['deuterium'] ?? 0), 'Debris field in battle report is empty for large-scale attack.');
 
         // Assert that a debris field was actually created in the database
         $debrisFieldService = resolve(DebrisFieldService::class);
@@ -881,6 +968,9 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
         // Get fleet mission
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($fleetMission === null) {
+            $this->fail('No active fleet mission found.');
+        }
         $fleetMissionId = $fleetMission->id;
 
         // Calculate fleet mission duration
@@ -898,20 +988,23 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
 
         // Assert that the fleet mission is processed without errors
         $fleetMission = $fleetMissionService->getFleetMissionById($fleetMissionId, false);
+        if ($fleetMission === null) {
+            $this->fail('Fleet mission not found.');
+        }
         $this->assertTrue($fleetMission->processed == 1, 'Battle with expected moon creation fleet mission was not processed successfully.');
 
         // Get the battle report
         $battleReport = BattleReport::orderBy('id', 'desc')->first();
         $this->assertNotNull($battleReport, 'Battle report was not created for battle that should result in moon creation.');
-        $this->assertSame(100, $battleReport->general['moon_chance'], 'Battle report does not contain 100% moon chance.');
+        $this->assertSame(100, ($battleReport->general['moon_chance'] ?? 0), 'Battle report does not contain 100% moon chance.');
 
         $this->assertNotEmpty($battleReport->debris, 'Battle report does not contain debris field information for large-scale attack.');
-        $this->assertFalse($battleReport->general['moon_existed'], 'Battle report does not contain correct boolean that moon already existed before battle.');
-        $this->assertTrue($battleReport->general['moon_created'], 'Battle report does not contain moon creation information.');
+        $this->assertFalse(($battleReport->general['moon_existed'] ?? false), 'Battle report does not contain correct boolean that moon already existed before battle.');
+        $this->assertTrue(($battleReport->general['moon_created'] ?? false), 'Battle report does not contain moon creation information.');
 
         // Assert that debris field is at least 10M resources combined as every 100k results in 1%
         // So 10M results in 100% moon chance which is required for this test.
-        $this->assertGreaterThan(10000000, $battleReport->debris['metal'] + $battleReport->debris['crystal'] + $battleReport->debris['deuterium'], 'Debris field in battle report does not contain at least 10M resources required for 100% moon chance.');
+        $this->assertGreaterThan(10000000, ($battleReport->debris['metal'] ?? 0) + ($battleReport->debris['crystal'] ?? 0) + ($battleReport->debris['deuterium'] ?? 0), 'Debris field in battle report does not contain at least 10M resources required for 100% moon chance.');
 
         // Assert that a moon was actually created by attempting to load it.
         $planetServiceFactory = resolve(PlanetServiceFactory::class);
@@ -953,6 +1046,9 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
         // Get fleet mission
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($fleetMission === null) {
+            $this->fail('No active fleet mission found.');
+        }
         $fleetMissionId = $fleetMission->id;
 
         // Calculate fleet mission duration
@@ -970,14 +1066,17 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
 
         // Assert that the fleet mission is processed without errors
         $fleetMission = $fleetMissionService->getFleetMissionById($fleetMissionId, false);
+        if ($fleetMission === null) {
+            $this->fail('Fleet mission not found.');
+        }
         $this->assertTrue($fleetMission->processed == 1, 'Battle with expected moon creation fleet mission was not processed successfully.');
 
         // Get the battle report
         $battleReport = BattleReport::orderBy('id', 'desc')->first();
         $this->assertNotNull($battleReport, 'Battle report was not created for battle that should result in moon creation.');
-        $this->assertSame(0, $battleReport->general['moon_chance'], 'Battle report should contain 0 percent moon chance because moon already existed before battle.');
-        $this->assertTrue($battleReport->general['moon_existed'], 'Battle report does not contain correct boolean that moon already existed before battle.');
-        $this->assertFalse($battleReport->general['moon_created'], 'Battle report does not contain moon creation information.');
+        $this->assertSame(0, ($battleReport->general['moon_chance'] ?? 0), 'Battle report should contain 0 percent moon chance because moon already existed before battle.');
+        $this->assertTrue(($battleReport->general['moon_existed'] ?? false), 'Battle report does not contain correct boolean that moon already existed before battle.');
+        $this->assertFalse(($battleReport->general['moon_created'] ?? false), 'Battle report does not contain moon creation information.');
     }
 
     /**
@@ -1015,6 +1114,9 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
         // Get fleet mission
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($fleetMission === null) {
+            $this->fail('No active fleet mission found.');
+        }
         $fleetMissionId = $fleetMission->id;
 
         // Calculate fleet mission duration
@@ -1032,6 +1134,9 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
 
         // Assert that the fleet mission is processed without errors
         $fleetMission = $fleetMissionService->getFleetMissionById($fleetMissionId, false);
+        if ($fleetMission === null) {
+            $this->fail('Fleet mission not found.');
+        }
         $this->assertTrue($fleetMission->processed == 1, 'Battle against moon fleet mission was not processed successfully.');
 
         // Get the battle report
@@ -1039,13 +1144,13 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
         $this->assertNotNull($battleReport, 'Battle report was not created for battle against moon.');
 
         // Assert that battle report shows moon was NOT created (moon_created should be false)
-        $this->assertFalse($battleReport->general['moon_created'], 'Moon creation should not occur when attacking a moon, even with sufficient debris.');
+        $this->assertFalse(($battleReport->general['moon_created'] ?? false), 'Moon creation should not occur when attacking a moon, even with sufficient debris.');
 
         // Assert that battle report indicates moon already existed
-        $this->assertTrue($battleReport->general['moon_existed'], 'Battle report should indicate that moon already existed before battle.');
+        $this->assertTrue(($battleReport->general['moon_existed'] ?? false), 'Battle report should indicate that moon already existed before battle.');
 
         // Assert that moon chance is 0 (because moon already exists)
-        $this->assertSame(0, $battleReport->general['moon_chance'], 'Moon chance should be 0 when attacking a moon.');
+        $this->assertSame(0, ($battleReport->general['moon_chance'] ?? 0), 'Moon chance should be 0 when attacking a moon.');
 
         // Verify there's still exactly one moon at these coordinates (no duplicate created)
         $moonAtCoordinates = $planetServiceFactory->makeMoonForCoordinate($moonCoordinates);
@@ -1100,6 +1205,9 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
             // Get fleet mission
             $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
             $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+            if ($fleetMission === null) {
+                $this->fail('No active fleet mission found.');
+            }
             $fleetMissionId = $fleetMission->id;
 
             // Calculate fleet mission duration
@@ -1122,6 +1230,9 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
 
             // Assert that the fleet mission is processed
             $fleetMission = $fleetMissionService->getFleetMissionById($fleetMissionId, false);
+            if ($fleetMission === null) {
+                $this->fail('Fleet mission not found.');
+            }
             $this->assertTrue($fleetMission->processed == 1, 'Fleet mission was not processed successfully.');
 
             // Get the battle report
@@ -1129,7 +1240,7 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
             $this->assertNotNull($battleReport, 'Battle report was not created.');
 
             // Check if moon was created in this attempt
-            if ($battleReport->general['moon_created']) {
+            if (($battleReport->general['moon_created'] ?? false)) {
                 $moonCreated = true;
             }
 
@@ -1201,6 +1312,9 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
 
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($fleetMission === null) {
+            $this->fail('No active fleet mission found.');
+        }
         $fleetMissionDuration = $fleetMissionService->calculateFleetMissionDuration($this->planetService, $foreignPlanet->getPlanetCoordinates(), $unitCollection, resolve(AttackMission::class));
 
         // Set time to fleet mission duration + 1 second.
@@ -1213,6 +1327,9 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
 
         // Assert that the fleet mission is processed.
         $fleetMission = $fleetMissionService->getFleetMissionById($fleetMission->id, false);
+        if ($fleetMission === null) {
+            $this->fail('Fleet mission not found.');
+        }
         $this->assertTrue($fleetMission->processed == 1);
     }
 
@@ -1239,6 +1356,9 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
         // Get just dispatched fleet mission ID from database.
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($fleetMission === null) {
+            $this->fail('No active fleet mission found.');
+        }
         $fleetMissionId = $fleetMission->id;
 
         // Get time it takes for the fleet to travel to the second planet.
@@ -1259,24 +1379,31 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
 
         // Assert that the fleet mission is processed.
         $fleetMission = $fleetMissionService->getFleetMissionById($fleetMissionId, false);
+        if ($fleetMission === null) {
+            $this->fail('Fleet mission not found.');
+        }
         $this->assertTrue($fleetMission->processed == 1, 'Fleet mission is not processed after fleet has arrived at destination.');
 
         // Assert that attacker received a "fleet_lost_contact" message instead of battle report.
-        $attackerMessage = Message::where('user_id', $this->planetService->getPlayer()->getId())
+        $attackerMessage = Message::where('user_id', $this->planetPlayer()->getId())
             ->where('key', 'fleet_lost_contact')
             ->orderByDesc('id')
             ->first();
         $this->assertNotNull($attackerMessage, 'Attacker did not receive a fleet_lost_contact message after being destroyed in first round.');
 
         // Assert that attacker did NOT receive a normal battle report.
-        $attackerBattleReport = Message::where('user_id', $this->planetService->getPlayer()->getId())
+        $attackerBattleReport = Message::where('user_id', $this->planetPlayer()->getId())
             ->where('key', 'battle_report')
             ->orderByDesc('id')
             ->first();
         $this->assertNull($attackerBattleReport, 'Attacker received a battle report when they should have received fleet_lost_contact message.');
 
         // Assert that defender received the full battle report.
-        $defenderMessage = Message::where('user_id', $foreignPlanet->getPlayer()->getId())
+        $foreignPlanetPlayer = $foreignPlanet->getPlayer();
+        if ($foreignPlanetPlayer === null) {
+            $this->fail('Foreign planet has no player.');
+        }
+        $defenderMessage = Message::where('user_id', $foreignPlanetPlayer->getId())
             ->where('key', 'battle_report')
             ->orderByDesc('id')
             ->first();
@@ -1325,8 +1452,15 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
         $fleetMissionService = resolve(FleetMissionService::class);
         $activeMissions = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer();
         $this->assertCount(1, $activeMissions, 'Attack mission not created');
-        $fleetMissionId = $activeMissions->first()->id;
+        $firstMission = $activeMissions->first();
+        if ($firstMission === null) {
+            $this->fail('Attack mission not created.');
+        }
+        $fleetMissionId = $firstMission->id;
         $fleetMission = $fleetMissionService->getFleetMissionById($fleetMissionId, false);
+        if ($fleetMission === null) {
+            $this->fail('Fleet mission not found.');
+        }
 
         // Recall the mission before it arrives
         $fleetParentTime = Date::createFromTimestamp($fleetMission->time_departure);
@@ -1342,6 +1476,9 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
         $activeMissions = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer();
         $this->assertCount(1, $activeMissions, 'Return mission should be created after recall');
         $returnMission = $activeMissions->first();
+        if ($returnMission === null) {
+            $this->fail('Return mission should be created after recall.');
+        }
 
         // Verify return mission has original resources (deuterium may be slightly higher from fuel return)
         $this->assertEquals(80000, $returnMission->metal);
@@ -1510,12 +1647,12 @@ class FleetDispatchAttackTest extends FleetDispatchTestCase
         );
         $this->assertArrayHasKey(
             'rocket_launcher',
-            $battleReport->repaired_defenses,
+            $battleReport->repaired_defenses ?? [],
             'Battle report should contain repaired rocket launchers'
         );
         $this->assertEquals(
             100,
-            $battleReport->repaired_defenses['rocket_launcher'],
+            $battleReport->repaired_defenses['rocket_launcher'] ?? null,
             'With 100% repair rate, all 100 rocket launchers should be in repaired_defenses'
         );
     }

--- a/tests/Feature/FleetDispatch/FleetDispatchColoniseTest.php
+++ b/tests/Feature/FleetDispatch/FleetDispatchColoniseTest.php
@@ -2,13 +2,15 @@
 
 namespace Tests\Feature\FleetDispatch;
 
-use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Date;
 use OGame\Factories\PlanetServiceFactory;
 use OGame\GameObjects\Models\Units\UnitCollection;
 use OGame\Models\Enums\PlanetType;
+use OGame\Models\Planet\Coordinate;
 use OGame\Models\Resources;
 use OGame\Services\FleetMissionService;
 use OGame\Services\ObjectService;
+use OGame\Services\PlayerService;
 use Tests\FleetDispatchTestCase;
 
 /**
@@ -27,6 +29,18 @@ class FleetDispatchColoniseTest extends FleetDispatchTestCase
     protected string $missionName = 'Colonisation';
 
     protected bool $hasReturnMission = false;
+
+    /**
+     * Returns the current planet's player, failing the test if none is set.
+     */
+    private function currentPlayer(): PlayerService
+    {
+        $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('Player not found.');
+        }
+        return $player;
+    }
 
     /**
      * Prepare the planet for the test, so it has the required buildings and research.
@@ -119,7 +133,7 @@ class FleetDispatchColoniseTest extends FleetDispatchTestCase
         $this->assertNotNull($newPlanet, 'New planet cannot be loaded while it should have been created.');
 
         // Assert that last message sent to current player contains the new planet colonize confirm message.
-        $this->assertMessageReceivedAndContainsDatabase($this->planetService->getPlayer(), [
+        $this->assertMessageReceivedAndContainsDatabase($this->currentPlayer(), [
             'The fleet has arrived',
             'found a new planet there and are beginning to develop upon it immediately.',
         ]);
@@ -167,7 +181,7 @@ class FleetDispatchColoniseTest extends FleetDispatchTestCase
         $this->assertCount(2, $created_planets, 'Exactly two planets should have been created with astrophysics level 5. Check astrophysics logic.');
 
         // Check that 3 messages have been sent to the player about failed colonization attempts.
-        $this->assertMessageReceivedAndContainsDatabase($this->planetService->getPlayer(), [
+        $this->assertMessageReceivedAndContainsDatabase($this->currentPlayer(), [
             'The fleet has arrived',
             'knowledge of astrophysics is not sufficient',
         ], 3);
@@ -309,7 +323,7 @@ class FleetDispatchColoniseTest extends FleetDispatchTestCase
 
         // Create custom coordinates for position 3
         $planetCoords = $this->planetService->getPlanetCoordinates();
-        $targetCoordinates = new \OGame\Models\Planet\Coordinate($planetCoords->galaxy, $planetCoords->system, 3);
+        $targetCoordinates = new Coordinate($planetCoords->galaxy, $planetCoords->system, 3);
 
         // This should fail with 400 status
         $this->dispatchFleet($targetCoordinates, $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet, 0, false);
@@ -349,7 +363,7 @@ class FleetDispatchColoniseTest extends FleetDispatchTestCase
 
         // Create custom coordinates for position 2
         $planetCoords = $this->planetService->getPlanetCoordinates();
-        $targetCoordinates = new \OGame\Models\Planet\Coordinate($planetCoords->galaxy, $planetCoords->system, 2);
+        $targetCoordinates = new Coordinate($planetCoords->galaxy, $planetCoords->system, 2);
 
         // This should fail with 400 status
         $this->dispatchFleet($targetCoordinates, $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet, 0, false);
@@ -389,7 +403,7 @@ class FleetDispatchColoniseTest extends FleetDispatchTestCase
 
         // Create custom coordinates for position 1
         $planetCoords = $this->planetService->getPlanetCoordinates();
-        $targetCoordinates = new \OGame\Models\Planet\Coordinate($planetCoords->galaxy, $planetCoords->system, 1);
+        $targetCoordinates = new Coordinate($planetCoords->galaxy, $planetCoords->system, 1);
 
         // This should fail with 400 status
         $this->dispatchFleet($targetCoordinates, $unitCollection, new Resources(0, 0, 0, 0), PlanetType::Planet, 0, false);
@@ -436,10 +450,15 @@ class FleetDispatchColoniseTest extends FleetDispatchTestCase
         // Get just dispatched fleet mission ID from database.
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($fleetMission === null) {
+            $this->fail('Fleet mission not found.');
+        }
         $fleetMissionId = $fleetMission->id;
 
         // Advance time by 1 minute
-        $fleetParentTime = Carbon::getTestNow()->addMinute();
+        $testNow = Date::getTestNow();
+        $this->assertNotNull($testNow, 'Test time not set');
+        $fleetParentTime = $testNow->addMinute();
         $this->travelTo($fleetParentTime);
 
         // Cancel the mission
@@ -451,6 +470,9 @@ class FleetDispatchColoniseTest extends FleetDispatchTestCase
 
         // Assert that the original mission is now canceled.
         $fleetMission = $fleetMissionService->getFleetMissionById($fleetMissionId, false);
+        if ($fleetMission === null) {
+            $this->fail('Fleet mission not found.');
+        }
         $this->assertTrue($fleetMission->canceled == 1, 'Fleet mission is not canceled after fleet recall is requested.');
 
         // Assert that only the return trip is now visible.
@@ -462,21 +484,30 @@ class FleetDispatchColoniseTest extends FleetDispatchTestCase
 
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($fleetMission === null) {
+            $this->fail('Fleet mission not found.');
+        }
         $fleetMissionId = $fleetMission->id;
         $fleetMission = $fleetMissionService->getFleetMissionById($fleetMissionId, false);
+        if ($fleetMission === null) {
+            $this->fail('Fleet mission not found.');
+        }
 
         // Assert that the return trip arrival time is exactly 1 minute after the cancellation time.
         // Because the return trip should take exactly as long as the original trip has traveled until it was canceled.
         $this->assertTrue($fleetMission->time_arrival == $fleetParentTime->addSeconds(60)->timestamp, 'Return trip duration is not the same as the original mission has been active.');
 
         // Advance time by amount it takes for the return trip to arrive.
-        $this->travelTo(Carbon::createFromTimestamp($fleetMission->time_arrival));
+        $this->travelTo(Date::createFromTimestamp($fleetMission->time_arrival));
 
         // Do a request to trigger the update logic.
         $this->get('/overview');
 
         // Assert that the return trip is processed.
         $fleetMission = $fleetMissionService->getFleetMissionById($fleetMissionId, false);
+        if ($fleetMission === null) {
+            $this->fail('Fleet mission not found.');
+        }
         $this->assertTrue($fleetMission->processed == 1, 'Return trip is not processed after fleet has arrived back at origin planet.');
 
         // Assert that the units have been returned to the origin planet.
@@ -488,7 +519,7 @@ class FleetDispatchColoniseTest extends FleetDispatchTestCase
         $this->assertTrue($this->planetService->hasResources(new Resources(5000, 5000, 0, 0)), 'Resources are not returned to origin planet after recalling mission.');
 
         // Assert that the last message sent contains the return trip message.
-        $this->assertMessageReceivedAndContainsDatabase($this->planetService->getPlayer(), [
+        $this->assertMessageReceivedAndContainsDatabase($this->currentPlayer(), [
             'Your fleet is returning from',
             '[' . $emptyPositionCoordinate->asString() . ']',
             'Metal: 5,000',

--- a/tests/Feature/FleetDispatch/FleetDispatchCounterEspionageTest.php
+++ b/tests/Feature/FleetDispatch/FleetDispatchCounterEspionageTest.php
@@ -2,10 +2,13 @@
 
 namespace Tests\Feature\FleetDispatch;
 
+use OGame\Factories\GameMessageFactory;
+use OGame\Factories\PlanetServiceFactory;
 use OGame\GameObjects\Models\Units\UnitCollection;
 use OGame\Models\BattleReport;
 use OGame\Models\Enums\PlanetType;
 use OGame\Models\EspionageReport;
+use OGame\Models\Message;
 use OGame\Models\Resources;
 use OGame\Services\CounterEspionageService;
 use OGame\Services\FleetMissionService;
@@ -230,7 +233,7 @@ class FleetDispatchCounterEspionageTest extends FleetDispatchTestCase
             $this->assertNotNull($battleReport, 'Battle report should exist.');
 
             // Verify defender units only contain ships, not defense
-            $defenderUnits = $battleReport->defender['units'];
+            $defenderUnits = $battleReport->defender['units'] ?? [];
 
             // Check that no defense units are in the battle
             $this->assertArrayNotHasKey('rocket_launcher', $defenderUnits, 'Rocket launchers should not be in counter-espionage battle.');
@@ -318,7 +321,11 @@ class FleetDispatchCounterEspionageTest extends FleetDispatchTestCase
         $foreignPlanet = $this->getNearbyForeignPlanet();
 
         // Set defender's espionage technology very high to further guarantee counter-espionage
-        $foreignPlanet->getPlayer()->setResearchLevel('espionage_technology', 10);
+        $foreignPlanetPlayer = $foreignPlanet->getPlayer();
+        if ($foreignPlanetPlayer === null) {
+            $this->fail('Foreign planet has no player.');
+        }
+        $foreignPlanetPlayer->setResearchLevel('espionage_technology', 10);
 
         // Add overwhelming number of ships
         $foreignPlanet->addUnit('battlecruiser', 5000);
@@ -326,8 +333,11 @@ class FleetDispatchCounterEspionageTest extends FleetDispatchTestCase
         $foreignPlanet->update(); // Ensure planet state is fully persisted
 
         // Force a fresh reload of the foreign planet to ensure no caching issues
-        $planetServiceFactory = resolve(\OGame\Factories\PlanetServiceFactory::class);
+        $planetServiceFactory = resolve(PlanetServiceFactory::class);
         $foreignPlanet = $planetServiceFactory->make($foreignPlanet->getPlanetId());
+        if ($foreignPlanet === null) {
+            $this->fail('Foreign planet could not be reloaded.');
+        }
 
         // Send only 1 probe (high chance to be destroyed)
         $unitCollection = new UnitCollection();
@@ -374,7 +384,11 @@ class FleetDispatchCounterEspionageTest extends FleetDispatchTestCase
         $foreignPlanet = $this->getNearbyForeignPlanet();
 
         // Set defender's espionage technology very high to further guarantee counter-espionage
-        $foreignPlanet->getPlayer()->setResearchLevel('espionage_technology', 10);
+        $foreignPlanetPlayer = $foreignPlanet->getPlayer();
+        if ($foreignPlanetPlayer === null) {
+            $this->fail('Foreign planet has no player.');
+        }
+        $foreignPlanetPlayer->setResearchLevel('espionage_technology', 10);
 
         // Add overwhelming number of ships
         $foreignPlanet->addUnit('battlecruiser', 5000);
@@ -382,8 +396,11 @@ class FleetDispatchCounterEspionageTest extends FleetDispatchTestCase
         $foreignPlanet->update(); // Ensure planet state is fully persisted
 
         // Force a fresh reload of the foreign planet to ensure no caching issues
-        $planetServiceFactory = resolve(\OGame\Factories\PlanetServiceFactory::class);
+        $planetServiceFactory = resolve(PlanetServiceFactory::class);
         $foreignPlanet = $planetServiceFactory->make($foreignPlanet->getPlanetId());
+        if ($foreignPlanet === null) {
+            $this->fail('Foreign planet could not be reloaded.');
+        }
 
         // Send only 1 probe (high chance to be destroyed)
         $unitCollection = new UnitCollection();
@@ -437,7 +454,7 @@ class FleetDispatchCounterEspionageTest extends FleetDispatchTestCase
         ]);
 
         // Check that espionage_detected message was created
-        $espionageDetectedMessage = \OGame\Models\Message::where('key', 'espionage_detected')
+        $espionageDetectedMessage = Message::where('key', 'espionage_detected')
             ->orderByDesc('id')
             ->first();
 
@@ -445,7 +462,7 @@ class FleetDispatchCounterEspionageTest extends FleetDispatchTestCase
 
         // Verify the message contains expected text
         if ($espionageDetectedMessage) {
-            $gameMessage = \OGame\Factories\GameMessageFactory::createGameMessage($espionageDetectedMessage);
+            $gameMessage = GameMessageFactory::createGameMessage($espionageDetectedMessage);
             $body = $gameMessage->getBody();
             $this->assertStringContainsString('was sighted near your planet', $body);
         }

--- a/tests/Feature/FleetDispatch/FleetDispatchDeployTest.php
+++ b/tests/Feature/FleetDispatch/FleetDispatchDeployTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Feature\FleetDispatch;
 
-use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Date;
 use OGame\GameMissions\DeploymentMission;
 use OGame\GameObjects\Models\Units\UnitCollection;
 use OGame\Models\Resources;
@@ -63,12 +63,14 @@ class FleetDispatchDeployTest extends FleetDispatchTestCase
 
     protected function messageCheckMissionReturn(): void
     {
+        $secondPlanet = $this->secondPlanetService;
+        $this->assertNotNull($secondPlanet, 'Second planet not found');
         // Assert that message has been sent to player and contains the correct information.
         $this->assertMessageReceivedAndContains('fleets', 'other', [
             'Your fleet is returning from',
             'Metal:',
             $this->planetService->getPlanetName(),
-            $this->secondPlanetService->getPlanetName()
+            $secondPlanet->getPlanetName()
         ]);
     }
 
@@ -125,11 +127,13 @@ class FleetDispatchDeployTest extends FleetDispatchTestCase
         $response->assertStatus(200);
 
         // Assert that message has been sent to player and contains the correct information.
+        $secondPlanet = $this->secondPlanetService;
+        $this->assertNotNull($secondPlanet, 'Second planet not found');
         $this->assertMessageReceivedAndContains('fleets', 'other', [
             'has reached',
             //'The fleet doesn`t deliver goods.', Deployment now leaves half of the consumed deuterium on the target, so this feature has been removed.
             $this->planetService->getPlanetName(),
-            $this->secondPlanetService->getPlanetName()
+            $secondPlanet->getPlanetName()
         ]);
 
         // Assert that the units have been added to the second planet.
@@ -229,10 +233,13 @@ class FleetDispatchDeployTest extends FleetDispatchTestCase
         // Get just dispatched fleet mission ID from database.
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        $this->assertNotNull($fleetMission, 'Fleet mission not found');
         $fleetMissionId = $fleetMission->id;
 
         // Get time it takes for the fleet to travel to the second planet.
-        $fleetMissionDuration = $fleetMissionService->calculateFleetMissionDuration($this->planetService, $this->secondPlanetService->getPlanetCoordinates(), $unitCollection, resolve(DeploymentMission::class));
+        $secondPlanet = $this->secondPlanetService;
+        $this->assertNotNull($secondPlanet, 'Second planet not found');
+        $fleetMissionDuration = $fleetMissionService->calculateFleetMissionDuration($this->planetService, $secondPlanet->getPlanetCoordinates(), $unitCollection, resolve(DeploymentMission::class));
 
         // Set time to fleet mission duration + 30 seconds (we do 30 instead of 1 second to test later if the return trip start and endtime work as expected
         // and are calculated based on the arrival time instead of the time the job got processed).
@@ -247,10 +254,11 @@ class FleetDispatchDeployTest extends FleetDispatchTestCase
 
         // Assert that the fleet mission is processed.
         $fleetMission = $fleetMissionService->getFleetMissionById($fleetMissionId, false);
+        $this->assertNotNull($fleetMission, 'Fleet mission not found');
         $this->assertTrue($fleetMission->processed == 1, 'Fleet mission is not processed after fleet has arrived at destination.');
 
         // Check that message has been received by calling extended method
-        $this->messageCheckMissionArrival($this->secondPlanetService);
+        $this->messageCheckMissionArrival($secondPlanet);
 
         $activeMissions = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer();
 
@@ -277,6 +285,7 @@ class FleetDispatchDeployTest extends FleetDispatchTestCase
         // Get just dispatched fleet mission ID from database.
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        $this->assertNotNull($fleetMission, 'Fleet mission not found');
         $fleetMissionId = $fleetMission->id;
 
         // Get time it takes for the fleet to travel to the second planet.
@@ -295,6 +304,7 @@ class FleetDispatchDeployTest extends FleetDispatchTestCase
 
         // Assert that the fleet mission is processed.
         $fleetMission = $fleetMissionService->getFleetMissionById($fleetMissionId, false);
+        $this->assertNotNull($fleetMission, 'Fleet mission not found');
         $this->assertTrue($fleetMission->processed == 1, 'Fleet mission is not processed after fleet has arrived at destination.');
 
         // Check that message has been received by calling extended method
@@ -357,10 +367,13 @@ class FleetDispatchDeployTest extends FleetDispatchTestCase
         // Get just dispatched fleet mission ID from database.
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        $this->assertNotNull($fleetMission, 'Fleet mission not found');
         $fleetMissionId = $fleetMission->id;
 
         // Advance time by 1 minute.
-        $fleetParentTime = Carbon::getTestNow()->addSeconds(60);
+        $testNow = Date::getTestNow();
+        $this->assertNotNull($testNow, 'Test time not set');
+        $fleetParentTime = $testNow->addSeconds(60);
         $this->travelTo($fleetParentTime);
 
         // Cancel the mission
@@ -372,6 +385,7 @@ class FleetDispatchDeployTest extends FleetDispatchTestCase
 
         // Assert that the original mission is now canceled.
         $fleetMission = $fleetMissionService->getFleetMissionById($fleetMissionId, false);
+        $this->assertNotNull($fleetMission, 'Fleet mission not found');
         $this->assertTrue($fleetMission->canceled == 1, 'Fleet mission is not canceled after fleet recall is requested.');
 
         // Assert that only the return trip is now visible.
@@ -383,8 +397,10 @@ class FleetDispatchDeployTest extends FleetDispatchTestCase
 
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        $this->assertNotNull($fleetMission, 'Fleet mission not found');
         $fleetMissionId = $fleetMission->id;
         $fleetMission = $fleetMissionService->getFleetMissionById($fleetMissionId, false);
+        $this->assertNotNull($fleetMission, 'Fleet mission not found');
 
         // Assert that the return trip arrival time is exactly 1 minute after the cancellation time.
         // Because the return trip should take exactly as long as the original trip has traveled until it was canceled.
@@ -394,7 +410,7 @@ class FleetDispatchDeployTest extends FleetDispatchTestCase
         $this->playerSetAllMessagesRead();
 
         // Advance time by amount of minutes it takes for the return trip to arrive.
-        $this->travelTo(Carbon::createFromTimestamp($fleetMission->time_arrival));
+        $this->travelTo(Date::createFromTimestamp($fleetMission->time_arrival));
 
         // Do a request to trigger the update logic.
         $response = $this->get('/overview');
@@ -402,6 +418,7 @@ class FleetDispatchDeployTest extends FleetDispatchTestCase
 
         // Assert that the return trip is processed.
         $fleetMission = $fleetMissionService->getFleetMissionById($fleetMissionId, false);
+        $this->assertNotNull($fleetMission, 'Fleet mission not found');
         $this->assertTrue($fleetMission->processed == 1, 'Return trip is not processed after fleet has arrived back at origin planet.');
 
         // Assert that the units have been returned to the origin planet.
@@ -433,6 +450,7 @@ class FleetDispatchDeployTest extends FleetDispatchTestCase
         // Get just dispatched fleet mission ID from database.
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        $this->assertNotNull($fleetMission, 'Fleet mission not found');
         $fleetMissionId = $fleetMission->id;
 
         // Advance time by 1 minute

--- a/tests/Feature/FleetDispatch/FleetDispatchEspionageTest.php
+++ b/tests/Feature/FleetDispatch/FleetDispatchEspionageTest.php
@@ -8,7 +8,6 @@ use OGame\Factories\PlayerServiceFactory;
 use OGame\GameMissions\EspionageMission;
 use OGame\GameObjects\Models\Units\UnitCollection;
 use OGame\Models\EspionageReport;
-use OGame\Models\Planet;
 use OGame\Models\Resources;
 use OGame\Services\DebrisFieldService;
 use OGame\Services\FleetMissionService;
@@ -260,6 +259,7 @@ class FleetDispatchEspionageTest extends FleetDispatchTestCase
         // Get just dispatched fleet mission ID from database.
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        $this->assertNotNull($fleetMission, 'Fleet mission not found');
         $fleetMissionId = $fleetMission->id;
 
         // Get time it takes for the fleet to travel to the second planet.
@@ -277,6 +277,7 @@ class FleetDispatchEspionageTest extends FleetDispatchTestCase
 
         // Assert that the fleet mission is processed.
         $fleetMission = $fleetMissionService->getFleetMissionById($fleetMissionId, false);
+        $this->assertNotNull($fleetMission, 'Fleet mission not found');
         $this->assertTrue($fleetMission->processed == 1, 'Fleet mission is not processed after fleet has arrived at destination.');
 
         // Check that message has been received by calling extended method
@@ -320,6 +321,7 @@ class FleetDispatchEspionageTest extends FleetDispatchTestCase
         // Cancel the fleet mission, so it doesn't interfere with other tests.
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        $this->assertNotNull($fleetMission, 'Fleet mission not found');
         $fleetMissionService->cancelMission($fleetMission);
     }
 
@@ -346,10 +348,13 @@ class FleetDispatchEspionageTest extends FleetDispatchTestCase
         // Get just dispatched fleet mission ID from database.
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        $this->assertNotNull($fleetMission, 'Fleet mission not found');
         $fleetMissionId = $fleetMission->id;
 
         // Advance time by 5 seconds.
-        $fleetParentTime = Date::getTestNow()->addSeconds(5);
+        $testNow = Date::getTestNow();
+        $this->assertNotNull($testNow, 'Test time not set');
+        $fleetParentTime = $testNow->addSeconds(5);
         $this->travelTo($fleetParentTime);
 
         // Cancel the mission
@@ -361,6 +366,7 @@ class FleetDispatchEspionageTest extends FleetDispatchTestCase
 
         // Assert that the original mission is now canceled.
         $fleetMission = $fleetMissionService->getFleetMissionById($fleetMissionId, false);
+        $this->assertNotNull($fleetMission, 'Fleet mission not found');
         $this->assertTrue($fleetMission->canceled == 1, 'Fleet mission is not canceled after fleet recall is requested.');
 
         // Assert that only the return trip is now visible.
@@ -372,8 +378,10 @@ class FleetDispatchEspionageTest extends FleetDispatchTestCase
 
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        $this->assertNotNull($fleetMission, 'Fleet mission not found');
         $fleetMissionId = $fleetMission->id;
         $fleetMission = $fleetMissionService->getFleetMissionById($fleetMissionId, false);
+        $this->assertNotNull($fleetMission, 'Fleet mission not found');
 
         // Assert that the return trip arrival time is exactly 10 seconds  after the cancelation time.
         // Because the return trip should take exactly as long as the original trip has traveled until it was canceled.
@@ -391,6 +399,7 @@ class FleetDispatchEspionageTest extends FleetDispatchTestCase
 
         // Assert that the return trip is processed.
         $fleetMission = $fleetMissionService->getFleetMissionById($fleetMissionId, false);
+        $this->assertNotNull($fleetMission, 'Fleet mission not found');
         $this->assertTrue($fleetMission->processed == 1, 'Return trip is not processed after fleet has arrived back at origin planet.');
 
         // Assert that the units have been returned to the origin planet.
@@ -420,6 +429,7 @@ class FleetDispatchEspionageTest extends FleetDispatchTestCase
         // Get just dispatched fleet mission ID from database.
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        $this->assertNotNull($fleetMission, 'Fleet mission not found');
         $fleetMissionId = $fleetMission->id;
 
         // Advance time by 5 seconds
@@ -482,6 +492,7 @@ class FleetDispatchEspionageTest extends FleetDispatchTestCase
         // Cancel the fleet mission, so it doesn't interfere with other tests.
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        $this->assertNotNull($fleetMission, 'Fleet mission not found');
         $fleetMissionService->cancelMission($fleetMission);
     }
 
@@ -494,6 +505,7 @@ class FleetDispatchEspionageTest extends FleetDispatchTestCase
 
         // Set user's preferred espionage probe count
         $playerService = $this->planetService->getPlayer();
+        $this->assertNotNull($playerService, 'Player not found');
         $playerService->setEspionageProbesAmount(5);
         $playerService->save();
 
@@ -537,6 +549,7 @@ class FleetDispatchEspionageTest extends FleetDispatchTestCase
 
         // Ensure user has no saved preference (should be null by default)
         $playerService = $this->planetService->getPlayer();
+        $this->assertNotNull($playerService, 'Player not found');
         $playerService->setEspionageProbesAmount(null);
         $playerService->save();
 
@@ -589,7 +602,9 @@ class FleetDispatchEspionageTest extends FleetDispatchTestCase
         $this->get('/overview');
 
         // Verify that an espionage report was created targeting the foreign player.
-        $targetUserId = $foreignPlanet->getPlayer()->getId();
+        $foreignPlayer = $foreignPlanet->getPlayer();
+        $this->assertNotNull($foreignPlayer, 'Foreign player not found');
+        $targetUserId = $foreignPlayer->getId();
         $report = EspionageReport::where('planet_user_id', $targetUserId)->first();
         $this->assertNotNull($report, 'Espionage report should exist before target player is deleted.');
 

--- a/tests/Feature/FleetDispatch/FleetDispatchExpeditionTest.php
+++ b/tests/Feature/FleetDispatch/FleetDispatchExpeditionTest.php
@@ -3,12 +3,18 @@
 namespace Tests\Feature\FleetDispatch;
 
 use Exception;
+use Illuminate\Support\Facades\Date;
 use OGame\GameMissions\Models\ExpeditionOutcomeType;
 use OGame\GameObjects\Models\Units\UnitCollection;
+use OGame\Models\BattleReport;
+use OGame\Models\Enums\PlanetType;
 use OGame\Models\Highscore;
+use OGame\Models\Message;
+use OGame\Models\Planet\Coordinate;
 use OGame\Models\Resources;
 use OGame\Services\FleetMissionService;
 use OGame\Services\ObjectService;
+use OGame\Services\PlayerService;
 use OGame\Services\SettingsService;
 use Tests\FleetDispatchTestCase;
 
@@ -49,6 +55,19 @@ class FleetDispatchExpeditionTest extends FleetDispatchTestCase
         $settingsService->set('fleet_speed_holding', 1);
         $settingsService->set('fleet_speed_peaceful', 1);
         $this->planetAddResources(new Resources(0, 0, 100000, 0));
+    }
+
+    /**
+     * Get the current planet's player, failing the test if it is null.
+     */
+    private function planetPlayer(): PlayerService
+    {
+        $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('Planet has no player.');
+        }
+
+        return $player;
     }
 
     protected function messageCheckMissionArrival(): void
@@ -126,8 +145,8 @@ class FleetDispatchExpeditionTest extends FleetDispatchTestCase
         $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('large_cargo'), 1);
 
         $currentPlanetCoords = $this->planetService->getPlanetCoordinates();
-        $coordinates = new \OGame\Models\Planet\Coordinate($currentPlanetCoords->galaxy, $currentPlanetCoords->system, 16);
-        $this->checkTargetFleet($coordinates, $unitCollection, \OGame\Models\Enums\PlanetType::DebrisField, false);
+        $coordinates = new Coordinate($currentPlanetCoords->galaxy, $currentPlanetCoords->system, 16);
+        $this->checkTargetFleet($coordinates, $unitCollection, PlanetType::DebrisField, false);
     }
 
     /**
@@ -142,18 +161,18 @@ class FleetDispatchExpeditionTest extends FleetDispatchTestCase
 
         // First expedition should succeed
         $this->sendTestExpedition();
-        $this->assertEquals(1, $this->planetService->getPlayer()->getExpeditionSlotsInUse(), 'Expedition slots in use should be 1 after first expedition');
+        $this->assertEquals(1, $this->planetPlayer()->getExpeditionSlotsInUse(), 'Expedition slots in use should be 1 after first expedition');
 
         // Second expedition should fail due to max expedition slots restriction
         $this->sendTestExpedition(false);
-        $this->assertEquals(1, $this->planetService->getPlayer()->getExpeditionSlotsInUse(), 'Expedition mission has been created but should have been rejected due to max expedition slots restriction (astrophysics level 1)');
+        $this->assertEquals(1, $this->planetPlayer()->getExpeditionSlotsInUse(), 'Expedition mission has been created but should have been rejected due to max expedition slots restriction (astrophysics level 1)');
 
         // Upgrade astrophysics to level 4 to allow 2 expedition slots
         $this->playerSetResearchLevel('astrophysics', 4);
 
         // Now second expedition should succeed
         $this->sendTestExpedition();
-        $this->assertEquals(2, $this->planetService->getPlayer()->getExpeditionSlotsInUse(), 'Expedition slots in use should be 2 after second expedition');
+        $this->assertEquals(2, $this->planetPlayer()->getExpeditionSlotsInUse(), 'Expedition slots in use should be 2 after second expedition');
     }
 
     /**
@@ -168,15 +187,15 @@ class FleetDispatchExpeditionTest extends FleetDispatchTestCase
 
         // Send first expedition
         $this->sendTestExpedition();
-        $this->assertEquals(1, $this->planetService->getPlayer()->getExpeditionSlotsInUse(), 'Expedition slots in use should be 1 after first expedition');
+        $this->assertEquals(1, $this->planetPlayer()->getExpeditionSlotsInUse(), 'Expedition slots in use should be 1 after first expedition');
 
         // Send second expedition
         $this->sendTestExpedition();
-        $this->assertEquals(2, $this->planetService->getPlayer()->getExpeditionSlotsInUse(), 'Expedition slots in use should be 2 after second expedition');
+        $this->assertEquals(2, $this->planetPlayer()->getExpeditionSlotsInUse(), 'Expedition slots in use should be 2 after second expedition');
 
         // Send third expedition
         $this->sendTestExpedition();
-        $this->assertEquals(3, $this->planetService->getPlayer()->getExpeditionSlotsInUse(), 'Expedition slots in use should be 3 after third expedition');
+        $this->assertEquals(3, $this->planetPlayer()->getExpeditionSlotsInUse(), 'Expedition slots in use should be 3 after third expedition');
 
         // Increase time by 10 hours to ensure all expeditions are done
         $this->travel(10)->hours();
@@ -186,7 +205,7 @@ class FleetDispatchExpeditionTest extends FleetDispatchTestCase
         $response->assertStatus(200);
 
         // Ensure that the expedition slots in use are updated correctly
-        $this->assertEquals(0, $this->planetService->getPlayer()->getExpeditionSlotsInUse(), 'Expedition slots in use should be 0 after all expeditions are done');
+        $this->assertEquals(0, $this->planetPlayer()->getExpeditionSlotsInUse(), 'Expedition slots in use should be 0 after all expeditions are done');
     }
 
     /**
@@ -221,6 +240,9 @@ class FleetDispatchExpeditionTest extends FleetDispatchTestCase
         // Cancel the fleet mission, so it doesn't interfere with other tests.
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($fleetMission === null) {
+            $this->fail('No active fleet mission found.');
+        }
         $fleetMissionService->cancelMission($fleetMission);
     }
 
@@ -241,6 +263,9 @@ class FleetDispatchExpeditionTest extends FleetDispatchTestCase
         // Get the fleet mission
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $parentMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($parentMission === null) {
+            $this->fail('No active fleet mission found.');
+        }
 
         // Record when the mission departed
         $departureTime = (int)$parentMission->time_departure;
@@ -254,7 +279,7 @@ class FleetDispatchExpeditionTest extends FleetDispatchTestCase
         $this->travel(5)->seconds();
 
         // Recall the fleet after 5 seconds
-        $currentTime = (int)\Illuminate\Support\Carbon::now()->timestamp;
+        $currentTime = (int)Date::now()->timestamp;
         $fleetMissionService->cancelMission($parentMission);
 
         // Reload the fleet mission service
@@ -359,6 +384,9 @@ class FleetDispatchExpeditionTest extends FleetDispatchTestCase
         // Get the parent mission.
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $parentMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($parentMission === null) {
+            $this->fail('No active fleet mission found.');
+        }
 
         // Verify the parent mission has holding time set (expeditions should have at least 1 hour).
         $this->assertGreaterThan(0, $parentMission->time_holding, 'Expedition mission should have holding time set');
@@ -423,7 +451,7 @@ class FleetDispatchExpeditionTest extends FleetDispatchTestCase
 
         // Create a highscore record with 100.000.000 points to test max resource find.
         $highscore = Highscore::create([
-            'player_id' => $this->planetService->getPlayer()->getId(),
+            'player_id' => $this->planetPlayer()->getId(),
             'general' => 100000000,
         ]);
         $highscore->save();
@@ -434,6 +462,9 @@ class FleetDispatchExpeditionTest extends FleetDispatchTestCase
         // Get the mission ID.
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $originalMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($originalMission === null) {
+            $this->fail('No active fleet mission found.');
+        }
 
         // Wait for the mission to complete.
         $this->travel(10)->hours();
@@ -477,7 +508,7 @@ class FleetDispatchExpeditionTest extends FleetDispatchTestCase
 
         // Create a highscore record with 100.000.000 points.
         $highscore = Highscore::create([
-            'player_id' => $this->planetService->getPlayer()->getId(),
+            'player_id' => $this->planetPlayer()->getId(),
             'general' => 100000000,
         ]);
         $highscore->save();
@@ -490,6 +521,9 @@ class FleetDispatchExpeditionTest extends FleetDispatchTestCase
         // Get the mission ID.
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $originalMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($originalMission === null) {
+            $this->fail('No active fleet mission found.');
+        }
 
         // Wait for the mission to complete.
         $this->travel(10)->hours();
@@ -529,7 +563,7 @@ class FleetDispatchExpeditionTest extends FleetDispatchTestCase
 
         // Create a highscore record with only 1 point.
         $highscore = Highscore::create([
-            'player_id' => $this->planetService->getPlayer()->getId(),
+            'player_id' => $this->planetPlayer()->getId(),
             'general' => 1,
         ]);
         $highscore->save();
@@ -540,6 +574,9 @@ class FleetDispatchExpeditionTest extends FleetDispatchTestCase
         // Get the mission ID.
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $originalMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($originalMission === null) {
+            $this->fail('No active fleet mission found.');
+        }
 
         // Wait for the mission to complete.
         $this->travel(10)->hours();
@@ -649,6 +686,9 @@ class FleetDispatchExpeditionTest extends FleetDispatchTestCase
         // Get the mission ID.
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $originalMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($originalMission === null) {
+            $this->fail('No active fleet mission found.');
+        }
 
         // Wait for the mission to complete.
         $this->travel(10)->hours();
@@ -686,6 +726,9 @@ class FleetDispatchExpeditionTest extends FleetDispatchTestCase
         // Get the mission ID.
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $originalMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($originalMission === null) {
+            $this->fail('No active fleet mission found.');
+        }
 
         // Wait for the mission to complete.
         $this->travel(10)->hours();
@@ -750,7 +793,11 @@ class FleetDispatchExpeditionTest extends FleetDispatchTestCase
         $fleetMissionService = resolve(FleetMissionService::class);
         $activeMissions = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer();
         $this->assertCount(1, $activeMissions, 'Expedition mission not created');
-        $fleetMissionId = $activeMissions->first()->id;
+        $firstMission = $activeMissions->first();
+        if ($firstMission === null) {
+            $this->fail('Expedition mission not created.');
+        }
+        $fleetMissionId = $firstMission->id;
 
         // Verify resources were deducted from planet (including fuel)
         $this->get('/overview');
@@ -765,6 +812,9 @@ class FleetDispatchExpeditionTest extends FleetDispatchTestCase
 
         // Advance time to expedition arrival (1 hour holding time + travel time)
         $fleetMission = $fleetMissionService->getFleetMissionById($fleetMissionId, false);
+        if ($fleetMission === null) {
+            $this->fail('Fleet mission not found.');
+        }
         $travelTime = $fleetMission->time_arrival - $fleetMission->time_departure;
         $holdingTime = $fleetMission->time_holding ?? 0;
         $this->travel($travelTime + $holdingTime + 1)->seconds();
@@ -776,6 +826,9 @@ class FleetDispatchExpeditionTest extends FleetDispatchTestCase
         $activeMissions = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer();
         $this->assertCount(1, $activeMissions, 'Return mission should be created');
         $returnMission = $activeMissions->first();
+        if ($returnMission === null) {
+            $this->fail('Return mission should be created.');
+        }
 
         // Verify return mission has original resources
         $this->assertEquals(100000, $returnMission->metal);
@@ -833,10 +886,17 @@ class FleetDispatchExpeditionTest extends FleetDispatchTestCase
         // Get the mission ID
         $fleetMissionService = resolve(FleetMissionService::class);
         $activeMissions = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer();
-        $fleetMissionId = $activeMissions->first()->id;
+        $firstMission = $activeMissions->first();
+        if ($firstMission === null) {
+            $this->fail('Expedition mission not created.');
+        }
+        $fleetMissionId = $firstMission->id;
 
         // Advance time to expedition arrival
         $fleetMission = $fleetMissionService->getFleetMissionById($fleetMissionId, false);
+        if ($fleetMission === null) {
+            $this->fail('Fleet mission not found.');
+        }
         $travelTime = $fleetMission->time_arrival - $fleetMission->time_departure;
         $holdingTime = $fleetMission->time_holding ?? 0;
         $this->travel($travelTime + $holdingTime + 1)->seconds();
@@ -848,6 +908,9 @@ class FleetDispatchExpeditionTest extends FleetDispatchTestCase
         $activeMissions = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer();
         $this->assertCount(1, $activeMissions, 'Return mission should be created');
         $returnMission = $activeMissions->first();
+        if ($returnMission === null) {
+            $this->fail('Return mission should be created.');
+        }
 
         // Verify return mission has at least original resources (should have more from found resources)
         $this->assertGreaterThanOrEqual(50000, $returnMission->metal);
@@ -881,6 +944,9 @@ class FleetDispatchExpeditionTest extends FleetDispatchTestCase
 
         // Verify no merchant is active initially
         $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('Planet has no player.');
+        }
         $this->assertNull(cache()->get('active_merchant_' . $player->getId()));
 
         // Send the expedition mission
@@ -910,7 +976,7 @@ class FleetDispatchExpeditionTest extends FleetDispatchTestCase
 
         // Assert that the expedition message was sent
         // Check that we have at least one expedition merchant message
-        $messages = \OGame\Models\Message::where('user_id', $player->getId())
+        $messages = Message::where('user_id', $player->getId())
             ->where('key', 'expedition_merchant_found')
             ->get();
 
@@ -1042,7 +1108,7 @@ class FleetDispatchExpeditionTest extends FleetDispatchTestCase
         ]);
 
         // Check that a battle report was created
-        $battleReports = \OGame\Models\BattleReport::where('planet_user_id', $this->planetService->getPlayer()->getId())->get();
+        $battleReports = BattleReport::where('planet_user_id', $this->planetPlayer()->getId())->get();
         $this->assertGreaterThan(0, $battleReports->count(), 'Battle report should be created');
 
         // Verify the battle report has expedition battle markers
@@ -1051,15 +1117,15 @@ class FleetDispatchExpeditionTest extends FleetDispatchTestCase
         $this->assertEquals('pirate', $report->general['npc_type'] ?? '', 'NPC type should be pirate');
 
         // Verify NPC appears as attacker with correct ID
-        $this->assertEquals(-1, $report->attacker['player_id'], 'Pirate player ID should be -1');
+        $this->assertEquals(-1, ($report->attacker['player_id'] ?? null), 'Pirate player ID should be -1');
 
         // Verify player appears as defender
-        $this->assertEquals($this->planetService->getPlayer()->getId(), $report->defender['player_id']);
+        $this->assertEquals($this->planetPlayer()->getId(), ($report->defender['player_id'] ?? null));
 
         // Verify NPC has lower tech (player tech - 3)
-        $this->assertEquals(7, $report->attacker['weapon_technology'], 'Pirates should have player tech - 3');
-        $this->assertEquals(7, $report->attacker['shielding_technology'], 'Pirates should have player tech - 3');
-        $this->assertEquals(7, $report->attacker['armor_technology'], 'Pirates should have player tech - 3');
+        $this->assertEquals(7, ($report->attacker['weapon_technology'] ?? null), 'Pirates should have player tech - 3');
+        $this->assertEquals(7, ($report->attacker['shielding_technology'] ?? null), 'Pirates should have player tech - 3');
+        $this->assertEquals(7, ($report->attacker['armor_technology'] ?? null), 'Pirates should have player tech - 3');
     }
 
     /**
@@ -1102,7 +1168,7 @@ class FleetDispatchExpeditionTest extends FleetDispatchTestCase
         ]);
 
         // Check that a battle report was created
-        $battleReports = \OGame\Models\BattleReport::where('planet_user_id', $this->planetService->getPlayer()->getId())->get();
+        $battleReports = BattleReport::where('planet_user_id', $this->planetPlayer()->getId())->get();
         $this->assertGreaterThan(0, $battleReports->count(), 'Battle report should be created');
 
         // Verify the battle report has expedition battle markers
@@ -1111,15 +1177,15 @@ class FleetDispatchExpeditionTest extends FleetDispatchTestCase
         $this->assertEquals('alien', $report->general['npc_type'] ?? '', 'NPC type should be alien');
 
         // Verify NPC appears as attacker with correct ID
-        $this->assertEquals(-2, $report->attacker['player_id'], 'Alien player ID should be -2');
+        $this->assertEquals(-2, ($report->attacker['player_id'] ?? null), 'Alien player ID should be -2');
 
         // Verify player appears as defender
-        $this->assertEquals($this->planetService->getPlayer()->getId(), $report->defender['player_id']);
+        $this->assertEquals($this->planetPlayer()->getId(), ($report->defender['player_id'] ?? null));
 
         // Verify NPC has higher tech (player tech + 3)
-        $this->assertEquals(13, $report->attacker['weapon_technology'], 'Aliens should have player tech + 3');
-        $this->assertEquals(13, $report->attacker['shielding_technology'], 'Aliens should have player tech + 3');
-        $this->assertEquals(13, $report->attacker['armor_technology'], 'Aliens should have player tech + 3');
+        $this->assertEquals(13, ($report->attacker['weapon_technology'] ?? null), 'Aliens should have player tech + 3');
+        $this->assertEquals(13, ($report->attacker['shielding_technology'] ?? null), 'Aliens should have player tech + 3');
+        $this->assertEquals(13, ($report->attacker['armor_technology'] ?? null), 'Aliens should have player tech + 3');
     }
 
     /**
@@ -1198,7 +1264,7 @@ class FleetDispatchExpeditionTest extends FleetDispatchTestCase
         $this->planetService->reloadPlanet();
 
         // Get the battle report
-        $battleReports = \OGame\Models\BattleReport::where('planet_user_id', $this->planetService->getPlayer()->getId())->get();
+        $battleReports = BattleReport::where('planet_user_id', $this->planetPlayer()->getId())->get();
         $this->assertGreaterThan(0, $battleReports->count(), 'Battle report should be created');
 
         $report = $battleReports->first();
@@ -1266,7 +1332,7 @@ class FleetDispatchExpeditionTest extends FleetDispatchTestCase
         $this->planetService->reloadPlanet();
 
         // Get the battle report
-        $battleReports = \OGame\Models\BattleReport::where('planet_user_id', $this->planetService->getPlayer()->getId())->get();
+        $battleReports = BattleReport::where('planet_user_id', $this->planetPlayer()->getId())->get();
         $this->assertGreaterThan(0, $battleReports->count(), 'Battle report should be created');
 
         $report = $battleReports->first();
@@ -1280,7 +1346,7 @@ class FleetDispatchExpeditionTest extends FleetDispatchTestCase
         $maxReasonableHitsPerRound = 500000; // Very generous upper bound to catch the original bug
 
         // The NPC is the "attacker" in expedition reports (roles are swapped)
-        foreach ($report->rounds as $i => $round) {
+        foreach (($report->rounds ?? []) as $i => $round) {
             $npcHits = $round['hits_attacker'] ?? 0; // NPC shots (attacker in swapped report)
             $playerHits = $round['hits_defender'] ?? 0; // Player shots (defender in swapped report)
 

--- a/tests/Feature/FleetDispatch/FleetDispatchGenericTest.php
+++ b/tests/Feature/FleetDispatch/FleetDispatchGenericTest.php
@@ -7,6 +7,7 @@ use OGame\GameObjects\Models\Units\UnitCollection;
 use OGame\Models\Resources;
 use OGame\Services\FleetMissionService;
 use OGame\Services\ObjectService;
+use OGame\Services\PlayerService;
 use OGame\Services\SettingsService;
 use Tests\FleetDispatchTestCase;
 
@@ -24,6 +25,18 @@ class FleetDispatchGenericTest extends FleetDispatchTestCase
      * @var string The mission name for the test, displayed in UI.
      */
     protected string $missionName = 'Transport';
+
+    /**
+     * Returns the current planet's player, failing the test if none is set.
+     */
+    private function currentPlayer(): PlayerService
+    {
+        $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('Player not found.');
+        }
+        return $player;
+    }
 
     /**
      * Prepare the planet for the test so it has the required buildings and research.
@@ -153,18 +166,18 @@ class FleetDispatchGenericTest extends FleetDispatchTestCase
 
         // First mission should succeed
         $this->sendTestMission();
-        $this->assertEquals(1, $this->planetService->getPlayer()->getFleetSlotsInUse(), 'Fleet slots in use should be 1 after first mission');
+        $this->assertEquals(1, $this->currentPlayer()->getFleetSlotsInUse(), 'Fleet slots in use should be 1 after first mission');
 
         // Second mission should fail due to max fleet slots restriction
         $this->sendTestMission(false);
-        $this->assertEquals(1, $this->planetService->getPlayer()->getFleetSlotsInUse(), 'Fleet mission has been created but should have been rejected due to max fleet slots restriction (computer technology level 0)');
+        $this->assertEquals(1, $this->currentPlayer()->getFleetSlotsInUse(), 'Fleet mission has been created but should have been rejected due to max fleet slots restriction (computer technology level 0)');
 
         // Upgrade computer technology to level 1
         $this->playerSetResearchLevel('computer_technology', 1);
 
         // Now second mission should succeed
         $this->sendTestMission();
-        $this->assertEquals(2, $this->planetService->getPlayer()->getFleetSlotsInUse(), 'Fleet slots in use should be 2 after second mission');
+        $this->assertEquals(2, $this->currentPlayer()->getFleetSlotsInUse(), 'Fleet slots in use should be 2 after second mission');
     }
 
     /**
@@ -179,15 +192,15 @@ class FleetDispatchGenericTest extends FleetDispatchTestCase
 
         // Send first mission
         $this->sendTestMission();
-        $this->assertEquals(1, $this->planetService->getPlayer()->getFleetSlotsInUse(), 'Fleet slots in use should be 1 after first mission');
+        $this->assertEquals(1, $this->currentPlayer()->getFleetSlotsInUse(), 'Fleet slots in use should be 1 after first mission');
 
         // Send second mission
         $this->sendTestMission();
-        $this->assertEquals(2, $this->planetService->getPlayer()->getFleetSlotsInUse(), 'Fleet slots in use should be 2 after second mission');
+        $this->assertEquals(2, $this->currentPlayer()->getFleetSlotsInUse(), 'Fleet slots in use should be 2 after second mission');
 
         // Send third mission
         $this->sendTestMission();
-        $this->assertEquals(3, $this->planetService->getPlayer()->getFleetSlotsInUse(), 'Fleet slots in use should be 3 after third mission');
+        $this->assertEquals(3, $this->currentPlayer()->getFleetSlotsInUse(), 'Fleet slots in use should be 3 after third mission');
 
         // Increase time by 10 hours to ensure all missions are done.
         $this->travel(10)->hours();
@@ -197,7 +210,7 @@ class FleetDispatchGenericTest extends FleetDispatchTestCase
         $response->assertStatus(200);
 
         // Ensure that the fleet slots in use are updated correctly.
-        $this->assertEquals(0, $this->planetService->getPlayer()->getFleetSlotsInUse(), 'Fleet slots in use should be 0 after all missions are done');
+        $this->assertEquals(0, $this->currentPlayer()->getFleetSlotsInUse(), 'Fleet slots in use should be 0 after all missions are done');
     }
 
     /**

--- a/tests/Feature/FleetDispatch/FleetDispatchMissionResourceHandlingTest.php
+++ b/tests/Feature/FleetDispatch/FleetDispatchMissionResourceHandlingTest.php
@@ -121,6 +121,7 @@ class FleetDispatchMissionResourceHandlingTest extends FleetDispatchTestCase
         $this->assertGreaterThan(0, $activeMissions->count(), 'No return mission found');
 
         $returnMission = $activeMissions->first();
+        $this->assertNotNull($returnMission, 'Return mission not found');
         $returnedTotal = $returnMission->metal + $returnMission->crystal + $returnMission->deuterium;
         $originalTotal = $initialMetal + $initialCrystal + $initialDeuterium;
 
@@ -227,8 +228,10 @@ class FleetDispatchMissionResourceHandlingTest extends FleetDispatchTestCase
         $this->planetAddResources(new Resources($initialMetal, $initialCrystal, $initialDeuterium + 100000, 0));
 
         // Create debris field at second planet coordinates
+        $secondPlanet = $this->secondPlanetService;
+        $this->assertNotNull($secondPlanet, 'Second planet not found');
         $debrisFieldService = resolve(DebrisFieldService::class);
-        $debrisFieldService->loadOrCreateForCoordinates($this->secondPlanetService->getPlanetCoordinates());
+        $debrisFieldService->loadOrCreateForCoordinates($secondPlanet->getPlanetCoordinates());
         $debrisFieldService->appendResources(new Resources(5000, 3000, 0, 0));
         $debrisFieldService->save();
 
@@ -255,6 +258,7 @@ class FleetDispatchMissionResourceHandlingTest extends FleetDispatchTestCase
         $this->assertGreaterThan(0, $activeMissions->count(), 'No return mission found');
 
         $returnMission = $activeMissions->first();
+        $this->assertNotNull($returnMission, 'Return mission not found');
         $returnedTotal = $returnMission->metal + $returnMission->crystal + $returnMission->deuterium;
         $originalTotal = $initialMetal + $initialCrystal + $initialDeuterium;
 
@@ -318,6 +322,7 @@ class FleetDispatchMissionResourceHandlingTest extends FleetDispatchTestCase
         $this->assertGreaterThan(0, $activeMissions->count(), 'No return mission found');
 
         $returnMission = $activeMissions->first();
+        $this->assertNotNull($returnMission, 'Return mission not found');
         $returnedTotal = $returnMission->metal + $returnMission->crystal + $returnMission->deuterium;
         $originalTotal = $initialMetal + $initialCrystal + $initialDeuterium;
 

--- a/tests/Feature/FleetDispatch/FleetDispatchMoonDestructionTest.php
+++ b/tests/Feature/FleetDispatch/FleetDispatchMoonDestructionTest.php
@@ -157,7 +157,11 @@ class FleetDispatchMoonDestructionTest extends FleetDispatchTestCase
 
         // Boost the foreign player's computer tech to guarantee enough fleet slots, even if
         // previous tests in the suite left unprocessed fleet missions for this player in the DB.
-        $foreignMoon->getPlayer()->setResearchLevel('computer_technology', 25);
+        $foreignMoonPlayer = $foreignMoon->getPlayer();
+        if ($foreignMoonPlayer === null) {
+            $this->fail('Foreign moon has no player.');
+        }
+        $foreignMoonPlayer->setResearchLevel('computer_technology', 25);
 
         $outgoingUnits = new UnitCollection();
         $outgoingUnits->addUnit(ObjectService::getUnitObjectByMachineName('small_cargo'), 1);
@@ -238,6 +242,10 @@ class FleetDispatchMoonDestructionTest extends FleetDispatchTestCase
 
         // --- Attacker setup ---
         $attacker = $this->planetService;
+        $attackerPlayer = $attacker->getPlayer();
+        if ($attackerPlayer === null) {
+            $this->fail('Attacker has no player.');
+        }
         $attacker->removeUnits($attacker->getShipUnits(), true);
         $attacker->save();
         $attacker->reloadPlanet();
@@ -250,7 +258,7 @@ class FleetDispatchMoonDestructionTest extends FleetDispatchTestCase
         $foreignMoon = $this->sendMissionToOtherPlayerMoon($units, new Resources(0, 0, 0, 0));
 
         // Snapshot the outbound mission ID so we can locate it (and its return child) precisely.
-        $outboundMission = FleetMission::where('user_id', $attacker->getPlayer()->getId())
+        $outboundMission = FleetMission::where('user_id', $attackerPlayer->getId())
             ->where('mission_type', 9)
             ->whereNull('parent_id')
             ->where('processed', 0)
@@ -266,6 +274,9 @@ class FleetDispatchMoonDestructionTest extends FleetDispatchTestCase
         $foreignMoon->reloadPlanet();
 
         $defenderPlayer = $foreignMoon->getPlayer();
+        if ($defenderPlayer === null) {
+            $this->fail('Foreign moon has no player.');
+        }
         $defenderPlayerId = $defenderPlayer->getId();
         // Force weapon tech to 0 so LF attack (50) stays below the 1%-of-shield bounce
         // threshold (500) for the death star — DS remain untouchable.
@@ -299,7 +310,7 @@ class FleetDispatchMoonDestructionTest extends FleetDispatchTestCase
         $this->assertSame(
             0,
             Message::where('id', '>', $maxMessageIdBefore)
-                ->where('user_id', $attacker->getPlayer()->getId())
+                ->where('user_id', $attackerPlayer->getId())
                 ->whereIn('key', [
                     'moon_destruction_success',
                     'moon_destruction_failure',

--- a/tests/Feature/FleetDispatch/FleetDispatchMultiDefenderBattleTest.php
+++ b/tests/Feature/FleetDispatch/FleetDispatchMultiDefenderBattleTest.php
@@ -84,6 +84,43 @@ class FleetDispatchMultiDefenderBattleTest extends FleetDispatchTestCase
     }
 
     /**
+     * Get the buddy's planet, failing the test if it is not set.
+     */
+    private function buddyPlanet(): PlanetService
+    {
+        if ($this->buddyPlanet === null) {
+            $this->fail('Buddy planet is not set.');
+        }
+
+        return $this->buddyPlanet;
+    }
+
+    /**
+     * Get the buddy user, failing the test if it is not set.
+     */
+    private function buddyUser(): User
+    {
+        if ($this->buddyUser === null) {
+            $this->fail('Buddy user is not set.');
+        }
+
+        return $this->buddyUser;
+    }
+
+    /**
+     * Get the current planet's player, failing the test if it is null.
+     */
+    private function planetPlayer(): PlayerService
+    {
+        $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('Planet has no player.');
+        }
+
+        return $player;
+    }
+
+    /**
      * Prepare the attacker planet for testing.
      */
     protected function basicSetup(): void
@@ -130,8 +167,8 @@ class FleetDispatchMultiDefenderBattleTest extends FleetDispatchTestCase
         self::$allCreatedBuddyUserIds[] = $defenderUser->id;
 
         // Place defender 1 system away from the buddy so fleet arrival is fast.
-        $buddyGalaxy  = $this->buddyPlanet->getPlanetCoordinates()->galaxy;
-        $buddySystem  = $this->buddyPlanet->getPlanetCoordinates()->system;
+        $buddyGalaxy  = $this->buddyPlanet()->getPlanetCoordinates()->galaxy;
+        $buddySystem  = $this->buddyPlanet()->getPlanetCoordinates()->system;
         $defenderSystem = min(499, $buddySystem + 1);
         $defenderPosition = collect([13, 14, 15, 1, 2, 3])->first(
             fn ($p) => !Planet::where('galaxy', $buddyGalaxy)->where('system', $defenderSystem)->where('planet', $p)->exists()
@@ -149,8 +186,8 @@ class FleetDispatchMultiDefenderBattleTest extends FleetDispatchTestCase
 
         // Create buddy relationship between defender and buddy (target planet owner)
         $buddyService = resolve(BuddyService::class);
-        $request = $buddyService->sendRequest($defenderUser->id, $this->buddyUser->id);
-        $buddyService->acceptRequest($request->id, $this->buddyUser->id);
+        $request = $buddyService->sendRequest($defenderUser->id, $this->buddyUser()->id);
+        $buddyService->acceptRequest($request->id, $this->buddyUser()->id);
 
         return [
             'user' => $defenderUser,
@@ -160,7 +197,7 @@ class FleetDispatchMultiDefenderBattleTest extends FleetDispatchTestCase
 
     protected function messageCheckMissionArrival(): void
     {
-        $messageAttacker = Message::where('user_id', $this->planetService->getPlayer()->getId())
+        $messageAttacker = Message::where('user_id', $this->planetPlayer()->getId())
             ->whereIn('key', ['battle_report', 'fleet_lost_contact'])
             ->orderByDesc('id')
             ->first();
@@ -184,7 +221,7 @@ class FleetDispatchMultiDefenderBattleTest extends FleetDispatchTestCase
         $this->createBuddyPlayer();
 
         // Give buddy planet some defenses
-        $this->buddyPlanet->addUnit('rocket_launcher', 10);
+        $this->buddyPlanet()->addUnit('rocket_launcher', 10);
 
         // Create ACS defender and send defend fleet
         $acsDefender = $this->createAcsDefender();
@@ -198,7 +235,7 @@ class FleetDispatchMultiDefenderBattleTest extends FleetDispatchTestCase
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $acsDefender['planet']->getPlayer()]);
         $acsDefendMission = $fleetMissionService->createNewFromPlanet(
             $acsDefender['planet'],
-            $this->buddyPlanet->getPlanetCoordinates(),
+            $this->buddyPlanet()->getPlanetCoordinates(),
             PlanetType::Planet,
             5, // ACS Defend mission type
             $acsDefendFleet,
@@ -217,7 +254,7 @@ class FleetDispatchMultiDefenderBattleTest extends FleetDispatchTestCase
         $attackFleet = new UnitCollection();
         $attackFleet->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 50);
         $this->dispatchFleet(
-            $this->buddyPlanet->getPlanetCoordinates(),
+            $this->buddyPlanet()->getPlanetCoordinates(),
             $attackFleet,
             new Resources(0, 0, 0, 0),
             PlanetType::Planet
@@ -225,6 +262,9 @@ class FleetDispatchMultiDefenderBattleTest extends FleetDispatchTestCase
 
         $attackerFleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $attackMission = $attackerFleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($attackMission === null) {
+            $this->fail('No active attack mission found.');
+        }
 
         // Advance time for attack to arrive (defend fleet should still be holding)
         $this->travelTo(Date::createFromTimestamp($attackMission->time_arrival + 10));
@@ -240,7 +280,7 @@ class FleetDispatchMultiDefenderBattleTest extends FleetDispatchTestCase
         // Planet owner: 10 rocket launchers
         // ACS defender: 20 light fighters
         // Total should be 30+ units
-        $defenderStartUnits = $battleReport->defender['units'];
+        $defenderStartUnits = $battleReport->defender['units'] ?? [];
         $totalDefenderUnits = array_sum($defenderStartUnits);
         $this->assertGreaterThan(25, $totalDefenderUnits, 'ACS defend fleet should participate in battle');
     }
@@ -265,7 +305,7 @@ class FleetDispatchMultiDefenderBattleTest extends FleetDispatchTestCase
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $acsDefender['planet']->getPlayer()]);
         $acsDefendMission = $fleetMissionService->createNewFromPlanet(
             $acsDefender['planet'],
-            $this->buddyPlanet->getPlanetCoordinates(),
+            $this->buddyPlanet()->getPlanetCoordinates(),
             PlanetType::Planet,
             5,
             $acsDefendFleet,
@@ -285,7 +325,7 @@ class FleetDispatchMultiDefenderBattleTest extends FleetDispatchTestCase
         $attackFleet = new UnitCollection();
         $attackFleet->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 100);
         $this->dispatchFleet(
-            $this->buddyPlanet->getPlanetCoordinates(),
+            $this->buddyPlanet()->getPlanetCoordinates(),
             $attackFleet,
             new Resources(0, 0, 0, 0),
             PlanetType::Planet
@@ -293,6 +333,9 @@ class FleetDispatchMultiDefenderBattleTest extends FleetDispatchTestCase
 
         $attackerFleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $attackMission = $attackerFleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($attackMission === null) {
+            $this->fail('No active attack mission found.');
+        }
 
         // Advance time for attack to arrive
         $this->travelTo(Date::createFromTimestamp($attackMission->time_arrival + 10));
@@ -302,6 +345,9 @@ class FleetDispatchMultiDefenderBattleTest extends FleetDispatchTestCase
 
         // Check that ACS defend mission is marked as processed
         $acsDefendMissionReloaded = FleetMission::find($acsDefendMission->id);
+        if ($acsDefendMissionReloaded === null) {
+            $this->fail('Fleet mission not found.');
+        }
         $this->assertEquals(1, $acsDefendMissionReloaded->processed, 'Destroyed ACS defend fleet should be marked as processed');
 
         // Check that defender received fleet lost contact message
@@ -319,6 +365,9 @@ class FleetDispatchMultiDefenderBattleTest extends FleetDispatchTestCase
         // Reload planet and check units are still 0
         $planetServiceFactory = resolve(PlanetServiceFactory::class);
         $acsDefenderPlanetReloaded = $planetServiceFactory->make($acsDefender['planet']->getPlanetId());
+        if ($acsDefenderPlanetReloaded === null) {
+            $this->fail('Planet could not be loaded.');
+        }
         $this->assertEquals(
             0,
             $acsDefenderPlanetReloaded->getShipUnits()->getAmountByMachineName('light_fighter'),
@@ -339,7 +388,7 @@ class FleetDispatchMultiDefenderBattleTest extends FleetDispatchTestCase
         $this->createBuddyPlayer();
 
         // Give buddy planet strong defenses to ensure defenders win
-        $this->buddyPlanet->addUnit('rocket_launcher', 50);
+        $this->buddyPlanet()->addUnit('rocket_launcher', 50);
 
         // Create ACS defender and send defend fleet
         $acsDefender = $this->createAcsDefender();
@@ -353,7 +402,7 @@ class FleetDispatchMultiDefenderBattleTest extends FleetDispatchTestCase
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $acsDefender['planet']->getPlayer()]);
         $acsDefendMission = $fleetMissionService->createNewFromPlanet(
             $acsDefender['planet'],
-            $this->buddyPlanet->getPlanetCoordinates(),
+            $this->buddyPlanet()->getPlanetCoordinates(),
             PlanetType::Planet,
             5,
             $acsDefendFleet,
@@ -373,7 +422,7 @@ class FleetDispatchMultiDefenderBattleTest extends FleetDispatchTestCase
         $attackFleet = new UnitCollection();
         $attackFleet->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 10);
         $this->dispatchFleet(
-            $this->buddyPlanet->getPlanetCoordinates(),
+            $this->buddyPlanet()->getPlanetCoordinates(),
             $attackFleet,
             new Resources(0, 0, 0, 0),
             PlanetType::Planet
@@ -381,6 +430,9 @@ class FleetDispatchMultiDefenderBattleTest extends FleetDispatchTestCase
 
         $attackerFleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $attackMission = $attackerFleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($attackMission === null) {
+            $this->fail('No active attack mission found.');
+        }
 
         // Advance time for attack to arrive - battle occurs, outbound mission unit counts updated
         $this->travelTo(Date::createFromTimestamp($attackMission->time_arrival + 10));
@@ -414,6 +466,9 @@ class FleetDispatchMultiDefenderBattleTest extends FleetDispatchTestCase
         // Check that ships returned to ACS defender's planet
         $planetServiceFactory = resolve(PlanetServiceFactory::class);
         $acsDefenderPlanetReloaded = $planetServiceFactory->make($acsDefender['planet']->getPlanetId(), true);
+        if ($acsDefenderPlanetReloaded === null) {
+            $this->fail('Planet could not be loaded.');
+        }
         $returnedShips = $acsDefenderPlanetReloaded->getShipUnits()->getAmountByMachineName('light_fighter');
         $this->assertGreaterThan(0, $returnedShips, 'Some ships should have returned');
     }
@@ -446,7 +501,7 @@ class FleetDispatchMultiDefenderBattleTest extends FleetDispatchTestCase
         $acsFleetMissionService = resolve(FleetMissionService::class, ['player' => $acsDefender['planet']->getPlayer()]);
         $acsDefendMission = $acsFleetMissionService->createNewFromPlanet(
             $acsDefender['planet'],
-            $this->buddyPlanet->getPlanetCoordinates(),
+            $this->buddyPlanet()->getPlanetCoordinates(),
             PlanetType::Planet,
             5,
             $acsDefendFleet,
@@ -465,7 +520,7 @@ class FleetDispatchMultiDefenderBattleTest extends FleetDispatchTestCase
         $attackFleet = new UnitCollection();
         $attackFleet->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 1);
         $this->dispatchFleet(
-            $this->buddyPlanet->getPlanetCoordinates(),
+            $this->buddyPlanet()->getPlanetCoordinates(),
             $attackFleet,
             new Resources(0, 0, 0, 0),
             PlanetType::Planet
@@ -473,6 +528,9 @@ class FleetDispatchMultiDefenderBattleTest extends FleetDispatchTestCase
 
         $attackerFleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $attackMission = $attackerFleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($attackMission === null) {
+            $this->fail('No active attack mission found.');
+        }
 
         // Advance time to attack arrival - battle occurs during ACS defend hold time
         $this->travelTo(Date::createFromTimestamp($attackMission->time_arrival + 10));
@@ -496,6 +554,9 @@ class FleetDispatchMultiDefenderBattleTest extends FleetDispatchTestCase
 
         // Advance past return mission arrival and process it
         $returnMission = $returnMissionsAfterHold->first();
+        if ($returnMission === null) {
+            $this->fail('Return mission should exist.');
+        }
         $this->travelTo(Date::createFromTimestamp($returnMission->time_arrival + 10));
         $this->reloadApplication();
         $acsDefenderPlayerService = resolve(PlayerService::class, ['player_id' => $acsDefender['user']->id]);
@@ -504,6 +565,9 @@ class FleetDispatchMultiDefenderBattleTest extends FleetDispatchTestCase
         // Reload ACS defender's planet and verify exactly 100 light fighters returned (no duplication)
         $planetServiceFactory = resolve(PlanetServiceFactory::class);
         $acsDefenderPlanetReloaded = $planetServiceFactory->make($acsDefender['planet']->getPlanetId(), true);
+        if ($acsDefenderPlanetReloaded === null) {
+            $this->fail('Planet could not be loaded.');
+        }
         $returnedLightFighters = $acsDefenderPlanetReloaded->getShipUnits()->getAmountByMachineName('light_fighter');
         $this->assertEquals(
             100,
@@ -529,7 +593,7 @@ class FleetDispatchMultiDefenderBattleTest extends FleetDispatchTestCase
         $this->createBuddyPlayer();
 
         // Give buddy planet some defenses to force real combat (so attacker doesn't just walk through)
-        $this->buddyPlanet->addUnit('rocket_launcher', 20);
+        $this->buddyPlanet()->addUnit('rocket_launcher', 20);
 
         // ACS defender: 100 LFs with same tech as the attacker (basicSetup sets weapon/shield/armor 5)
         // Attacker: 100 LFs (same tech, same numbers) → roughly 50% losses on both sides each battle
@@ -547,7 +611,7 @@ class FleetDispatchMultiDefenderBattleTest extends FleetDispatchTestCase
         $acsFleetMissionService = resolve(FleetMissionService::class, ['player' => $acsDefender['planet']->getPlayer()]);
         $acsDefendMission = $acsFleetMissionService->createNewFromPlanet(
             $acsDefender['planet'],
-            $this->buddyPlanet->getPlanetCoordinates(),
+            $this->buddyPlanet()->getPlanetCoordinates(),
             PlanetType::Planet,
             5,
             $acsDefendFleet,
@@ -566,7 +630,7 @@ class FleetDispatchMultiDefenderBattleTest extends FleetDispatchTestCase
         $attackFleet = new UnitCollection();
         $attackFleet->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 100);
         $this->dispatchFleet(
-            $this->buddyPlanet->getPlanetCoordinates(),
+            $this->buddyPlanet()->getPlanetCoordinates(),
             $attackFleet,
             new Resources(0, 0, 0, 0),
             PlanetType::Planet
@@ -574,6 +638,9 @@ class FleetDispatchMultiDefenderBattleTest extends FleetDispatchTestCase
 
         $attackerFleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $attackMission = $attackerFleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($attackMission === null) {
+            $this->fail('No active attack mission found.');
+        }
 
         // Advance to attack arrival - battle occurs during ACS defend hold time
         $this->travelTo(Date::createFromTimestamp($attackMission->time_arrival + 10));
@@ -583,6 +650,9 @@ class FleetDispatchMultiDefenderBattleTest extends FleetDispatchTestCase
         // After battle: no return mission yet - fleet is still holding with updated unit counts.
         // If completely destroyed, the outbound mission is marked processed=1 and no return ever arrives.
         $acsDefendMissionReloaded = FleetMission::find($acsDefendMission->id);
+        if ($acsDefendMissionReloaded === null) {
+            $this->fail('Fleet mission not found.');
+        }
 
         if ($acsDefendMissionReloaded->processed === 1) {
             // Fleet was completely destroyed - nothing to duplicate, test ends here
@@ -608,6 +678,9 @@ class FleetDispatchMultiDefenderBattleTest extends FleetDispatchTestCase
         $allReturnMissions = FleetMission::where('parent_id', $acsDefendMission->id)->get();
         $this->assertCount(1, $allReturnMissions, 'Exactly 1 return mission must be created when hold expires (no duplication)');
         $returnMission = $allReturnMissions->first();
+        if ($returnMission === null) {
+            $this->fail('Return mission should exist.');
+        }
 
         // Process the return trip
         $this->travelTo(Date::createFromTimestamp($returnMission->time_arrival + 10));
@@ -618,6 +691,9 @@ class FleetDispatchMultiDefenderBattleTest extends FleetDispatchTestCase
         // Planet must receive exactly the survivor count - not survivor + original 100 from a duplicate return
         $planetServiceFactory = resolve(PlanetServiceFactory::class);
         $acsDefenderPlanetReloaded = $planetServiceFactory->make($acsDefender['planet']->getPlanetId(), true);
+        if ($acsDefenderPlanetReloaded === null) {
+            $this->fail('Planet could not be loaded.');
+        }
         $returnedLightFighters = $acsDefenderPlanetReloaded->getShipUnits()->getAmountByMachineName('light_fighter');
         $this->assertEquals(
             $survivorCount,
@@ -635,8 +711,8 @@ class FleetDispatchMultiDefenderBattleTest extends FleetDispatchTestCase
         $this->createBuddyPlayer();
 
         // Give buddy planet some ships and defenses
-        $this->buddyPlanet->addUnit('light_fighter', 10);
-        $this->buddyPlanet->addUnit('rocket_launcher', 10);
+        $this->buddyPlanet()->addUnit('light_fighter', 10);
+        $this->buddyPlanet()->addUnit('rocket_launcher', 10);
         $originalBuddyShips = 10;
         $originalBuddyDefenses = 10;
 
@@ -652,7 +728,7 @@ class FleetDispatchMultiDefenderBattleTest extends FleetDispatchTestCase
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $acsDefender['planet']->getPlayer()]);
         $acsDefendMission = $fleetMissionService->createNewFromPlanet(
             $acsDefender['planet'],
-            $this->buddyPlanet->getPlanetCoordinates(),
+            $this->buddyPlanet()->getPlanetCoordinates(),
             PlanetType::Planet,
             5,
             $acsDefendFleet,
@@ -672,7 +748,7 @@ class FleetDispatchMultiDefenderBattleTest extends FleetDispatchTestCase
         $attackFleet = new UnitCollection();
         $attackFleet->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 40);
         $this->dispatchFleet(
-            $this->buddyPlanet->getPlanetCoordinates(),
+            $this->buddyPlanet()->getPlanetCoordinates(),
             $attackFleet,
             new Resources(0, 0, 0, 0),
             PlanetType::Planet
@@ -680,6 +756,9 @@ class FleetDispatchMultiDefenderBattleTest extends FleetDispatchTestCase
 
         $attackerFleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $attackMission = $attackerFleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($attackMission === null) {
+            $this->fail('No active attack mission found.');
+        }
 
         // Advance time for attack to arrive
         $this->travelTo(Date::createFromTimestamp($attackMission->time_arrival + 10));
@@ -689,7 +768,10 @@ class FleetDispatchMultiDefenderBattleTest extends FleetDispatchTestCase
 
         // Reload buddy's planet
         $planetServiceFactory = resolve(PlanetServiceFactory::class);
-        $buddyPlanetReloaded = $planetServiceFactory->make($this->buddyPlanet->getPlanetId());
+        $buddyPlanetReloaded = $planetServiceFactory->make($this->buddyPlanet()->getPlanetId());
+        if ($buddyPlanetReloaded === null) {
+            $this->fail('Planet could not be loaded.');
+        }
 
         // Check that buddy's planet had units removed
         $currentBuddyShips = $buddyPlanetReloaded->getShipUnits()->getAmountByMachineName('light_fighter');
@@ -721,10 +803,14 @@ class FleetDispatchMultiDefenderBattleTest extends FleetDispatchTestCase
         $this->createBuddyPlayer();
 
         // Set buddy's tech levels (low)
-        $this->buddyPlanet->getPlayer()->setResearchLevel('weapon_technology', 1);
-        $this->buddyPlanet->getPlayer()->setResearchLevel('shielding_technology', 1);
-        $this->buddyPlanet->getPlayer()->setResearchLevel('armor_technology', 1);
-        $this->buddyPlanet->addUnit('light_fighter', 10);
+        $buddyPlayer = $this->buddyPlanet()->getPlayer();
+        if ($buddyPlayer === null) {
+            $this->fail('Buddy planet has no player.');
+        }
+        $buddyPlayer->setResearchLevel('weapon_technology', 1);
+        $buddyPlayer->setResearchLevel('shielding_technology', 1);
+        $buddyPlayer->setResearchLevel('armor_technology', 1);
+        $this->buddyPlanet()->addUnit('light_fighter', 10);
 
         // Create first ACS defender with medium tech
         $acsDefender1 = $this->createAcsDefender();
@@ -738,29 +824,33 @@ class FleetDispatchMultiDefenderBattleTest extends FleetDispatchTestCase
         $acsDefender2User = User::factory()->create();
         self::$allCreatedBuddyUserIds[] = $acsDefender2User->id;
         // Place second defender 2 systems away from buddy to keep fleet arrival fast.
-        $acsDefender2System = min(499, $this->buddyPlanet->getPlanetCoordinates()->system + 2);
+        $acsDefender2System = min(499, $this->buddyPlanet()->getPlanetCoordinates()->system + 2);
         $acsDefender2Position = collect([13, 14, 15, 1, 2, 3])->first(
-            fn ($p) => !Planet::where('galaxy', $this->buddyPlanet->getPlanetCoordinates()->galaxy)->where('system', $acsDefender2System)->where('planet', $p)->exists()
+            fn ($p) => !Planet::where('galaxy', $this->buddyPlanet()->getPlanetCoordinates()->galaxy)->where('system', $acsDefender2System)->where('planet', $p)->exists()
         );
         $acsDefender2Planet = Planet::factory()->create([
             'user_id' => $acsDefender2User->id,
-            'galaxy'  => $this->buddyPlanet->getPlanetCoordinates()->galaxy,
+            'galaxy'  => $this->buddyPlanet()->getPlanetCoordinates()->galaxy,
             'system'  => $acsDefender2System,
             'planet'  => $acsDefender2Position,
         ]);
         $planetServiceFactory = resolve(PlanetServiceFactory::class);
         $acsDefender2PlayerService = resolve(PlayerService::class, ['player_id' => $acsDefender2User->id]);
         $acsDefender2PlanetService = $planetServiceFactory->makeForPlayer($acsDefender2PlayerService, $acsDefender2Planet->id);
-        $acsDefender2PlanetService->getPlayer()->setResearchLevel('weapon_technology', 10);
-        $acsDefender2PlanetService->getPlayer()->setResearchLevel('shielding_technology', 10);
-        $acsDefender2PlanetService->getPlayer()->setResearchLevel('armor_technology', 10);
+        $acsDefender2Player = $acsDefender2PlanetService->getPlayer();
+        if ($acsDefender2Player === null) {
+            $this->fail('ACS defender 2 planet has no player.');
+        }
+        $acsDefender2Player->setResearchLevel('weapon_technology', 10);
+        $acsDefender2Player->setResearchLevel('shielding_technology', 10);
+        $acsDefender2Player->setResearchLevel('armor_technology', 10);
         $acsDefender2PlanetService->addUnit('light_fighter', 20);
         $acsDefender2PlanetService->addResources(new Resources(0, 0, 1000000, 0));
 
         // Create buddy relationships
         $buddyService = resolve(BuddyService::class);
-        $request = $buddyService->sendRequest($acsDefender2User->id, $this->buddyUser->id);
-        $buddyService->acceptRequest($request->id, $this->buddyUser->id);
+        $request = $buddyService->sendRequest($acsDefender2User->id, $this->buddyUser()->id);
+        $buddyService->acceptRequest($request->id, $this->buddyUser()->id);
 
         // Send first ACS defend fleet
         $acsDefendFleet1 = new UnitCollection();
@@ -768,7 +858,7 @@ class FleetDispatchMultiDefenderBattleTest extends FleetDispatchTestCase
         $fleetMissionService1 = resolve(FleetMissionService::class, ['player' => $acsDefender1['planet']->getPlayer()]);
         $acsDefendMission1 = $fleetMissionService1->createNewFromPlanet(
             $acsDefender1['planet'],
-            $this->buddyPlanet->getPlanetCoordinates(),
+            $this->buddyPlanet()->getPlanetCoordinates(),
             PlanetType::Planet,
             5,
             $acsDefendFleet1,
@@ -783,7 +873,7 @@ class FleetDispatchMultiDefenderBattleTest extends FleetDispatchTestCase
         $fleetMissionService2 = resolve(FleetMissionService::class, ['player' => $acsDefender2PlanetService->getPlayer()]);
         $acsDefendMission2 = $fleetMissionService2->createNewFromPlanet(
             $acsDefender2PlanetService,
-            $this->buddyPlanet->getPlanetCoordinates(),
+            $this->buddyPlanet()->getPlanetCoordinates(),
             PlanetType::Planet,
             5,
             $acsDefendFleet2,
@@ -805,7 +895,7 @@ class FleetDispatchMultiDefenderBattleTest extends FleetDispatchTestCase
         $attackFleet = new UnitCollection();
         $attackFleet->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 30);
         $this->dispatchFleet(
-            $this->buddyPlanet->getPlanetCoordinates(),
+            $this->buddyPlanet()->getPlanetCoordinates(),
             $attackFleet,
             new Resources(0, 0, 0, 0),
             PlanetType::Planet
@@ -813,6 +903,9 @@ class FleetDispatchMultiDefenderBattleTest extends FleetDispatchTestCase
 
         $attackerFleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $attackMission = $attackerFleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($attackMission === null) {
+            $this->fail('No active attack mission found.');
+        }
 
         // Advance time for attack to arrive
         $this->travelTo(Date::createFromTimestamp($attackMission->time_arrival + 10));
@@ -829,7 +922,7 @@ class FleetDispatchMultiDefenderBattleTest extends FleetDispatchTestCase
         // ACS defender 1: 15 light fighters (medium tech)
         // ACS defender 2: 20 light fighters (high tech)
         // Total: 45 light fighters
-        $defenderStartUnits = $battleReport->defender['units'];
+        $defenderStartUnits = $battleReport->defender['units'] ?? [];
         $totalDefenderLightFighters = $defenderStartUnits['light_fighter'] ?? 0;
         $this->assertEquals(45, $totalDefenderLightFighters, 'All defending fleets should participate with their units');
     }

--- a/tests/Feature/FleetDispatch/FleetDispatchRecycleTest.php
+++ b/tests/Feature/FleetDispatch/FleetDispatchRecycleTest.php
@@ -11,6 +11,7 @@ use OGame\Models\Resources;
 use OGame\Services\DebrisFieldService;
 use OGame\Services\FleetMissionService;
 use OGame\Services\ObjectService;
+use OGame\Services\PlanetService;
 use Tests\FleetDispatchTestCase;
 
 /**
@@ -45,7 +46,7 @@ class FleetDispatchRecycleTest extends FleetDispatchTestCase
 
         // Add debris field to the second planet of the test user.
         $debrisFieldService = resolve(DebrisFieldService::class);
-        $debrisFieldService->loadOrCreateForCoordinates($this->secondPlanetService->getPlanetCoordinates());
+        $debrisFieldService->loadOrCreateForCoordinates($this->secondPlanet()->getPlanetCoordinates());
         $debrisFieldService->appendResources(new Resources(5000, 4000, 3000, 0));
         $debrisFieldService->save();
     }
@@ -60,6 +61,19 @@ class FleetDispatchRecycleTest extends FleetDispatchTestCase
         }
 
         parent::tearDown();
+    }
+
+    /**
+     * Get the second planet service, failing the test if it is not set.
+     */
+    private function secondPlanet(): PlanetService
+    {
+        $secondPlanetService = $this->secondPlanetService;
+        if ($secondPlanetService === null) {
+            $this->fail('Second planet service is null.');
+        }
+
+        return $secondPlanetService;
     }
 
     protected function messageCheckMissionArrival(): void
@@ -157,10 +171,13 @@ class FleetDispatchRecycleTest extends FleetDispatchTestCase
         // Get just dispatched fleet mission ID from database.
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($fleetMission === null) {
+            $this->fail('No active fleet mission found.');
+        }
         $fleetMissionId = $fleetMission->id;
 
         // Get time it takes for the fleet to travel to the second planet.
-        $fleetMissionDuration = $fleetMissionService->calculateFleetMissionDuration($this->planetService, $this->secondPlanetService->getPlanetCoordinates(), $unitCollection, resolve(RecycleMission::class));
+        $fleetMissionDuration = $fleetMissionService->calculateFleetMissionDuration($this->planetService, $this->secondPlanet()->getPlanetCoordinates(), $unitCollection, resolve(RecycleMission::class));
 
         // Set time to fleet mission duration + 30 seconds (we do 30 instead of 1 second to test later if the return trip start and endtime work as expected
         // and are calculated based on the arrival time instead of the time the job got processed).
@@ -175,6 +192,9 @@ class FleetDispatchRecycleTest extends FleetDispatchTestCase
 
         // Assert that the fleet mission is processed.
         $fleetMission = $fleetMissionService->getFleetMissionById($fleetMissionId, false);
+        if ($fleetMission === null) {
+            $this->fail('Fleet mission not found.');
+        }
         $this->assertTrue($fleetMission->processed == 1, 'Fleet mission is not processed after fleet has arrived at destination.');
 
         // Check that message has been received by calling extended method
@@ -182,7 +202,7 @@ class FleetDispatchRecycleTest extends FleetDispatchTestCase
 
         // Assert that the debris field is now empty after harvesting.
         $debrisFieldService = resolve(DebrisFieldService::class);
-        $debrisFieldService->loadOrCreateForCoordinates($this->secondPlanetService->getPlanetCoordinates());
+        $debrisFieldService->loadOrCreateForCoordinates($this->secondPlanet()->getPlanetCoordinates());
         $this->assertFalse($debrisFieldService->getResources()->any(), 'Debris field still has resources after recyclers have harvested it.');
 
         $activeMissions = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer();
@@ -190,6 +210,9 @@ class FleetDispatchRecycleTest extends FleetDispatchTestCase
         // Assert that a return trip has been launched by checking the active missions for the current planet.
         $this->assertCount(1, $activeMissions, 'No return trip launched after fleet has arrived at destination.');
         $returnMission = $activeMissions->first();
+        if ($returnMission === null) {
+            $this->fail('No return mission found.');
+        }
         // Assert that the return mission contains the correct resources.
         $this->assertTrue($returnMission->metal === 5000.0, 'Metal resources are not correct in return trip.');
         $this->assertTrue($returnMission->crystal === 4000.0, 'Crystal resources are not correct in return trip.');
@@ -241,6 +264,9 @@ class FleetDispatchRecycleTest extends FleetDispatchTestCase
 
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $outboundMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($outboundMission === null) {
+            $this->fail('No outbound mission found.');
+        }
         $fleetMissionDuration = $fleetMissionService->calculateFleetMissionDuration(
             $this->moonService,
             $targetCoordinate,
@@ -267,6 +293,9 @@ class FleetDispatchRecycleTest extends FleetDispatchTestCase
         $this->assertCount(1, $activeMissions, 'Recycle mission should create a return trip even after the moon is destroyed.');
 
         $returnMission = $activeMissions->first();
+        if ($returnMission === null) {
+            $this->fail('No return mission found.');
+        }
         $this->assertSame($this->planetService->getPlanetId(), $returnMission->planet_id_to, 'Return trip should be rerouted to the parent planet.');
         $this->assertSame(PlanetType::Planet->value, $returnMission->type_to, 'Return trip should target the parent planet.');
 
@@ -322,7 +351,7 @@ class FleetDispatchRecycleTest extends FleetDispatchTestCase
 
         // Make sure the debris field has a lot of resources.
         $debrisFieldService = resolve(DebrisFieldService::class);
-        $debrisFieldService->loadForCoordinates($this->secondPlanetService->getPlanetCoordinates());
+        $debrisFieldService->loadForCoordinates($this->secondPlanet()->getPlanetCoordinates());
         $debrisFieldService->appendResources(new Resources(500000, 500000, 500000, 0));
         $debrisFieldService->save();
 
@@ -336,10 +365,13 @@ class FleetDispatchRecycleTest extends FleetDispatchTestCase
         // Get just dispatched fleet mission ID from database.
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($fleetMission === null) {
+            $this->fail('No active fleet mission found.');
+        }
         $fleetMissionId = $fleetMission->id;
 
         // Get time it takes for the fleet to travel to the second planet.
-        $fleetMissionDuration = $fleetMissionService->calculateFleetMissionDuration($this->planetService, $this->secondPlanetService->getPlanetCoordinates(), $unitCollection, resolve(RecycleMission::class));
+        $fleetMissionDuration = $fleetMissionService->calculateFleetMissionDuration($this->planetService, $this->secondPlanet()->getPlanetCoordinates(), $unitCollection, resolve(RecycleMission::class));
 
         // Set time to fleet mission duration + 30 seconds (we do 30 instead of 1 second to test later if the return trip start and endtime work as expected
         // and are calculated based on the arrival time instead of the time the job got processed).
@@ -351,11 +383,14 @@ class FleetDispatchRecycleTest extends FleetDispatchTestCase
 
         // Assert that the fleet mission is processed.
         $fleetMission = $fleetMissionService->getFleetMissionById($fleetMissionId, false);
+        if ($fleetMission === null) {
+            $this->fail('Fleet mission not found.');
+        }
         $this->assertTrue($fleetMission->processed == 1, 'Fleet mission is not processed after fleet has arrived at destination.');
 
         // Assert that the debris field contents have been reduced by the amount the recyclers can carry.
         $debrisFieldService = resolve(DebrisFieldService::class);
-        $debrisFieldService->loadForCoordinates($this->secondPlanetService->getPlanetCoordinates());
+        $debrisFieldService->loadForCoordinates($this->secondPlanet()->getPlanetCoordinates());
 
         $this->assertEquals($beforeDebrisFieldResources->metal->get() - 33333.33333333, $debrisFieldService->getResources()->metal->get(), 'Metal resources are not correct in debris field after recyclers have harvested it.');
         $this->assertEquals($beforeDebrisFieldResources->crystal->get() - 33333.33333333, $debrisFieldService->getResources()->crystal->get(), 'Crystal resources are not correct in debris field after recyclers have harvested it.');
@@ -364,6 +399,9 @@ class FleetDispatchRecycleTest extends FleetDispatchTestCase
         // Expecting a return trip that will contain the extracted resources.
         $activeMissions = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer();
         $returnMission = $activeMissions->first();
+        if ($returnMission === null) {
+            $this->fail('No return mission found.');
+        }
 
         // Assert that the return mission contains the correct resources
         // which should be the same as the total capacity of the recyclers.
@@ -383,7 +421,7 @@ class FleetDispatchRecycleTest extends FleetDispatchTestCase
 
         // Make sure the debris field contains resources when sending the fleet.
         $debrisFieldService = resolve(DebrisFieldService::class);
-        $debrisFieldService->loadOrCreateForCoordinates($this->secondPlanetService->getPlanetCoordinates());
+        $debrisFieldService->loadOrCreateForCoordinates($this->secondPlanet()->getPlanetCoordinates());
         $debrisFieldService->appendResources(new Resources(5000, 4000, 3000, 0));
         $debrisFieldService->save();
 
@@ -398,10 +436,13 @@ class FleetDispatchRecycleTest extends FleetDispatchTestCase
         // Get just dispatched fleet mission ID from database.
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($fleetMission === null) {
+            $this->fail('No active fleet mission found.');
+        }
         $fleetMissionId = $fleetMission->id;
 
         // Get time it takes for the fleet to travel to the second planet.
-        $fleetMissionDuration = $fleetMissionService->calculateFleetMissionDuration($this->planetService, $this->secondPlanetService->getPlanetCoordinates(), $unitCollection, resolve(RecycleMission::class));
+        $fleetMissionDuration = $fleetMissionService->calculateFleetMissionDuration($this->planetService, $this->secondPlanet()->getPlanetCoordinates(), $unitCollection, resolve(RecycleMission::class));
 
         // Set time to fleet mission duration + 30 seconds (we do 30 instead of 1 second to test later if the return trip start and endtime work as expected
         // and are calculated based on the arrival time instead of the time the job got processed).
@@ -413,11 +454,17 @@ class FleetDispatchRecycleTest extends FleetDispatchTestCase
 
         // Assert that the fleet mission is processed.
         $fleetMission = $fleetMissionService->getFleetMissionById($fleetMissionId, false);
+        if ($fleetMission === null) {
+            $this->fail('Fleet mission not found.');
+        }
         $this->assertTrue($fleetMission->processed == 1, 'Fleet mission is not processed after fleet has arrived at destination.');
 
         // Expecting a return trip that will contain 0 resources.
         $activeMissions = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer();
         $returnMission = $activeMissions->first();
+        if ($returnMission === null) {
+            $this->fail('No return mission found.');
+        }
 
         // Assert that the return mission contains the correct resources
         // which should be the same as the total capacity of the recyclers.
@@ -445,10 +492,17 @@ class FleetDispatchRecycleTest extends FleetDispatchTestCase
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
 
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($fleetMission === null) {
+            $this->fail('No active fleet mission found.');
+        }
         $fleetMissionId = $fleetMission->id;
 
         // Advance time by 1 minute
-        $fleetParentTime = Date::getTestNow()->addMinute();
+        $testNow = Date::getTestNow();
+        if ($testNow === null) {
+            $this->fail('Test now is null.');
+        }
+        $fleetParentTime = $testNow->addMinute();
         $this->travelTo($fleetParentTime);
 
         // Cancel the mission
@@ -461,6 +515,9 @@ class FleetDispatchRecycleTest extends FleetDispatchTestCase
 
         // Assert that the original mission is now canceled.
         $fleetMission = $fleetMissionService->getFleetMissionById($fleetMissionId, false);
+        if ($fleetMission === null) {
+            $this->fail('Fleet mission not found.');
+        }
         $this->assertTrue($fleetMission->canceled == 1, 'Fleet mission is not canceled after fleet recall is requested.');
 
         // Assert that only the return trip is now visible.
@@ -473,8 +530,14 @@ class FleetDispatchRecycleTest extends FleetDispatchTestCase
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
 
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($fleetMission === null) {
+            $this->fail('No active fleet mission found.');
+        }
         $fleetMissionId = $fleetMission->id;
         $fleetMission = $fleetMissionService->getFleetMissionById($fleetMissionId, false);
+        if ($fleetMission === null) {
+            $this->fail('Fleet mission not found.');
+        }
 
         // Assert that the return trip arrival time is exactly 1 minute after the cancelation time.
         // Because the return trip should take exactly as long as the original trip has traveled until it was canceled.
@@ -488,6 +551,9 @@ class FleetDispatchRecycleTest extends FleetDispatchTestCase
 
         // Assert that the return trip is processed.
         $fleetMission = $fleetMissionService->getFleetMissionById($fleetMissionId, false);
+        if ($fleetMission === null) {
+            $this->fail('Fleet mission not found.');
+        }
         $this->assertTrue($fleetMission->processed == 1, 'Return trip is not processed after fleet has arrived back at origin planet.');
 
         // Assert that the units have been returned to the origin planet.
@@ -511,6 +577,9 @@ class FleetDispatchRecycleTest extends FleetDispatchTestCase
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
 
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($fleetMission === null) {
+            $this->fail('No active fleet mission found.');
+        }
         $fleetMissionId = $fleetMission->id;
 
         // Advance time by 1 minute
@@ -588,7 +657,7 @@ class FleetDispatchRecycleTest extends FleetDispatchTestCase
 
         // Add debris field to the second planet of the test user.
         $debrisFieldService = resolve(DebrisFieldService::class);
-        $debrisFieldService->loadOrCreateForCoordinates($this->secondPlanetService->getPlanetCoordinates());
+        $debrisFieldService->loadOrCreateForCoordinates($this->secondPlanet()->getPlanetCoordinates());
         $debrisFieldService->appendResources(new Resources(5000, 4000, 3000, 0));
         $debrisFieldService->save();
 
@@ -613,7 +682,11 @@ class FleetDispatchRecycleTest extends FleetDispatchTestCase
         $fleetMissionService = resolve(FleetMissionService::class);
         $activeMissions = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer();
         $this->assertCount(1, $activeMissions, 'Recycle mission not created');
-        $fleetMissionId = $activeMissions->first()->id;
+        $firstMission = $activeMissions->first();
+        if ($firstMission === null) {
+            $this->fail('No active fleet mission found.');
+        }
+        $fleetMissionId = $firstMission->id;
 
         // Verify resources were deducted from planet
         $this->get('/overview');
@@ -628,13 +701,16 @@ class FleetDispatchRecycleTest extends FleetDispatchTestCase
 
         // Get debris field resources before harvest
         $debrisFieldService = resolve(DebrisFieldService::class);
-        $debrisFieldService->loadForCoordinates($this->secondPlanetService->getPlanetCoordinates());
+        $debrisFieldService->loadForCoordinates($this->secondPlanet()->getPlanetCoordinates());
         $debrisFieldResources = $debrisFieldService->getResources();
         $debrisFieldMetal = $debrisFieldResources->metal->get();
         $debrisFieldCrystal = $debrisFieldResources->crystal->get();
 
         // Advance time to mission arrival
         $fleetMission = $fleetMissionService->getFleetMissionById($fleetMissionId, false);
+        if ($fleetMission === null) {
+            $this->fail('Fleet mission not found.');
+        }
         $travelTime = $fleetMission->time_arrival - $fleetMission->time_departure;
         $this->travel($travelTime + 1)->seconds();
 
@@ -645,6 +721,9 @@ class FleetDispatchRecycleTest extends FleetDispatchTestCase
         $activeMissions = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer();
         $this->assertCount(1, $activeMissions, 'Return mission should be created');
         $returnMission = $activeMissions->first();
+        if ($returnMission === null) {
+            $this->fail('No return mission found.');
+        }
 
         // Verify return mission has original + harvested resources
         $debrisFieldDeuterium = $debrisFieldResources->deuterium->get();
@@ -692,13 +771,13 @@ class FleetDispatchRecycleTest extends FleetDispatchTestCase
 
         // Add debris field to the second planet of the test user.
         $debrisFieldService = resolve(DebrisFieldService::class);
-        $debrisFieldService->loadOrCreateForCoordinates($this->secondPlanetService->getPlanetCoordinates());
+        $debrisFieldService->loadOrCreateForCoordinates($this->secondPlanet()->getPlanetCoordinates());
         $debrisFieldService->appendResources(new Resources(5000, 4000, 3000, 0));
         $debrisFieldService->save();
 
         // Empty the debris field completely
         $debrisFieldService = resolve(DebrisFieldService::class);
-        $debrisFieldService->loadForCoordinates($this->secondPlanetService->getPlanetCoordinates());
+        $debrisFieldService->loadForCoordinates($this->secondPlanet()->getPlanetCoordinates());
         $debrisFieldService->deductResources($debrisFieldService->getResources());
         $debrisFieldService->save();
 
@@ -722,10 +801,17 @@ class FleetDispatchRecycleTest extends FleetDispatchTestCase
         // Get the mission
         $fleetMissionService = resolve(FleetMissionService::class);
         $activeMissions = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer();
-        $fleetMissionId = $activeMissions->first()->id;
+        $firstMission = $activeMissions->first();
+        if ($firstMission === null) {
+            $this->fail('No active fleet mission found.');
+        }
+        $fleetMissionId = $firstMission->id;
 
         // Advance time to mission arrival
         $fleetMission = $fleetMissionService->getFleetMissionById($fleetMissionId, false);
+        if ($fleetMission === null) {
+            $this->fail('Fleet mission not found.');
+        }
         $travelTime = $fleetMission->time_arrival - $fleetMission->time_departure;
         $this->travel($travelTime + 1)->seconds();
 
@@ -735,6 +821,9 @@ class FleetDispatchRecycleTest extends FleetDispatchTestCase
         // Verify return mission has exact original resources (nothing harvested from empty field)
         $activeMissions = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer();
         $returnMission = $activeMissions->first();
+        if ($returnMission === null) {
+            $this->fail('No return mission found.');
+        }
 
         $this->assertEquals(80000, $returnMission->metal);
         $this->assertEquals(40000, $returnMission->crystal);

--- a/tests/Feature/FleetDispatch/FleetDispatchTransportTest.php
+++ b/tests/Feature/FleetDispatch/FleetDispatchTransportTest.php
@@ -130,7 +130,11 @@ class FleetDispatchTransportTest extends FleetDispatchTestCase
         $response->assertStatus(200);
 
         // Assert that last message sent to second player contains the transport confirm message.
-        $this->assertMessageReceivedAndContainsDatabase($foreignPlanet->getPlayer(), [
+        $foreignPlayer = $foreignPlanet->getPlayer();
+        if ($foreignPlayer === null) {
+            $this->fail('Foreign planet player is null.');
+        }
+        $this->assertMessageReceivedAndContainsDatabase($foreignPlayer, [
             'An incoming fleet from',
             'has reached your',
         ]);
@@ -227,10 +231,17 @@ class FleetDispatchTransportTest extends FleetDispatchTestCase
         // Get just dispatched fleet mission ID from database.
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($fleetMission === null) {
+            $this->fail('No active fleet mission found.');
+        }
         $fleetMissionId = $fleetMission->id;
 
         // Get time it takes for the fleet to travel to the second planet.
-        $fleetMissionDuration = $fleetMissionService->calculateFleetMissionDuration($this->planetService, $this->secondPlanetService->getPlanetCoordinates(), $unitCollection, resolve(TransportMission::class));
+        $secondPlanetService = $this->secondPlanetService;
+        if ($secondPlanetService === null) {
+            $this->fail('Second planet service is null.');
+        }
+        $fleetMissionDuration = $fleetMissionService->calculateFleetMissionDuration($this->planetService, $secondPlanetService->getPlanetCoordinates(), $unitCollection, resolve(TransportMission::class));
 
         // Set time to fleet mission duration + 30 seconds (we do 30 instead of 1 second to test later if the return trip start and endtime work as expected
         // and are calculated based on the arrival time instead of the time the job got processed).
@@ -245,10 +256,13 @@ class FleetDispatchTransportTest extends FleetDispatchTestCase
 
         // Assert that the fleet mission is processed.
         $fleetMission = $fleetMissionService->getFleetMissionById($fleetMissionId, false);
+        if ($fleetMission === null) {
+            $this->fail('Fleet mission not found.');
+        }
         $this->assertTrue($fleetMission->processed == 1, 'Fleet mission is not processed after fleet has arrived at destination.');
 
         // Check that message has been received by calling extended method
-        $this->messageCheckMissionArrival($this->secondPlanetService);
+        $this->messageCheckMissionArrival($secondPlanetService);
 
         $activeMissions = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer();
 
@@ -256,7 +270,11 @@ class FleetDispatchTransportTest extends FleetDispatchTestCase
         $this->assertCount(1, $activeMissions, 'No return trip launched after fleet has arrived at destination.');
 
         // Advance time to the return trip arrival.
-        $returnTripDuration = $activeMissions->first()->time_arrival - $activeMissions->first()->time_departure;
+        $returnMission = $activeMissions->first();
+        if ($returnMission === null) {
+            $this->fail('No return mission found.');
+        }
+        $returnTripDuration = $returnMission->time_arrival - $returnMission->time_departure;
         $this->travel($returnTripDuration + 1)->seconds();
 
         // Do a request to trigger the update logic.
@@ -271,7 +289,7 @@ class FleetDispatchTransportTest extends FleetDispatchTestCase
         $response = $this->get('/shipyard');
         $this->assertObjectLevelOnPage($response, 'small_cargo', 5, 'Small Cargo ships are not at 5 units after return trip.');
 
-        $this->messageCheckMissionReturn($this->secondPlanetService);
+        $this->messageCheckMissionReturn($secondPlanetService);
     }
 
     /**
@@ -293,6 +311,9 @@ class FleetDispatchTransportTest extends FleetDispatchTestCase
         // Get just dispatched fleet mission ID from database.
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($fleetMission === null) {
+            $this->fail('No active fleet mission found.');
+        }
         $fleetMissionId = $fleetMission->id;
 
         // Get time it takes for the fleet to travel to the second planet.
@@ -311,6 +332,9 @@ class FleetDispatchTransportTest extends FleetDispatchTestCase
 
         // Assert that the fleet mission is processed.
         $fleetMission = $fleetMissionService->getFleetMissionById($fleetMissionId, false);
+        if ($fleetMission === null) {
+            $this->fail('Fleet mission not found.');
+        }
         $this->assertTrue($fleetMission->processed == 1, 'Fleet mission is not processed after fleet has arrived at destination.');
 
         // Check that message has been received by calling extended method
@@ -322,7 +346,11 @@ class FleetDispatchTransportTest extends FleetDispatchTestCase
         $this->assertCount(1, $activeMissions, 'No return trip launched after fleet has arrived at destination.');
 
         // Advance time to the return trip arrival.
-        $returnTripDuration = $activeMissions->first()->time_arrival - $activeMissions->first()->time_departure;
+        $returnMission = $activeMissions->first();
+        if ($returnMission === null) {
+            $this->fail('No return mission found.');
+        }
+        $returnTripDuration = $returnMission->time_arrival - $returnMission->time_departure;
         $this->travel($returnTripDuration + 1)->seconds();
 
         // Do a request to trigger the update logic.
@@ -361,7 +389,11 @@ class FleetDispatchTransportTest extends FleetDispatchTestCase
         $response = $this->get('/ajax/fleet/eventlist/fetch');
         $response->assertStatus(200);
         $response->assertSee('planetIcon planet');
-        $response->assertSee($this->secondPlanetService->getPlanetName());
+        $secondPlanetService = $this->secondPlanetService;
+        if ($secondPlanetService === null) {
+            $this->fail('Second planet service is null.');
+        }
+        $response->assertSee($secondPlanetService->getPlanetName());
 
         // If the mission has a return mission, we should see both in the event list.
         $response->assertSee($this->missionName);
@@ -425,10 +457,17 @@ class FleetDispatchTransportTest extends FleetDispatchTestCase
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
 
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($fleetMission === null) {
+            $this->fail('No active fleet mission found.');
+        }
         $fleetMissionId = $fleetMission->id;
 
         // Advance time by 1 minute
-        $fleetParentTime = Date::getTestNow()->addMinute();
+        $testNow = Date::getTestNow();
+        if ($testNow === null) {
+            $this->fail('Test now is null.');
+        }
+        $fleetParentTime = $testNow->addMinute();
         $this->travelTo($fleetParentTime);
 
         // Cancel the mission
@@ -441,6 +480,9 @@ class FleetDispatchTransportTest extends FleetDispatchTestCase
 
         // Assert that the original mission is now canceled.
         $fleetMission = $fleetMissionService->getFleetMissionById($fleetMissionId, false);
+        if ($fleetMission === null) {
+            $this->fail('Fleet mission not found.');
+        }
         $this->assertTrue($fleetMission->canceled == 1, 'Fleet mission is not canceled after fleet recall is requested.');
 
         // Assert that only the return trip is now visible.
@@ -453,8 +495,14 @@ class FleetDispatchTransportTest extends FleetDispatchTestCase
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
 
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($fleetMission === null) {
+            $this->fail('No active fleet mission found.');
+        }
         $fleetMissionId = $fleetMission->id;
         $fleetMission = $fleetMissionService->getFleetMissionById($fleetMissionId, false);
+        if ($fleetMission === null) {
+            $this->fail('Fleet mission not found.');
+        }
 
         // Assert that the return trip arrival time is exactly 1 minute after the cancelation time.
         // Because the return trip should take exactly as long as the original trip has traveled until it was canceled.
@@ -468,6 +516,9 @@ class FleetDispatchTransportTest extends FleetDispatchTestCase
 
         // Assert that the return trip is processed.
         $fleetMission = $fleetMissionService->getFleetMissionById($fleetMissionId, false);
+        if ($fleetMission === null) {
+            $this->fail('Fleet mission not found.');
+        }
         $this->assertTrue($fleetMission->processed == 1, 'Return trip is not processed after fleet has arrived back at origin planet.');
 
         // Assert that the units have been returned to the origin planet.
@@ -498,6 +549,9 @@ class FleetDispatchTransportTest extends FleetDispatchTestCase
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
 
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($fleetMission === null) {
+            $this->fail('No active fleet mission found.');
+        }
         $fleetMissionId = $fleetMission->id;
 
         // Advance time by 1 minute
@@ -539,7 +593,11 @@ class FleetDispatchTransportTest extends FleetDispatchTestCase
         $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('small_cargo'), 1);
 
         // Use second planet coordinates but specify it's a (non existent) moon target
-        $coordinates = $this->secondPlanetService->getPlanetCoordinates();
+        $secondPlanetService = $this->secondPlanetService;
+        if ($secondPlanetService === null) {
+            $this->fail('Second planet service is null.');
+        }
+        $coordinates = $secondPlanetService->getPlanetCoordinates();
 
         // Dispatch fleet to the non-existent moon and expect mission to fail (assertStatus is false)
         $this->dispatchFleet($coordinates, $unitCollection, new Resources(100, 100, 0, 0), PlanetType::Moon, 0, false);

--- a/tests/Feature/FleetDispatch/GeneralWreckFieldTest.php
+++ b/tests/Feature/FleetDispatch/GeneralWreckFieldTest.php
@@ -63,6 +63,9 @@ class GeneralWreckFieldTest extends FleetDispatchTestCase
         // Set up: attacker with General class
         $attacker = $this->planetService;
         $attackerPlayer = $attacker->getPlayer();
+        if ($attackerPlayer === null) {
+            $this->fail('Attacker player is null.');
+        }
 
         // Set character class to General (required for wreck field generation)
         $attackerPlayer->getUser()->character_class = CharacterClass::GENERAL->value;
@@ -92,6 +95,9 @@ class GeneralWreckFieldTest extends FleetDispatchTestCase
         // Get the mission
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $attacker->getPlayer()]);
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($fleetMission === null) {
+            $this->fail('No active fleet mission found.');
+        }
         $fleetMissionDuration = $fleetMission->time_arrival - $fleetMission->time_departure;
 
         // Set up: defender with defenses to inflict losses without wiping the fleet.
@@ -120,11 +126,11 @@ class GeneralWreckFieldTest extends FleetDispatchTestCase
         $attackerWreckField = WreckField::where('galaxy', $attackerCoords->galaxy)
             ->where('system', $attackerCoords->system)
             ->where('planet', $attackerCoords->position)
-            ->where('owner_player_id', $attacker->getPlayer()->getId())
+            ->where('owner_player_id', $attackerPlayer->getId())
             ->first();
         $this->assertNotNull($attackerWreckField, 'Wreck field should be created at attacker origin planet for General');
         $this->assertEquals('active', $attackerWreckField->status, 'Wreck field should be active');
-        $this->assertEquals($attacker->getPlayer()->getId(), $attackerWreckField->owner_player_id, 'Wreck field should belong to attacker');
+        $this->assertEquals($attackerPlayer->getId(), $attackerWreckField->owner_player_id, 'Wreck field should belong to attacker');
         $this->assertGreaterThan(0, $attackerWreckField->getTotalShips(), 'Wreck field should contain ships');
     }
 
@@ -149,6 +155,9 @@ class GeneralWreckFieldTest extends FleetDispatchTestCase
         // Set up: attacker with General class
         $attacker = $this->planetService;
         $attackerPlayer = $attacker->getPlayer();
+        if ($attackerPlayer === null) {
+            $this->fail('Attacker player is null.');
+        }
 
         // Set character class to General
         $attackerPlayer->getUser()->character_class = CharacterClass::GENERAL->value;
@@ -182,6 +191,9 @@ class GeneralWreckFieldTest extends FleetDispatchTestCase
         // Get the mission
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $attacker->getPlayer()]);
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($fleetMission === null) {
+            $this->fail('No active fleet mission found.');
+        }
         $fleetMissionDuration = $fleetMission->time_arrival - $fleetMission->time_departure;
 
         // Process arrival (battle happens, all attackers destroyed)
@@ -197,7 +209,7 @@ class GeneralWreckFieldTest extends FleetDispatchTestCase
         $wreckFieldAfterReturn = WreckField::where('galaxy', $coords->galaxy)
             ->where('system', $coords->system)
             ->where('planet', $coords->position)
-            ->where('owner_player_id', $attacker->getPlayer()->getId())
+            ->where('owner_player_id', $attackerPlayer->getId())
             ->first();
         $this->assertNull($wreckFieldAfterReturn, 'No wreck field should exist if all attacker ships were destroyed');
     }
@@ -223,6 +235,9 @@ class GeneralWreckFieldTest extends FleetDispatchTestCase
         // Set up: attacker with General class
         $attacker = $this->planetService;
         $attackerPlayer = $attacker->getPlayer();
+        if ($attackerPlayer === null) {
+            $this->fail('Attacker player is null.');
+        }
 
         // Set character class to General
         $attackerPlayer->getUser()->character_class = CharacterClass::GENERAL->value;
@@ -261,6 +276,9 @@ class GeneralWreckFieldTest extends FleetDispatchTestCase
         // Get the mission
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $attacker->getPlayer()]);
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($fleetMission === null) {
+            $this->fail('No active fleet mission found.');
+        }
         $fleetMissionDuration = $fleetMission->time_arrival - $fleetMission->time_departure;
 
         // Process arrival (battle happens)
@@ -269,10 +287,14 @@ class GeneralWreckFieldTest extends FleetDispatchTestCase
 
         // Check for defender wreck field at defender's planet
         $defenderCoords = $foreignPlanet->getPlanetCoordinates();
+        $defenderPlayer = $foreignPlanet->getPlayer();
+        if ($defenderPlayer === null) {
+            $this->fail('Foreign planet player is null.');
+        }
         $defenderWreckField = WreckField::where('galaxy', $defenderCoords->galaxy)
             ->where('system', $defenderCoords->system)
             ->where('planet', $defenderCoords->position)
-            ->where('owner_player_id', $foreignPlanet->getPlayer()->getId())
+            ->where('owner_player_id', $defenderPlayer->getId())
             ->first();
 
         // Process return mission
@@ -284,7 +306,7 @@ class GeneralWreckFieldTest extends FleetDispatchTestCase
         $attackerWreckField = WreckField::where('galaxy', $attackerCoords->galaxy)
             ->where('system', $attackerCoords->system)
             ->where('planet', $attackerCoords->position)
-            ->where('owner_player_id', $attacker->getPlayer()->getId())
+            ->where('owner_player_id', $attackerPlayer->getId())
             ->first();
 
         // Both wreck fields should potentially exist if conditions were met
@@ -326,6 +348,9 @@ class GeneralWreckFieldTest extends FleetDispatchTestCase
         // Set up: attacker WITHOUT General class
         $attacker = $this->planetService;
         $attackerPlayer = $attacker->getPlayer();
+        if ($attackerPlayer === null) {
+            $this->fail('Attacker player is null.');
+        }
 
         // Set character class to Collector (NOT General)
         $attackerPlayer->getUser()->character_class = CharacterClass::COLLECTOR->value;
@@ -359,6 +384,9 @@ class GeneralWreckFieldTest extends FleetDispatchTestCase
         // Get the mission
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $attacker->getPlayer()]);
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($fleetMission === null) {
+            $this->fail('No active fleet mission found.');
+        }
         $fleetMissionDuration = $fleetMission->time_arrival - $fleetMission->time_departure;
 
         // Process arrival (battle happens)
@@ -374,7 +402,7 @@ class GeneralWreckFieldTest extends FleetDispatchTestCase
         $wreckField = WreckField::where('galaxy', $coords->galaxy)
             ->where('system', $coords->system)
             ->where('planet', $coords->position)
-            ->where('owner_player_id', $attacker->getPlayer()->getId())
+            ->where('owner_player_id', $attackerPlayer->getId())
             ->first();
         $this->assertNull($wreckField, 'No wreck field should exist at origin planet for non-General class');
     }
@@ -400,6 +428,9 @@ class GeneralWreckFieldTest extends FleetDispatchTestCase
         // Set up: attacker with General class
         $attacker = $this->planetService;
         $attackerPlayer = $attacker->getPlayer();
+        if ($attackerPlayer === null) {
+            $this->fail('Attacker player is null.');
+        }
 
         // Set character class to General
         $attackerPlayer->getUser()->character_class = CharacterClass::GENERAL->value;
@@ -429,6 +460,9 @@ class GeneralWreckFieldTest extends FleetDispatchTestCase
         // Get the mission
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $attacker->getPlayer()]);
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($fleetMission === null) {
+            $this->fail('No active fleet mission found.');
+        }
         $fleetMissionDuration = $fleetMission->time_arrival - $fleetMission->time_departure;
 
         // Process arrival and return
@@ -442,7 +476,7 @@ class GeneralWreckFieldTest extends FleetDispatchTestCase
         $wreckField = WreckField::where('galaxy', $coords->galaxy)
             ->where('system', $coords->system)
             ->where('planet', $coords->position)
-            ->where('owner_player_id', $attacker->getPlayer()->getId())
+            ->where('owner_player_id', $attackerPlayer->getId())
             ->first();
         $this->assertNull($wreckField, 'No wreck field should exist if minimum resource loss not met');
     }
@@ -468,6 +502,9 @@ class GeneralWreckFieldTest extends FleetDispatchTestCase
         // Set up: attacker with General class
         $attacker = $this->planetService;
         $attackerPlayer = $attacker->getPlayer();
+        if ($attackerPlayer === null) {
+            $this->fail('Attacker player is null.');
+        }
 
         // Set character class to General
         $attackerPlayer->getUser()->character_class = CharacterClass::GENERAL->value;
@@ -500,6 +537,9 @@ class GeneralWreckFieldTest extends FleetDispatchTestCase
         // Get the mission
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $attacker->getPlayer()]);
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($fleetMission === null) {
+            $this->fail('No active fleet mission found.');
+        }
         $fleetMissionDuration = $fleetMission->time_arrival - $fleetMission->time_departure;
 
         // Process arrival (battle happens)
@@ -515,7 +555,7 @@ class GeneralWreckFieldTest extends FleetDispatchTestCase
         $wreckField = WreckField::where('galaxy', $coords->galaxy)
             ->where('system', $coords->system)
             ->where('planet', $coords->position)
-            ->where('owner_player_id', $attacker->getPlayer()->getId())
+            ->where('owner_player_id', $attackerPlayer->getId())
             ->first();
 
         if ($wreckField !== null) {
@@ -549,6 +589,9 @@ class GeneralWreckFieldTest extends FleetDispatchTestCase
         // Set up: attacker with General class
         $attacker = $this->planetService;
         $attackerPlayer = $attacker->getPlayer();
+        if ($attackerPlayer === null) {
+            $this->fail('Attacker player is null.');
+        }
 
         // Set character class to General
         $attackerPlayer->getUser()->character_class = CharacterClass::GENERAL->value;
@@ -583,6 +626,9 @@ class GeneralWreckFieldTest extends FleetDispatchTestCase
         // Get the mission
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $attacker->getPlayer()]);
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($fleetMission === null) {
+            $this->fail('No active fleet mission found.');
+        }
         $fleetMissionDuration = $fleetMission->time_arrival - $fleetMission->time_departure;
 
         // Process arrival (battle happens, solar satellites will be destroyed)
@@ -595,10 +641,14 @@ class GeneralWreckFieldTest extends FleetDispatchTestCase
 
         // Check for defender wreck field
         $defenderCoords = $foreignPlanet->getPlanetCoordinates();
+        $defenderPlayer = $foreignPlanet->getPlayer();
+        if ($defenderPlayer === null) {
+            $this->fail('Foreign planet player is null.');
+        }
         $defenderWreckField = WreckField::where('galaxy', $defenderCoords->galaxy)
             ->where('system', $defenderCoords->system)
             ->where('planet', $defenderCoords->position)
-            ->where('owner_player_id', $foreignPlanet->getPlayer()->getId())
+            ->where('owner_player_id', $defenderPlayer->getId())
             ->first();
 
         if ($defenderWreckField !== null) {

--- a/tests/Feature/FleetDispatch/PathfinderExpeditionDebrisHarvestTest.php
+++ b/tests/Feature/FleetDispatch/PathfinderExpeditionDebrisHarvestTest.php
@@ -3,8 +3,13 @@
 namespace Tests\Feature\FleetDispatch;
 
 use Illuminate\Contracts\Container\BindingResolutionException;
+use OGame\GameObjects\Models\Units\UnitCollection;
+use OGame\Models\Enums\PlanetType;
 use OGame\Models\Planet\Coordinate;
+use OGame\Models\Resources;
 use OGame\Services\DebrisFieldService;
+use OGame\Services\FleetMissionService;
+use OGame\Services\ObjectService;
 use Tests\FleetDispatchTestCase;
 
 /**
@@ -39,7 +44,7 @@ class PathfinderExpeditionDebrisHarvestTest extends FleetDispatchTestCase
         $planet->addUnit('pathfinder', 10);
 
         // Add deuterium for fleet travel
-        $this->planetAddResources(new \OGame\Models\Resources(0, 0, 10000, 0));
+        $this->planetAddResources(new Resources(0, 0, 10000, 0));
 
         // Create debris field at position 16 (expedition position)
         $debrisCoordinate = new Coordinate(
@@ -50,7 +55,7 @@ class PathfinderExpeditionDebrisHarvestTest extends FleetDispatchTestCase
 
         $debrisFieldService = resolve(DebrisFieldService::class);
         $debrisFieldService->loadOrCreateForCoordinates($debrisCoordinate);
-        $debrisFieldService->appendResources(new \OGame\Models\Resources(100000, 50000, 25000, 0));
+        $debrisFieldService->appendResources(new Resources(100000, 50000, 25000, 0));
         $debrisFieldService->save();
 
         // Get initial debris amount
@@ -59,13 +64,16 @@ class PathfinderExpeditionDebrisHarvestTest extends FleetDispatchTestCase
         $this->assertGreaterThan(0, $initialDebris, 'Debris field should have resources');
 
         // Send harvest mission with Pathfinders to position 16
-        $units = new \OGame\GameObjects\Models\Units\UnitCollection();
-        $units->addUnit(\OGame\Services\ObjectService::getShipObjectByMachineName('pathfinder'), 10);
-        $this->sendMissionToPosition16($units, new \OGame\Models\Resources(0, 0, 0, 0), true, \OGame\Models\Enums\PlanetType::DebrisField);
+        $units = new UnitCollection();
+        $units->addUnit(ObjectService::getShipObjectByMachineName('pathfinder'), 10);
+        $this->sendMissionToPosition16($units, new Resources(0, 0, 0, 0), true, PlanetType::DebrisField);
 
         // Get the mission to calculate travel time
-        $fleetMissionService = resolve(\OGame\Services\FleetMissionService::class, ['player' => $planet->getPlayer()]);
+        $fleetMissionService = resolve(FleetMissionService::class, ['player' => $planet->getPlayer()]);
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($fleetMission === null) {
+            $this->fail('Fleet mission not found.');
+        }
         $fleetMissionDuration = $fleetMission->time_arrival - $fleetMission->time_departure;
 
         // Process the mission (arrival)
@@ -81,6 +89,9 @@ class PathfinderExpeditionDebrisHarvestTest extends FleetDispatchTestCase
 
         // Process return mission
         $returnMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($returnMission === null) {
+            $this->fail('Return mission not found.');
+        }
         $returnDuration = $returnMission->time_arrival - $returnMission->time_departure;
         $this->travel($returnDuration + 1)->seconds();
         $this->get('/overview'); // Trigger return mission processing
@@ -114,7 +125,7 @@ class PathfinderExpeditionDebrisHarvestTest extends FleetDispatchTestCase
 
         $debrisFieldService = resolve(DebrisFieldService::class);
         $debrisFieldService->loadOrCreateForCoordinates($debrisCoordinate);
-        $debrisFieldService->appendResources(new \OGame\Models\Resources(100000, 50000, 25000, 0));
+        $debrisFieldService->appendResources(new Resources(100000, 50000, 25000, 0));
         $debrisFieldService->save();
 
         // Try to send harvest mission with Recyclers to position 16
@@ -123,7 +134,7 @@ class PathfinderExpeditionDebrisHarvestTest extends FleetDispatchTestCase
             'galaxy' => $debrisCoordinate->galaxy,
             'system' => $debrisCoordinate->system,
             'position' => $debrisCoordinate->position,
-            'type' => \OGame\Models\Enums\PlanetType::DebrisField->value,
+            'type' => PlanetType::DebrisField->value,
             'mission' => 8, // Harvest mission
             'recycler' => 10,
         ]);
@@ -146,7 +157,7 @@ class PathfinderExpeditionDebrisHarvestTest extends FleetDispatchTestCase
         $planet->addUnit('pathfinder', 10);
 
         // Add deuterium for fleet travel
-        $this->planetAddResources(new \OGame\Models\Resources(0, 0, 10000, 0));
+        $this->planetAddResources(new Resources(0, 0, 10000, 0));
 
         // Create debris field at a regular position (not 16)
         $debrisCoordinate = new Coordinate(
@@ -157,7 +168,7 @@ class PathfinderExpeditionDebrisHarvestTest extends FleetDispatchTestCase
 
         $debrisFieldService = resolve(DebrisFieldService::class);
         $debrisFieldService->loadOrCreateForCoordinates($debrisCoordinate);
-        $debrisFieldService->appendResources(new \OGame\Models\Resources(100000, 50000, 25000, 0));
+        $debrisFieldService->appendResources(new Resources(100000, 50000, 25000, 0));
         $debrisFieldService->save();
 
         // Get initial debris amount
@@ -171,7 +182,7 @@ class PathfinderExpeditionDebrisHarvestTest extends FleetDispatchTestCase
             'galaxy' => $debrisCoordinate->galaxy,
             'system' => $debrisCoordinate->system,
             'position' => $debrisCoordinate->position,
-            'type' => \OGame\Models\Enums\PlanetType::DebrisField->value,
+            'type' => PlanetType::DebrisField->value,
             'mission' => 8, // Harvest mission
             'pathfinder' => 10,
         ]);

--- a/tests/Feature/FleetDispatch/ReaperDebrisCollectionTest.php
+++ b/tests/Feature/FleetDispatch/ReaperDebrisCollectionTest.php
@@ -4,6 +4,14 @@ namespace Tests\Feature\FleetDispatch;
 
 use Illuminate\Contracts\Container\BindingResolutionException;
 use OGame\Enums\CharacterClass;
+use OGame\GameObjects\Models\Units\UnitCollection;
+use OGame\Models\BattleReport;
+use OGame\Models\Message;
+use OGame\Models\Resources;
+use OGame\Services\DebrisFieldService;
+use OGame\Services\FleetMissionService;
+use OGame\Services\ObjectService;
+use OGame\Services\SettingsService;
 use Tests\FleetDispatchTestCase;
 
 /**
@@ -23,11 +31,11 @@ class ReaperDebrisCollectionTest extends FleetDispatchTestCase
     {
         // Clear any existing battle reports to ensure test isolation
         // First delete messages that reference battle reports (foreign key constraint)
-        \OGame\Models\Message::where('battle_report_id', '!=', null)->delete();
-        \OGame\Models\BattleReport::query()->delete();
+        Message::where('battle_report_id', '!=', null)->delete();
+        BattleReport::query()->delete();
 
         // Enable debris field creation (30% of destroyed ships become debris)
-        $settingsService = resolve(\OGame\Services\SettingsService::class);
+        $settingsService = resolve(SettingsService::class);
         $settingsService->set('debris_field_from_ships', 30);
         $settingsService->set('debris_field_from_defense', 0); // Defenses don't create debris by default
     }
@@ -40,15 +48,19 @@ class ReaperDebrisCollectionTest extends FleetDispatchTestCase
     public function testReaperCollectsDebris(): void
     {
         // Clear all battle reports to ensure test isolation
-        \OGame\Models\Message::where('battle_report_id', '!=', null)->delete();
-        \OGame\Models\BattleReport::query()->delete();
+        Message::where('battle_report_id', '!=', null)->delete();
+        BattleReport::query()->delete();
 
         // Set up: attacker with any class (Reaper collection works for all classes)
         $attacker = $this->planetService;
         $attackerPlayer = $attacker->getPlayer();
 
+        if ($attackerPlayer === null) {
+            $this->fail('Attacker player is null.');
+        }
+
         // Set character class to General (required for Reaper ships)
-        $attackerPlayer->getUser()->character_class = \OGame\Enums\CharacterClass::GENERAL->value;
+        $attackerPlayer->getUser()->character_class = CharacterClass::GENERAL->value;
         $attackerPlayer->getUser()->save();
 
         // Clear any existing units from previous tests to ensure test isolation
@@ -64,12 +76,12 @@ class ReaperDebrisCollectionTest extends FleetDispatchTestCase
         $this->assertEquals(10, $attacker->getObjectAmount('reaper'), 'Reapers should be added to planet');
 
         // Add deuterium for fleet travel
-        $this->planetAddResources(new \OGame\Models\Resources(0, 0, 50000, 0));
+        $this->planetAddResources(new Resources(0, 0, 50000, 0));
 
         // Launch attack mission to foreign planet
-        $units = new \OGame\GameObjects\Models\Units\UnitCollection();
-        $units->addUnit(\OGame\Services\ObjectService::getShipObjectByMachineName('reaper'), 10);
-        $foreignPlanet = $this->sendMissionToOtherPlayerPlanet($units, new \OGame\Models\Resources(0, 0, 0, 0));
+        $units = new UnitCollection();
+        $units->addUnit(ObjectService::getShipObjectByMachineName('reaper'), 10);
+        $foreignPlanet = $this->sendMissionToOtherPlayerPlanet($units, new Resources(0, 0, 0, 0));
 
         // Clear foreign planet units from previous tests to ensure isolation
         $foreignPlanet->removeUnits($foreignPlanet->getShipUnits(), true);
@@ -82,15 +94,18 @@ class ReaperDebrisCollectionTest extends FleetDispatchTestCase
         $foreignPlanet->addUnit('cruiser', 5);
 
         // Get debris field before processing mission
-        $debrisFieldService = resolve(\OGame\Services\DebrisFieldService::class);
+        $debrisFieldService = resolve(DebrisFieldService::class);
         $debrisFieldBefore = 0;
         if ($debrisFieldService->loadForCoordinates($foreignPlanet->getPlanetCoordinates())) {
             $debrisFieldBefore = $debrisFieldService->getResources()->sum();
         }
 
         // Get the mission to calculate travel time
-        $fleetMissionService = resolve(\OGame\Services\FleetMissionService::class, ['player' => $attacker->getPlayer()]);
+        $fleetMissionService = resolve(FleetMissionService::class, ['player' => $attacker->getPlayer()]);
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($fleetMission === null) {
+            $this->fail('No active fleet mission found.');
+        }
         $fleetMissionDuration = $fleetMission->time_arrival - $fleetMission->time_departure;
 
         // Process arrival (battle happens)
@@ -100,7 +115,7 @@ class ReaperDebrisCollectionTest extends FleetDispatchTestCase
         // Get battle report to check debris amounts
         // Filter by target planet coordinates to ensure we get the correct report
         $coords = $foreignPlanet->getPlanetCoordinates();
-        $battleReport = \OGame\Models\BattleReport::query()
+        $battleReport = BattleReport::query()
             ->where('planet_galaxy', $coords->galaxy)
             ->where('planet_system', $coords->system)
             ->where('planet_position', $coords->position)
@@ -108,8 +123,8 @@ class ReaperDebrisCollectionTest extends FleetDispatchTestCase
             ->first();
         $this->assertNotNull($battleReport, 'Battle report should be created');
 
-        $totalDebris = (int)$battleReport->debris['metal'] + (int)$battleReport->debris['crystal'] + (int)$battleReport->debris['deuterium'];
-        $collectedDebris = (int)$battleReport->debris['collected_metal'] + (int)$battleReport->debris['collected_crystal'] + (int)$battleReport->debris['collected_deuterium'];
+        $totalDebris = (int)($battleReport->debris['metal'] ?? 0) + (int)($battleReport->debris['crystal'] ?? 0) + (int)($battleReport->debris['deuterium'] ?? 0);
+        $collectedDebris = (int)($battleReport->debris['collected_metal'] ?? 0) + (int)($battleReport->debris['collected_crystal'] ?? 0) + (int)($battleReport->debris['collected_deuterium'] ?? 0);
 
         // Check if any debris was created from battle
         $this->assertGreaterThan(0, $totalDebris, 'Battle should create debris from destroyed units');
@@ -123,7 +138,7 @@ class ReaperDebrisCollectionTest extends FleetDispatchTestCase
         $this->assertLessThanOrEqual($expectedCollected * 1.3, $collectedDebris, 'Reapers should not collect more than expected');
 
         // Check debris field: should contain remaining debris (100% - collected%)
-        $debrisFieldService = resolve(\OGame\Services\DebrisFieldService::class);
+        $debrisFieldService = resolve(DebrisFieldService::class);
         if ($debrisFieldService->loadForCoordinates($foreignPlanet->getPlanetCoordinates())) {
             $debrisFieldAfter = $debrisFieldService->getResources()->sum();
             $debrisInField = $debrisFieldAfter - $debrisFieldBefore;
@@ -152,12 +167,16 @@ class ReaperDebrisCollectionTest extends FleetDispatchTestCase
     public function testReaperCollectsDebrisWithNonGeneralClass(): void
     {
         // Clear all battle reports to ensure test isolation
-        \OGame\Models\Message::where('battle_report_id', '!=', null)->delete();
-        \OGame\Models\BattleReport::query()->delete();
+        Message::where('battle_report_id', '!=', null)->delete();
+        BattleReport::query()->delete();
 
         // Set up: attacker is NOT General class (using Collector to prove it works for all classes)
         $attacker = $this->planetService;
         $attackerPlayer = $attacker->getPlayer();
+
+        if ($attackerPlayer === null) {
+            $this->fail('Attacker player is null.');
+        }
 
         // Set character class to Collector (not General - to prove Reapers work for all classes)
         $attackerPlayer->getUser()->character_class = CharacterClass::COLLECTOR->value;
@@ -175,12 +194,12 @@ class ReaperDebrisCollectionTest extends FleetDispatchTestCase
         $this->assertEquals(10, $attacker->getObjectAmount('reaper'), 'Reapers should be added to planet');
 
         // Add deuterium for fleet travel
-        $this->planetAddResources(new \OGame\Models\Resources(0, 0, 50000, 0));
+        $this->planetAddResources(new Resources(0, 0, 50000, 0));
 
         // Launch attack mission to foreign planet
-        $units = new \OGame\GameObjects\Models\Units\UnitCollection();
-        $units->addUnit(\OGame\Services\ObjectService::getShipObjectByMachineName('reaper'), 10);
-        $foreignPlanet = $this->sendMissionToOtherPlayerPlanet($units, new \OGame\Models\Resources(0, 0, 0, 0));
+        $units = new UnitCollection();
+        $units->addUnit(ObjectService::getShipObjectByMachineName('reaper'), 10);
+        $foreignPlanet = $this->sendMissionToOtherPlayerPlanet($units, new Resources(0, 0, 0, 0));
 
         // Clear foreign planet units from previous tests to ensure isolation
         $foreignPlanet->removeUnits($foreignPlanet->getShipUnits(), true);
@@ -193,8 +212,11 @@ class ReaperDebrisCollectionTest extends FleetDispatchTestCase
         $foreignPlanet->addUnit('cruiser', 5);
 
         // Get the mission to calculate travel time
-        $fleetMissionService = resolve(\OGame\Services\FleetMissionService::class, ['player' => $attacker->getPlayer()]);
+        $fleetMissionService = resolve(FleetMissionService::class, ['player' => $attacker->getPlayer()]);
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($fleetMission === null) {
+            $this->fail('No active fleet mission found.');
+        }
         $fleetMissionDuration = $fleetMission->time_arrival - $fleetMission->time_departure;
 
         // Process arrival (battle happens)
@@ -204,7 +226,7 @@ class ReaperDebrisCollectionTest extends FleetDispatchTestCase
         // Get battle report to check debris amounts
         // Filter by target planet coordinates to ensure we get the correct report
         $coords = $foreignPlanet->getPlanetCoordinates();
-        $battleReport = \OGame\Models\BattleReport::query()
+        $battleReport = BattleReport::query()
             ->where('planet_galaxy', $coords->galaxy)
             ->where('planet_system', $coords->system)
             ->where('planet_position', $coords->position)
@@ -212,8 +234,8 @@ class ReaperDebrisCollectionTest extends FleetDispatchTestCase
             ->first();
         $this->assertNotNull($battleReport, 'Battle report should be created');
 
-        $totalDebris = (int)$battleReport->debris['metal'] + (int)$battleReport->debris['crystal'] + (int)$battleReport->debris['deuterium'];
-        $collectedDebris = (int)$battleReport->debris['collected_metal'] + (int)$battleReport->debris['collected_crystal'] + (int)$battleReport->debris['collected_deuterium'];
+        $totalDebris = (int)($battleReport->debris['metal'] ?? 0) + (int)($battleReport->debris['crystal'] ?? 0) + (int)($battleReport->debris['deuterium'] ?? 0);
+        $collectedDebris = (int)($battleReport->debris['collected_metal'] ?? 0) + (int)($battleReport->debris['collected_crystal'] ?? 0) + (int)($battleReport->debris['collected_deuterium'] ?? 0);
 
         // Check if any debris was created from battle
         $this->assertGreaterThan(0, $totalDebris, 'Battle should create debris from destroyed units');
@@ -235,8 +257,8 @@ class ReaperDebrisCollectionTest extends FleetDispatchTestCase
     public function testNoDebrisCollectionWithoutReapers(): void
     {
         // Clear all battle reports to ensure test isolation
-        \OGame\Models\Message::where('battle_report_id', '!=', null)->delete();
-        \OGame\Models\BattleReport::query()->delete();
+        Message::where('battle_report_id', '!=', null)->delete();
+        BattleReport::query()->delete();
 
         // Set up: attacker has no Reapers (only other ships)
         $attacker = $this->planetService;
@@ -251,12 +273,12 @@ class ReaperDebrisCollectionTest extends FleetDispatchTestCase
         $attacker->save();
 
         // Add deuterium for fleet travel
-        $this->planetAddResources(new \OGame\Models\Resources(0, 0, 50000, 0));
+        $this->planetAddResources(new Resources(0, 0, 50000, 0));
 
         // Launch attack mission to foreign planet
-        $units = new \OGame\GameObjects\Models\Units\UnitCollection();
-        $units->addUnit(\OGame\Services\ObjectService::getShipObjectByMachineName('light_fighter'), 200);
-        $foreignPlanet = $this->sendMissionToOtherPlayerPlanet($units, new \OGame\Models\Resources(0, 0, 0, 0));
+        $units = new UnitCollection();
+        $units->addUnit(ObjectService::getShipObjectByMachineName('light_fighter'), 200);
+        $foreignPlanet = $this->sendMissionToOtherPlayerPlanet($units, new Resources(0, 0, 0, 0));
 
         // Clear foreign planet units from previous tests to ensure isolation
         $foreignPlanet->removeUnits($foreignPlanet->getShipUnits(), true);
@@ -269,8 +291,11 @@ class ReaperDebrisCollectionTest extends FleetDispatchTestCase
         $foreignPlanet->save(); // Save defender units
 
         // Get the mission to calculate travel time
-        $fleetMissionService = resolve(\OGame\Services\FleetMissionService::class, ['player' => $attacker->getPlayer()]);
+        $fleetMissionService = resolve(FleetMissionService::class, ['player' => $attacker->getPlayer()]);
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($fleetMission === null) {
+            $this->fail('No active fleet mission found.');
+        }
         $fleetMissionDuration = $fleetMission->time_arrival - $fleetMission->time_departure;
 
         // Process arrival (battle happens)
@@ -278,7 +303,7 @@ class ReaperDebrisCollectionTest extends FleetDispatchTestCase
         $this->get('/overview'); // Trigger mission processing
 
         // Get battle report to check debris amounts
-        $battleReport = \OGame\Models\BattleReport::latest()->first();
+        $battleReport = BattleReport::latest()->first();
         $this->assertNotNull($battleReport, 'Battle report should be created');
 
         // Check attacker collected debris (should be 0 since attacker has no Reapers)

--- a/tests/Feature/FleetMovementTest.php
+++ b/tests/Feature/FleetMovementTest.php
@@ -68,7 +68,11 @@ class FleetMovementTest extends FleetDispatchTestCase
 
         // Should show the fleet details
         $response->assertSee('Transport');
-        $response->assertSee($this->secondPlanetService->getPlanetName());
+        $secondPlanet = $this->secondPlanetService;
+        if ($secondPlanet === null) {
+            $this->fail('Second planet not found.');
+        }
+        $response->assertSee($secondPlanet->getPlanetName());
     }
 
     /**
@@ -186,6 +190,9 @@ class FleetMovementTest extends FleetDispatchTestCase
         // Get fleet mission ID
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
         $fleetMission = $fleetMissionService->getActiveFleetMissionsForCurrentPlayer()->first();
+        if ($fleetMission === null) {
+            $this->fail('Fleet mission not found.');
+        }
 
         // Advance time by 1 minute
         $this->travel(1)->minutes();
@@ -290,7 +297,11 @@ class FleetMovementTest extends FleetDispatchTestCase
         $response->assertStatus(200);
 
         // Should show both planets as destinations
-        $response->assertSee($this->secondPlanetService->getPlanetName());
+        $secondPlanet = $this->secondPlanetService;
+        if ($secondPlanet === null) {
+            $this->fail('Second planet not found.');
+        }
+        $response->assertSee($secondPlanet->getPlanetName());
         $response->assertSee($this->moonService->getPlanetName());
     }
 

--- a/tests/Feature/FleetSpeedGeneralClassTest.php
+++ b/tests/Feature/FleetSpeedGeneralClassTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use OGame\Enums\CharacterClass;
 use Tests\AccountTestCase;
 
 class FleetSpeedGeneralClassTest extends AccountTestCase
@@ -12,8 +13,12 @@ class FleetSpeedGeneralClassTest extends AccountTestCase
     public function testGeneralClassCanUse5PercentFleetSpeed(): void
     {
         // Set user character class to General
-        $user = $this->planetService->getPlayer()->getUser();
-        $user->character_class = \OGame\Enums\CharacterClass::GENERAL->value;
+        $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('Player not found.');
+        }
+        $user = $player->getUser();
+        $user->character_class = CharacterClass::GENERAL->value;
         $user->save();
 
         // Add a ship to the planet
@@ -49,7 +54,11 @@ class FleetSpeedGeneralClassTest extends AccountTestCase
     public function testNonGeneralClassCannotUse5PercentFleetSpeed(): void
     {
         // Ensure user is not General class (default is no class)
-        $user = $this->planetService->getPlayer()->getUser();
+        $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('Player not found.');
+        }
+        $user = $player->getUser();
         $user->character_class = null;
         $user->save();
 
@@ -86,8 +95,12 @@ class FleetSpeedGeneralClassTest extends AccountTestCase
     public function testCollectorClassCannotUse5PercentFleetSpeed(): void
     {
         // Set user character class to Collector
-        $user = $this->planetService->getPlayer()->getUser();
-        $user->character_class = \OGame\Enums\CharacterClass::COLLECTOR->value;
+        $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('Player not found.');
+        }
+        $user = $player->getUser();
+        $user->character_class = CharacterClass::COLLECTOR->value;
         $user->save();
 
         // Add a ship to the planet
@@ -123,8 +136,12 @@ class FleetSpeedGeneralClassTest extends AccountTestCase
     public function testDiscovererClassCannotUse5PercentFleetSpeed(): void
     {
         // Set user character class to Discoverer
-        $user = $this->planetService->getPlayer()->getUser();
-        $user->character_class = \OGame\Enums\CharacterClass::DISCOVERER->value;
+        $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('Player not found.');
+        }
+        $user = $player->getUser();
+        $user->character_class = CharacterClass::DISCOVERER->value;
         $user->save();
 
         // Add a ship to the planet
@@ -160,8 +177,12 @@ class FleetSpeedGeneralClassTest extends AccountTestCase
     public function testGeneralClassCanUseNormalSpeedRanges(): void
     {
         // Set user character class to General
-        $user = $this->planetService->getPlayer()->getUser();
-        $user->character_class = \OGame\Enums\CharacterClass::GENERAL->value;
+        $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('Player not found.');
+        }
+        $user = $player->getUser();
+        $user->character_class = CharacterClass::GENERAL->value;
         $user->save();
 
         // Add a ship to the planet

--- a/tests/Feature/GlobalGameTest.php
+++ b/tests/Feature/GlobalGameTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Date;
 use Tests\AccountTestCase;
 
 class GlobalGameTest extends AccountTestCase
@@ -13,11 +13,15 @@ class GlobalGameTest extends AccountTestCase
     public function testPageLoadOnlyUpdatesCurrentPlanet(): void
     {
         // Check that the user has at least two planets.
-        $startPlanetCount = $this->planetService->getPlayer()->planets->planetCount();
+        $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('Player not found.');
+        }
+        $startPlanetCount = $player->planets->planetCount();
         $this->assertGreaterThanOrEqual(2, $startPlanetCount);
 
         // Set time to +1 hour, so we can verify that only the current planet will be updated with the new time.
-        $testTime = Carbon::now()->addHour();
+        $testTime = Date::now()->addHour();
         $this->travelTo($testTime);
 
         // Request overview page.
@@ -30,8 +34,12 @@ class GlobalGameTest extends AccountTestCase
             'time_last_update' => $testTime->getTimestamp(),
         ]);
 
+        $secondPlanet = $this->secondPlanetService;
+        if ($secondPlanet === null) {
+            $this->fail('Second planet not found.');
+        }
         $this->assertDatabaseMissing('planets', [
-            'id' => $this->secondPlanetService->getPlanetId(),
+            'id' => $secondPlanet->getPlanetId(),
             'time_last_update' => $testTime->getTimestamp(),
         ]);
     }

--- a/tests/Feature/HalvingIntegrationTest.php
+++ b/tests/Feature/HalvingIntegrationTest.php
@@ -2,11 +2,14 @@
 
 namespace Tests\Feature;
 
+use Illuminate\Support\Facades\Date;
 use OGame\Models\BuildingQueue;
 use OGame\Models\DarkMatterTransaction;
 use OGame\Models\ResearchQueue;
+use OGame\Models\Resources;
 use OGame\Models\UnitQueue;
 use OGame\Models\User;
+use OGame\Services\HalvingService;
 use Tests\AccountTestCase;
 
 /**
@@ -15,11 +18,24 @@ use Tests\AccountTestCase;
 class HalvingIntegrationTest extends AccountTestCase
 {
     /**
+     * Get the current user model, failing the test if it cannot be found.
+     */
+    private function findCurrentUser(): User
+    {
+        $user = User::find($this->currentUserId);
+        if ($user === null) {
+            $this->fail('Current user not found.');
+        }
+
+        return $user;
+    }
+
+    /**
      * Test building halving end-to-end workflow.
      */
     public function testBuildingHalvingEndToEnd(): void
     {
-        $user = User::find($this->currentUserId);
+        $user = $this->findCurrentUser();
         $user->dark_matter = 100000;
         $user->save();
 
@@ -67,12 +83,12 @@ class HalvingIntegrationTest extends AccountTestCase
      */
     public function testResearchHalvingEndToEnd(): void
     {
-        $user = User::find($this->currentUserId);
+        $user = $this->findCurrentUser();
         $user->dark_matter = 100000;
         $user->save();
 
         $this->planetSetObjectLevel('research_lab', 1);
-        $this->planetAddResources(new \OGame\Models\Resources(10000, 10000, 10000, 0));
+        $this->planetAddResources(new Resources(10000, 10000, 10000, 0));
         $this->addResearchBuildRequest('energy_technology');
 
         $queueItem = ResearchQueue::query()
@@ -102,6 +118,9 @@ class HalvingIntegrationTest extends AccountTestCase
         $this->assertLessThan($initialBalance, $user->dark_matter, 'Dark Matter should be deducted');
 
         $queueItem = ResearchQueue::find($queueItem->id);
+        if ($queueItem === null) {
+            $this->fail('Queue item should exist');
+        }
         $this->assertLessThan($initialTimeEnd, $queueItem->time_end, 'time_end should be reduced');
     }
 
@@ -114,14 +133,14 @@ class HalvingIntegrationTest extends AccountTestCase
      */
     public function testUnitHalvingEndToEnd(): void
     {
-        $user = User::find($this->currentUserId);
+        $user = $this->findCurrentUser();
         $user->dark_matter = 100000;
         $user->save();
 
         $this->planetSetObjectLevel('robot_factory', 2);
         $this->planetSetObjectLevel('shipyard', 2);
         $this->playerSetResearchLevel('combustion_drive', 1);
-        $this->planetAddResources(new \OGame\Models\Resources(50000, 50000, 50000, 0));
+        $this->planetAddResources(new Resources(50000, 50000, 50000, 0));
         $this->addShipyardBuildRequest('light_fighter', 10);
 
         $queueItem = UnitQueue::where('planet_id', $this->planetService->getPlanetId())
@@ -180,7 +199,7 @@ class HalvingIntegrationTest extends AccountTestCase
      */
     public function testDoubleHalvingCompletesTask(): void
     {
-        $user = User::find($this->currentUserId);
+        $user = $this->findCurrentUser();
         $user->dark_matter = 200000;
         $user->save();
 
@@ -230,7 +249,7 @@ class HalvingIntegrationTest extends AccountTestCase
      */
     public function testHalvingWithInsufficientDarkMatter(): void
     {
-        $user = User::find($this->currentUserId);
+        $user = $this->findCurrentUser();
         $user->dark_matter = 100;
         $user->save();
 
@@ -260,7 +279,7 @@ class HalvingIntegrationTest extends AccountTestCase
      */
     public function testHalvingWithInvalidQueueItemId(): void
     {
-        $user = User::find($this->currentUserId);
+        $user = $this->findCurrentUser();
         $user->dark_matter = 100000;
         $user->save();
 
@@ -281,7 +300,7 @@ class HalvingIntegrationTest extends AccountTestCase
      */
     public function testHalvingWithVeryShortRemainingTime(): void
     {
-        $user = User::find($this->currentUserId);
+        $user = $this->findCurrentUser();
         $user->dark_matter = 100000;
         $user->save();
 
@@ -294,7 +313,7 @@ class HalvingIntegrationTest extends AccountTestCase
 
         $this->assertNotNull($queueItem, 'Queue item should exist');
 
-        $queueItem->time_end = (int)\Carbon\Carbon::now()->timestamp + 2;
+        $queueItem->time_end = (int)Date::now()->timestamp + 2;
         $queueItem->save();
 
         $response = $this->post('/ajax/facilities/halve-building', [
@@ -323,10 +342,10 @@ class HalvingIntegrationTest extends AccountTestCase
 
         $this->assertNotNull($queueItem, 'Queue item should exist');
 
-        $halvingService = app(\OGame\Services\HalvingService::class);
+        $halvingService = app(HalvingService::class);
         $cost = $halvingService->calculateHalvingCost($queueItem->time_duration, 'building');
 
-        $user = User::find($this->currentUserId);
+        $user = $this->findCurrentUser();
         $user->dark_matter = $cost;
         $user->save();
 
@@ -347,7 +366,7 @@ class HalvingIntegrationTest extends AccountTestCase
      */
     public function testHalvingInvalidQueueItems(): void
     {
-        $user = User::find($this->currentUserId);
+        $user = $this->findCurrentUser();
         $user->dark_matter = 100000;
         $user->save();
 
@@ -371,6 +390,10 @@ class HalvingIntegrationTest extends AccountTestCase
             ->where('building', 1)
             ->where('processed', 0)
             ->first();
+
+        if ($queueItem === null) {
+            $this->fail('Queue item should exist');
+        }
 
         $queueItem->processed = 1;
         $queueItem->save();

--- a/tests/Feature/JumpGateTest.php
+++ b/tests/Feature/JumpGateTest.php
@@ -38,8 +38,10 @@ class JumpGateTest extends MoonTestCase
         $this->moonService->setObjectLevel($jumpGateObject->id, 1, true);
 
         // Create second moon for the second planet
+        $secondPlanet = $this->secondPlanetService;
+        $this->assertNotNull($secondPlanet, 'Second planet not found');
         $planetServiceFactory = resolve(PlanetServiceFactory::class);
-        $this->secondMoonService = $planetServiceFactory->createMoonForPlanet($this->secondPlanetService, 100000, 20);
+        $this->secondMoonService = $planetServiceFactory->createMoonForPlanet($secondPlanet, 100000, 20);
 
         // Set up Jump Gate on second moon
         $this->secondMoonService->setObjectLevel($jumpGateObject->id, 1, true);
@@ -188,6 +190,7 @@ class JumpGateTest extends MoonTestCase
     public function testEligibleTargetsExcludesCurrentMoon(): void
     {
         $player = $this->moonService->getPlayer();
+        $this->assertNotNull($player, 'Player not found');
         $eligibleTargets = $this->jumpGateService->getEligibleTargets($player, $this->moonService);
 
         // Should not include the current moon
@@ -205,6 +208,7 @@ class JumpGateTest extends MoonTestCase
         $this->secondMoonService->setJumpGateCooldown((int) Date::now()->addHour()->timestamp);
 
         $player = $this->moonService->getPlayer();
+        $this->assertNotNull($player, 'Player not found');
         $eligibleTargets = $this->jumpGateService->getEligibleTargets($player, $this->moonService);
 
         // Second moon should not be in eligible targets
@@ -223,6 +227,7 @@ class JumpGateTest extends MoonTestCase
         $this->secondMoonService->setObjectLevel($jumpGateObject->id, 0, true);
 
         $player = $this->moonService->getPlayer();
+        $this->assertNotNull($player, 'Player not found');
         $eligibleTargets = $this->jumpGateService->getEligibleTargets($player, $this->moonService);
 
         // Second moon should not be in eligible targets
@@ -241,10 +246,12 @@ class JumpGateTest extends MoonTestCase
 
         // Create a foreign player's attack fleet that has arrived but not processed
         $foreignPlanet = $this->getNearbyForeignPlanet();
+        $foreignPlayer = $foreignPlanet->getPlayer();
+        $this->assertNotNull($foreignPlayer, 'Foreign player not found');
 
         // Create fleet mission directly in database
         $fleetMission = new FleetMission();
-        $fleetMission->user_id = $foreignPlanet->getPlayer()->getId();
+        $fleetMission->user_id = $foreignPlayer->getId();
         $fleetMission->planet_id_from = $foreignPlanet->getPlanetId();
         $fleetMission->planet_id_to = $this->moonService->getPlanetId();
         $fleetMission->mission_type = 1; // Attack
@@ -266,9 +273,11 @@ class JumpGateTest extends MoonTestCase
     {
         // Create a foreign player's attack fleet that has NOT arrived yet
         $foreignPlanet = $this->getNearbyForeignPlanet();
+        $foreignPlayer = $foreignPlanet->getPlayer();
+        $this->assertNotNull($foreignPlayer, 'Foreign player not found');
 
         $fleetMission = new FleetMission();
-        $fleetMission->user_id = $foreignPlanet->getPlayer()->getId();
+        $fleetMission->user_id = $foreignPlayer->getId();
         $fleetMission->planet_id_from = $foreignPlanet->getPlanetId();
         $fleetMission->planet_id_to = $this->moonService->getPlanetId();
         $fleetMission->mission_type = 1; // Attack
@@ -289,9 +298,13 @@ class JumpGateTest extends MoonTestCase
     public function testOwnFleetDoesNotTriggerRaceCondition(): void
     {
         // Create own player's return fleet
+        $ownPlayer = $this->moonService->getPlayer();
+        $this->assertNotNull($ownPlayer, 'Player not found');
+        $secondPlanet = $this->secondPlanetService;
+        $this->assertNotNull($secondPlanet, 'Second planet not found');
         $fleetMission = new FleetMission();
-        $fleetMission->user_id = $this->moonService->getPlayer()->getId(); // Own player
-        $fleetMission->planet_id_from = $this->secondPlanetService->getPlanetId();
+        $fleetMission->user_id = $ownPlayer->getId(); // Own player
+        $fleetMission->planet_id_from = $secondPlanet->getPlanetId();
         $fleetMission->planet_id_to = $this->moonService->getPlanetId();
         $fleetMission->mission_type = 3; // Transport
         $fleetMission->time_departure = (int) Date::now()->subMinutes(10)->timestamp;
@@ -311,9 +324,11 @@ class JumpGateTest extends MoonTestCase
     public function testProcessedFleetDoesNotTriggerRaceCondition(): void
     {
         $foreignPlanet = $this->getNearbyForeignPlanet();
+        $foreignPlayer = $foreignPlanet->getPlayer();
+        $this->assertNotNull($foreignPlayer, 'Foreign player not found');
 
         $fleetMission = new FleetMission();
-        $fleetMission->user_id = $foreignPlanet->getPlayer()->getId();
+        $fleetMission->user_id = $foreignPlayer->getId();
         $fleetMission->planet_id_from = $foreignPlanet->getPlanetId();
         $fleetMission->planet_id_to = $this->moonService->getPlanetId();
         $fleetMission->mission_type = 1; // Attack
@@ -413,9 +428,11 @@ class JumpGateTest extends MoonTestCase
     public function testDefaultTargetSetAndGet(): void
     {
         // Initially no default target
+        $moonPlayer = $this->moonService->getPlayer();
+        $this->assertNotNull($moonPlayer, 'Player not found');
         $defaultTarget = $this->jumpGateService->getDefaultTarget(
             $this->moonService,
-            $this->moonService->getPlayer()
+            $moonPlayer
         );
         $this->assertNull($defaultTarget);
 
@@ -428,6 +445,7 @@ class JumpGateTest extends MoonTestCase
         // Reload moon and player to get fresh data
         $this->moonService->reloadPlanet();
         $player = $this->moonService->getPlayer();
+        $this->assertNotNull($player, 'Player not found');
         $player->load($player->getId());
 
         $defaultTarget = $this->jumpGateService->getDefaultTarget(

--- a/tests/Feature/MerchantTest.php
+++ b/tests/Feature/MerchantTest.php
@@ -6,6 +6,7 @@ use OGame\GameMessages\ExpeditionMerchantFound;
 use OGame\Models\Resources;
 use OGame\Services\MerchantService;
 use OGame\Services\ObjectService;
+use OGame\Services\PlayerService;
 use Tests\AccountTestCase;
 
 /**
@@ -14,6 +15,19 @@ use Tests\AccountTestCase;
  */
 class MerchantTest extends AccountTestCase
 {
+    /**
+     * Get the current player, failing the test if it is null.
+     */
+    private function player(): PlayerService
+    {
+        $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('Player is null.');
+        }
+
+        return $player;
+    }
+
     /**
      * Test that merchant index page loads successfully.
      */
@@ -58,7 +72,7 @@ class MerchantTest extends AccountTestCase
     public function testCallMerchantWithSufficientDarkMatter(): void
     {
         // Give player dark matter
-        $player = $this->planetService->getPlayer();
+        $player = $this->player();
         $player->getUser()->dark_matter = 10000;
         $player->save();
 
@@ -88,8 +102,8 @@ class MerchantTest extends AccountTestCase
     public function testCallMerchantWithoutSufficientDarkMatter(): void
     {
         // Set dark matter to less than cost
-        $this->planetService->getPlayer()->getUser()->dark_matter = 1000;
-        $this->planetService->getPlayer()->save();
+        $this->player()->getUser()->dark_matter = 1000;
+        $this->player()->save();
 
         $response = $this->post('/merchant/call', [
             'type' => 'crystal',
@@ -100,8 +114,8 @@ class MerchantTest extends AccountTestCase
         $response->assertJson(['success' => false]);
 
         // Verify dark matter was NOT deducted
-        $this->planetService->getPlayer()->getUser()->refresh();
-        $this->assertEquals(1000, $this->planetService->getPlayer()->getUser()->dark_matter);
+        $this->player()->getUser()->refresh();
+        $this->assertEquals(1000, $this->player()->getUser()->dark_matter);
     }
 
     /**
@@ -109,7 +123,7 @@ class MerchantTest extends AccountTestCase
      */
     public function testCallMerchantWithInvalidType(): void
     {
-        $player = $this->planetService->getPlayer();
+        $player = $this->player();
         $player->getUser()->dark_matter = 10000;
         $player->save();
 
@@ -129,8 +143,8 @@ class MerchantTest extends AccountTestCase
     public function testExecuteTradeWithSufficientResources(): void
     {
         // Call merchant first
-        $this->planetService->getPlayer()->getUser()->dark_matter = 10000;
-        $this->planetService->getPlayer()->save();
+        $this->player()->getUser()->dark_matter = 10000;
+        $this->player()->save();
 
         $callResponse = $this->post('/merchant/call', [
             'type' => 'metal',
@@ -169,8 +183,8 @@ class MerchantTest extends AccountTestCase
     public function testExecuteTradeWithoutSufficientResources(): void
     {
         // Call merchant first
-        $this->planetService->getPlayer()->getUser()->dark_matter = 10000;
-        $this->planetService->getPlayer()->save();
+        $this->player()->getUser()->dark_matter = 10000;
+        $this->player()->save();
 
         // Give planet minimal resources
         $this->planetService->addResources(new Resources(0, 0, 100, 0));
@@ -195,8 +209,8 @@ class MerchantTest extends AccountTestCase
     public function testTradeRespectsStorageCapacity(): void
     {
         // Call merchant first
-        $this->planetService->getPlayer()->getUser()->dark_matter = 10000;
-        $this->planetService->getPlayer()->save();
+        $this->player()->getUser()->dark_matter = 10000;
+        $this->player()->save();
 
         $callResponse = $this->post('/merchant/call', [
             'type' => 'metal',
@@ -256,8 +270,8 @@ class MerchantTest extends AccountTestCase
     public function testTradeAutomaticallyCapsToStorageCapacity(): void
     {
         // Call merchant first
-        $this->planetService->getPlayer()->getUser()->dark_matter = 10000;
-        $this->planetService->getPlayer()->save();
+        $this->player()->getUser()->dark_matter = 10000;
+        $this->player()->save();
 
         $this->post('/merchant/call', [
             'type' => 'metal',
@@ -323,8 +337,8 @@ class MerchantTest extends AccountTestCase
     public function testTradeCappedWhenStorageNearlyFull(): void
     {
         // Call merchant first
-        $this->planetService->getPlayer()->getUser()->dark_matter = 10000;
-        $this->planetService->getPlayer()->save();
+        $this->player()->getUser()->dark_matter = 10000;
+        $this->player()->save();
 
         $callResponse = $this->post('/merchant/call', [
             'type' => 'metal',
@@ -380,8 +394,8 @@ class MerchantTest extends AccountTestCase
     public function testExecuteTradeWithMultipleReceiveResources(): void
     {
         // Call merchant first
-        $this->planetService->getPlayer()->getUser()->dark_matter = 10000;
-        $this->planetService->getPlayer()->save();
+        $this->player()->getUser()->dark_matter = 10000;
+        $this->player()->save();
 
         $callResponse = $this->post('/merchant/call', [
             'type' => 'metal',
@@ -432,8 +446,8 @@ class MerchantTest extends AccountTestCase
     public function testMultiResourceTradeScalesDownWhenBudgetExceeded(): void
     {
         // Call merchant first
-        $this->planetService->getPlayer()->getUser()->dark_matter = 10000;
-        $this->planetService->getPlayer()->save();
+        $this->player()->getUser()->dark_matter = 10000;
+        $this->player()->save();
 
         $this->post('/merchant/call', [
             'type' => 'metal',
@@ -471,8 +485,8 @@ class MerchantTest extends AccountTestCase
     public function testDismissMerchant(): void
     {
         // Call merchant first
-        $this->planetService->getPlayer()->getUser()->dark_matter = 10000;
-        $this->planetService->getPlayer()->save();
+        $this->player()->getUser()->dark_matter = 10000;
+        $this->player()->save();
 
         $this->post('/merchant/call', [
             'type' => 'metal',
@@ -604,8 +618,8 @@ class MerchantTest extends AccountTestCase
     public function testScrapMerchantBargain(): void
     {
         // Give player dark matter
-        $this->planetService->getPlayer()->getUser()->dark_matter = 10000;
-        $this->planetService->getPlayer()->save();
+        $this->player()->getUser()->dark_matter = 10000;
+        $this->player()->save();
 
         // Bargain (first bargain costs 2000 DM)
         $response = $this->post('/merchant/scrap/bargain', [
@@ -616,8 +630,8 @@ class MerchantTest extends AccountTestCase
         $response->assertJson(['success' => true]);
 
         // Verify dark matter was deducted (10000 - 2000 = 8000)
-        $this->planetService->getPlayer()->getUser()->refresh();
-        $this->assertEquals(8000, $this->planetService->getPlayer()->getUser()->dark_matter);
+        $this->player()->getUser()->refresh();
+        $this->assertEquals(8000, $this->player()->getUser()->dark_matter);
 
         // Verify offer increased
         $data = $response->json();
@@ -631,8 +645,8 @@ class MerchantTest extends AccountTestCase
     public function testScrapMerchantBargainWithoutSufficientDarkMatter(): void
     {
         // Give player insufficient dark matter
-        $this->planetService->getPlayer()->getUser()->dark_matter = 1000;
-        $this->planetService->getPlayer()->save();
+        $this->player()->getUser()->dark_matter = 1000;
+        $this->player()->save();
 
         $response = $this->post('/merchant/scrap/bargain', [
             '_token' => csrf_token(),
@@ -648,8 +662,8 @@ class MerchantTest extends AccountTestCase
     public function testScrapMerchantBargainCostIncrease(): void
     {
         // Give player plenty of dark matter
-        $this->planetService->getPlayer()->getUser()->dark_matter = 50000;
-        $this->planetService->getPlayer()->save();
+        $this->player()->getUser()->dark_matter = 50000;
+        $this->player()->save();
 
         // First bargain - 2000 DM
         $response1 = $this->post('/merchant/scrap/bargain', ['_token' => csrf_token()]);
@@ -662,8 +676,8 @@ class MerchantTest extends AccountTestCase
         $this->assertEquals(6000, $response2->json()['newCost']); // Next cost is 6000
 
         // Verify total DM spent: 2000 + 4000 = 6000
-        $this->planetService->getPlayer()->getUser()->refresh();
-        $this->assertEquals(44000, $this->planetService->getPlayer()->getUser()->dark_matter);
+        $this->player()->getUser()->refresh();
+        $this->assertEquals(44000, $this->player()->getUser()->dark_matter);
     }
 
     /**
@@ -672,8 +686,8 @@ class MerchantTest extends AccountTestCase
     public function testScrapMerchantBargainCapsAt75Percent(): void
     {
         // Give player lots of dark matter
-        $this->planetService->getPlayer()->getUser()->dark_matter = 200000;
-        $this->planetService->getPlayer()->save();
+        $this->player()->getUser()->dark_matter = 200000;
+        $this->player()->save();
 
         // Bargain multiple times to reach cap
         $maxAttempts = 20;
@@ -840,7 +854,7 @@ class MerchantTest extends AccountTestCase
      */
     public function testAddExpeditionMerchantCallsResourceTrader(): void
     {
-        $player = $this->planetService->getPlayer();
+        $player = $this->player();
 
         // No active merchant initially
         $this->assertNull(cache()->get('active_merchant_' . $player->getId()));
@@ -865,7 +879,7 @@ class MerchantTest extends AccountTestCase
      */
     public function testExpeditionMerchantNeverCallsScrapMerchant(): void
     {
-        $player = $this->planetService->getPlayer();
+        $player = $this->player();
 
         // Call expedition merchant multiple times to verify it's always a resource trader
         for ($i = 0; $i < 10; $i++) {
@@ -908,7 +922,7 @@ class MerchantTest extends AccountTestCase
      */
     public function testExpeditionMerchantImprovesExistingMerchantRates(): void
     {
-        $player = $this->planetService->getPlayer();
+        $player = $this->player();
 
         // Call a merchant first
         $player->getUser()->dark_matter = 10000;
@@ -957,7 +971,7 @@ class MerchantTest extends AccountTestCase
      */
     public function testExpeditionMerchantWithNoActiveMerchantCallsNew(): void
     {
-        $player = $this->planetService->getPlayer();
+        $player = $this->player();
 
         // No active merchant
         $this->assertNull(cache()->get('active_merchant_' . $player->getId()));
@@ -984,7 +998,7 @@ class MerchantTest extends AccountTestCase
      */
     public function testCallingMerchantWithDarkMatterReplacesExisting(): void
     {
-        $player = $this->planetService->getPlayer();
+        $player = $this->player();
         $player->getUser()->dark_matter = 20000;
         $player->save();
 
@@ -1016,8 +1030,8 @@ class MerchantTest extends AccountTestCase
     public function testResourceMarketHandlesCommaSeparatedInput(): void
     {
         // Call merchant first
-        $this->planetService->getPlayer()->getUser()->dark_matter = 10000;
-        $this->planetService->getPlayer()->save();
+        $this->player()->getUser()->dark_matter = 10000;
+        $this->player()->save();
 
         $callResponse = $this->post('/merchant/call', [
             'type' => 'metal',

--- a/tests/Feature/MessagesTest.php
+++ b/tests/Feature/MessagesTest.php
@@ -194,7 +194,11 @@ class MessagesTest extends MoonTestCase
 
         // Create a new espionage report record in the db and set the espionage_report_id to its ID.
         $espionageReportId = $this->createEspionageReport();
-        $messageModel = $messageService->sendEspionageReportMessageToPlayer($this->planetService->getPlayer(), $espionageReportId);
+        $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('Player not found.');
+        }
+        $messageModel = $messageService->sendEspionageReportMessageToPlayer($player, $espionageReportId);
         $espionageMessage = GameMessageFactory::createGameMessage($messageModel);
 
         // Try to open the espionage report message via full screen AJAX request.
@@ -219,7 +223,11 @@ class MessagesTest extends MoonTestCase
 
         // Create a new espionage report record in the db and set the battle_report_id to its ID.
         $battleReportId = $this->createBattleReport();
-        $messageModel = $messageService->sendBattleReportMessageToPlayer($this->planetService->getPlayer(), $battleReportId);
+        $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('Player not found.');
+        }
+        $messageModel = $messageService->sendBattleReportMessageToPlayer($player, $battleReportId);
         $battleReport = GameMessageFactory::createGameMessage($messageModel);
 
         // Try to open the espionage report message via full screen AJAX request.
@@ -302,11 +310,16 @@ class MessagesTest extends MoonTestCase
         // Get a random planet to create the battle report for.
         $foreignPlanet = $this->getNearbyForeignPlanet();
 
+        $foreignPlayer = $foreignPlanet->getPlayer();
+        if ($foreignPlayer === null) {
+            $this->fail('Foreign player not found.');
+        }
+
         $battleReport = new BattleReport();
         $battleReport->planet_galaxy = $foreignPlanet->getPlanetCoordinates()->galaxy;
         $battleReport->planet_system = $foreignPlanet->getPlanetCoordinates()->system;
         $battleReport->planet_position = $foreignPlanet->getPlanetCoordinates()->position;
-        $battleReport->planet_user_id = $foreignPlanet->getPlayer()->getId();
+        $battleReport->planet_user_id = $foreignPlayer->getId();
         $battleReport->attacker = [
             'player_id' => $this->currentUserId,
             'resource_loss' => 20000,
@@ -316,7 +329,7 @@ class MessagesTest extends MoonTestCase
             'armor_technology' => 0,
         ];
         $battleReport->defender = [
-            'player_id' => $foreignPlanet->getPlayer()->getId(),
+            'player_id' => $foreignPlayer->getId(),
             'resource_loss' => 10000,
             'units' => [],
             'weapon_technology' => 0,
@@ -343,11 +356,16 @@ class MessagesTest extends MoonTestCase
         // Get a random planet to create the espionage report for.
         $foreignPlanet = $this->getNearbyForeignPlanet();
 
+        $foreignPlayer = $foreignPlanet->getPlayer();
+        if ($foreignPlayer === null) {
+            $this->fail('Foreign player not found.');
+        }
+
         $espionageReport = new EspionageReport();
         $espionageReport->planet_galaxy = $foreignPlanet->getPlanetCoordinates()->galaxy;
         $espionageReport->planet_system = $foreignPlanet->getPlanetCoordinates()->system;
         $espionageReport->planet_position = $foreignPlanet->getPlanetCoordinates()->position;
-        $espionageReport->planet_user_id = $foreignPlanet->getPlayer()->getId();
+        $espionageReport->planet_user_id = $foreignPlayer->getId();
         $espionageReport->resources = ['metal' => 1000, 'crystal' => 500, 'deuterium' => 100, 'energy' => 1000];
         $espionageReport->debris = ['metal' => 5000, 'crystal' => 2000, 'deuterium' => 0, 'energy' => 0];
         $espionageReport->buildings = ['metal_mine' => 10, 'crystal_mine' => 10, 'deuterium_synthesizer' => 10];

--- a/tests/Feature/MissilesDoNotParticipateInCombatTest.php
+++ b/tests/Feature/MissilesDoNotParticipateInCombatTest.php
@@ -98,6 +98,9 @@ class MissilesDoNotParticipateInCombatTest extends FleetDispatchTestCase
         // Reload the defender planet
         $planetServiceFactory = resolve(PlanetServiceFactory::class);
         $foreignPlanetReloaded = $planetServiceFactory->make($foreignPlanet->getPlanetId());
+        if ($foreignPlanetReloaded === null) {
+            $this->fail('Foreign planet not found.');
+        }
 
         // Key assertions: missiles should NOT have participated in combat
         // Therefore they should still be at their original counts
@@ -123,7 +126,11 @@ class MissilesDoNotParticipateInCombatTest extends FleetDispatchTestCase
         );
 
         // Get the battle report
-        $messageAttacker = Message::where('user_id', $this->planetService->getPlayer()->getId())
+        $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('Player not found.');
+        }
+        $messageAttacker = Message::where('user_id', $player->getId())
             ->where('key', 'battle_report')
             ->orderByDesc('id')
             ->first();
@@ -195,6 +202,9 @@ class MissilesDoNotParticipateInCombatTest extends FleetDispatchTestCase
         // Reload the defender planet
         $planetServiceFactory = resolve(PlanetServiceFactory::class);
         $foreignPlanetReloaded = $planetServiceFactory->make($foreignPlanet->getPlanetId());
+        if ($foreignPlanetReloaded === null) {
+            $this->fail('Foreign planet not found.');
+        }
 
         // Verify missiles remain at original count
         $this->assertEquals(
@@ -209,7 +219,11 @@ class MissilesDoNotParticipateInCombatTest extends FleetDispatchTestCase
         );
 
         // Get the battle report
-        $messageAttacker = Message::where('user_id', $this->planetService->getPlayer()->getId())
+        $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('Player not found.');
+        }
+        $messageAttacker = Message::where('user_id', $player->getId())
             ->where('key', 'battle_report')
             ->orderByDesc('id')
             ->first();

--- a/tests/Feature/MoonFieldRestrictionTest.php
+++ b/tests/Feature/MoonFieldRestrictionTest.php
@@ -24,6 +24,9 @@ class MoonFieldRestrictionTest extends MoonTestCase
     {
         // Set the moon to have very few fields and fill them up
         $moonModel = Planet::where('id', $this->moonService->getPlanetId())->first();
+        if ($moonModel === null) {
+            $this->fail('Moon model not found.');
+        }
         $moonModel->field_max = 3;
         $moonModel->save();
 
@@ -53,7 +56,11 @@ class MoonFieldRestrictionTest extends MoonTestCase
         $this->assertEquals(6, $this->moonService->getPlanetFieldMax());
 
         // Set hyperspace_technology to level 7 (required for jump_gate)
-        $this->moonService->getPlayer()->setResearchLevel('hyperspace_technology', 7);
+        $moonPlayer = $this->moonService->getPlayer();
+        if ($moonPlayer === null) {
+            $this->fail('Player is null.');
+        }
+        $moonPlayer->setResearchLevel('hyperspace_technology', 7);
 
         // Add resources to build jump_gate
         $this->moonAddResources(new GameResources(3000000, 5000000, 3000000));
@@ -82,6 +89,9 @@ class MoonFieldRestrictionTest extends MoonTestCase
     {
         // Set the moon to have 3 base fields
         $moonModel = Planet::where('id', $this->moonService->getPlanetId())->first();
+        if ($moonModel === null) {
+            $this->fail('Moon model not found.');
+        }
         $moonModel->field_max = 3;
         $moonModel->lunar_base = 0;
         $moonModel->save();
@@ -123,6 +133,9 @@ class MoonFieldRestrictionTest extends MoonTestCase
     private function moonAddResources(GameResources $resources): void
     {
         $moonModel = Planet::where('id', $this->moonService->getPlanetId())->first();
+        if ($moonModel === null) {
+            $this->fail('Moon model not found.');
+        }
         $moonModel->metal += $resources->metal->get();
         $moonModel->crystal += $resources->crystal->get();
         $moonModel->deuterium += $resources->deuterium->get();

--- a/tests/Feature/PlanetAbandonTest.php
+++ b/tests/Feature/PlanetAbandonTest.php
@@ -12,7 +12,11 @@ class PlanetAbandonTest extends AccountTestCase
     public function testSecondPlanetAbandon(): void
     {
         // Check that the user has at least two planets.
-        $startPlanetCount = $this->planetService->getPlayer()->planets->planetCount();
+        $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('Player is null.');
+        }
+        $startPlanetCount = $player->planets->planetCount();
         $this->assertGreaterThanOrEqual(2, $startPlanetCount);
 
         // Attempt to abandon the second planet.
@@ -24,9 +28,9 @@ class PlanetAbandonTest extends AccountTestCase
         $this->assertStringContainsString('Planet has been abandoned successfully!', (string)$response->getContent());
 
         // Reload player to get updated planet count.
-        $this->planetService->getPlayer()->load($this->planetService->getPlayer()->getId());
+        $player->load($player->getId());
         // Check that the user now has one less planet.
-        $this->assertEquals($startPlanetCount - 1, $this->planetService->getPlayer()->planets->planetCount());
+        $this->assertEquals($startPlanetCount - 1, $player->planets->planetCount());
     }
 
     /**
@@ -35,10 +39,14 @@ class PlanetAbandonTest extends AccountTestCase
     public function testFirstPlanetAbandonFail(): void
     {
         // Check that the user has at least two planets.
-        $startPlanetCount = $this->planetService->getPlayer()->planets->planetCount();
+        $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('Player is null.');
+        }
+        $startPlanetCount = $player->planets->planetCount();
         if ($startPlanetCount >= 2) {
             // Abandon all planets except the first one.
-            foreach ($this->planetService->getPlayer()->planets->all() as $planet) {
+            foreach ($player->planets->all() as $planet) {
                 if ($planet->getPlanetId() !== $this->planetService->getPlanetId()) {
                     $response = $this->post('/ajax/planet-abandon/abandon', [
                         '_token' => csrf_token(),
@@ -51,9 +59,9 @@ class PlanetAbandonTest extends AccountTestCase
         }
 
         // Reload player to get updated planet count.
-        $this->planetService->getPlayer()->load($this->planetService->getPlayer()->getId());
+        $player->load($player->getId());
         // Check that the user now has only one planet.
-        $this->assertEquals(1, $this->planetService->getPlayer()->planets->planetCount());
+        $this->assertEquals(1, $player->planets->planetCount());
 
         // Attempt to abandon the only remaining planet.
         $response = $this->post('/ajax/planet-abandon/abandon', [

--- a/tests/Feature/PlanetFieldRestrictionTest.php
+++ b/tests/Feature/PlanetFieldRestrictionTest.php
@@ -24,6 +24,9 @@ class PlanetFieldRestrictionTest extends AccountTestCase
     {
         // Set the planet to have very few fields and fill them up
         $planetModel = Planet::where('id', $this->planetService->getPlanetId())->first();
+        if ($planetModel === null) {
+            $this->fail('Planet model not found.');
+        }
         $planetModel->field_max = 5;
         $planetModel->save();
 
@@ -66,6 +69,9 @@ class PlanetFieldRestrictionTest extends AccountTestCase
     {
         // Set the planet to have 10 fields
         $planetModel = Planet::where('id', $this->planetService->getPlanetId())->first();
+        if ($planetModel === null) {
+            $this->fail('Planet model not found.');
+        }
         $planetModel->field_max = 10;
         $planetModel->save();
 
@@ -111,6 +117,9 @@ class PlanetFieldRestrictionTest extends AccountTestCase
     {
         // Set the planet to have 6 fields total
         $planetModel = Planet::where('id', $this->planetService->getPlanetId())->first();
+        if ($planetModel === null) {
+            $this->fail('Planet model not found.');
+        }
         $planetModel->field_max = 6;
         $planetModel->save();
 
@@ -157,6 +166,9 @@ class PlanetFieldRestrictionTest extends AccountTestCase
     {
         // Set the planet to have very few fields and fill them up
         $planetModel = Planet::where('id', $this->planetService->getPlanetId())->first();
+        if ($planetModel === null) {
+            $this->fail('Planet model not found.');
+        }
         $planetModel->field_max = 5;
         $planetModel->save();
 
@@ -192,6 +204,9 @@ class PlanetFieldRestrictionTest extends AccountTestCase
     {
         // Set the planet to have 5 base fields
         $planetModel = Planet::where('id', $this->planetService->getPlanetId())->first();
+        if ($planetModel === null) {
+            $this->fail('Planet model not found.');
+        }
         $planetModel->field_max = 5;
         $planetModel->terraformer = 0;
         $planetModel->save();
@@ -243,6 +258,9 @@ class PlanetFieldRestrictionTest extends AccountTestCase
     {
         // Set the planet to have 5 fields
         $planetModel = Planet::where('id', $this->planetService->getPlanetId())->first();
+        if ($planetModel === null) {
+            $this->fail('Planet model not found.');
+        }
         $planetModel->field_max = 5;
         $planetModel->save();
 
@@ -292,6 +310,9 @@ class PlanetFieldRestrictionTest extends AccountTestCase
     {
         // Set the planet to have 5 fields total
         $planetModel = Planet::where('id', $this->planetService->getPlanetId())->first();
+        if ($planetModel === null) {
+            $this->fail('Planet model not found.');
+        }
         $planetModel->field_max = 5;
         $planetModel->save();
 

--- a/tests/Feature/PlanetMoveTest.php
+++ b/tests/Feature/PlanetMoveTest.php
@@ -34,6 +34,9 @@ class PlanetMoveTest extends AccountTestCase
 
         // Give the user enough Dark Matter for relocations.
         $user = User::find($this->currentUserId);
+        if ($user === null) {
+            $this->fail('User not found.');
+        }
         $user->dark_matter = 500000;
         $user->save();
     }
@@ -89,8 +92,12 @@ class PlanetMoveTest extends AccountTestCase
 
         // Verify coordinates have NOT changed yet (move is only scheduled).
         $this->reloadApplication();
-        $this->planetService->getPlayer()->load($this->planetService->getPlayer()->getId());
-        $updatedPlanet = $this->planetService->getPlayer()->planets->current();
+        $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('Player is null.');
+        }
+        $player->load($player->getId());
+        $updatedPlanet = $player->planets->current();
         $currentCoordinates = $updatedPlanet->getPlanetCoordinates();
 
         $this->assertEquals($originalCoordinates->galaxy, $currentCoordinates->galaxy);
@@ -99,6 +106,9 @@ class PlanetMoveTest extends AccountTestCase
 
         // Verify DM was NOT deducted (only deducted when move executes).
         $user = User::find($this->currentUserId);
+        if ($user === null) {
+            $this->fail('User not found.');
+        }
         $this->assertEquals(500000, $user->dark_matter);
     }
 
@@ -108,7 +118,11 @@ class PlanetMoveTest extends AccountTestCase
     public function testRelocationToOccupiedPosition(): void
     {
         // The second planet of the user is occupied, try to relocate there.
-        $occupiedCoordinate = $this->secondPlanetService->getPlanetCoordinates();
+        $secondPlanet = $this->secondPlanetService;
+        if ($secondPlanet === null) {
+            $this->fail('Second planet service is null.');
+        }
+        $occupiedCoordinate = $secondPlanet->getPlanetCoordinates();
 
         $response = $this->post('/ajax/planet-move', [
             '_token' => csrf_token(),
@@ -122,6 +136,9 @@ class PlanetMoveTest extends AccountTestCase
 
         // Verify DM was not deducted.
         $user = User::find($this->currentUserId);
+        if ($user === null) {
+            $this->fail('User not found.');
+        }
         $this->assertEquals(500000, $user->dark_matter);
     }
 
@@ -132,6 +149,9 @@ class PlanetMoveTest extends AccountTestCase
     {
         // Set DM to less than the cost.
         $user = User::find($this->currentUserId);
+        if ($user === null) {
+            $this->fail('User not found.');
+        }
         $user->dark_matter = 100;
         $user->save();
 
@@ -253,10 +273,16 @@ class PlanetMoveTest extends AccountTestCase
 
         // Verify the move is canceled.
         $move = PlanetMove::where('planet_id', $this->planetService->getPlanetId())->first();
+        if ($move === null) {
+            $this->fail('Planet move not found.');
+        }
         $this->assertTrue((bool) $move->canceled);
 
         // Verify DM was not deducted.
         $user = User::find($this->currentUserId);
+        if ($user === null) {
+            $this->fail('User not found.');
+        }
         $this->assertEquals(500000, $user->dark_matter);
     }
 
@@ -276,6 +302,9 @@ class PlanetMoveTest extends AccountTestCase
             ->where('canceled', false)
             ->where('processed', false)
             ->first();
+        if ($move === null) {
+            $this->fail('Planet move not found.');
+        }
         $move->time_arrive = time() - 1;
         $move->save();
 
@@ -314,12 +343,19 @@ class PlanetMoveTest extends AccountTestCase
 
         // Verify DM was deducted.
         $user = User::find($this->currentUserId);
+        if ($user === null) {
+            $this->fail('User not found.');
+        }
         $this->assertEquals(260000, $user->dark_matter);
 
         // Verify the planet coordinates changed.
         $this->reloadApplication();
-        $this->planetService->getPlayer()->load($this->planetService->getPlayer()->getId());
-        $updatedPlanet = $this->planetService->getPlayer()->planets->current();
+        $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('Player is null.');
+        }
+        $player->load($player->getId());
+        $updatedPlanet = $player->planets->current();
         $newCoordinates = $updatedPlanet->getPlanetCoordinates();
 
         $this->assertEquals($emptyCoordinate->galaxy, $newCoordinates->galaxy);
@@ -533,6 +569,9 @@ class PlanetMoveTest extends AccountTestCase
             ->where('canceled', false)
             ->where('processed', false)
             ->first();
+        if ($move === null) {
+            $this->fail('Planet move not found.');
+        }
         $move->time_arrive = time() - 1;
         $move->save();
 
@@ -568,6 +607,9 @@ class PlanetMoveTest extends AccountTestCase
 
         // Verify DM was NOT deducted.
         $user = User::find($this->currentUserId);
+        if ($user === null) {
+            $this->fail('User not found.');
+        }
         $this->assertEquals(500000, $user->dark_matter);
     }
 
@@ -616,8 +658,12 @@ class PlanetMoveTest extends AccountTestCase
     public function testRelocationAllowedWithResearchOnDifferentPlanet(): void
     {
         // Insert a research queue item on the SECOND planet (not the one being moved).
+        $secondPlanet = $this->secondPlanetService;
+        if ($secondPlanet === null) {
+            $this->fail('Second planet service is null.');
+        }
         DB::table('research_queues')->insert([
-            'planet_id' => $this->secondPlanetService->getPlanetId(),
+            'planet_id' => $secondPlanet->getPlanetId(),
             'object_id' => 113, // energy_technology
             'object_level_target' => 1,
             'time_duration' => 3600,
@@ -642,7 +688,7 @@ class PlanetMoveTest extends AccountTestCase
         $response->assertJson(['error' => '']);
 
         // Clean up the research queue item on the second planet.
-        DB::table('research_queues')->where('planet_id', $this->secondPlanetService->getPlanetId())->delete();
+        DB::table('research_queues')->where('planet_id', $secondPlanet->getPlanetId())->delete();
     }
 
     /**
@@ -655,6 +701,9 @@ class PlanetMoveTest extends AccountTestCase
         // Get a foreign planet to use as the attacker origin.
         $foreignPlanet = $this->getNearbyForeignPlanet();
         $foreignPlayer = $foreignPlanet->getPlayer();
+        if ($foreignPlayer === null) {
+            $this->fail('Foreign player is null.');
+        }
 
         $emptyCoordinate = $this->getNearbyEmptyCoordinate();
 
@@ -754,8 +803,12 @@ class PlanetMoveTest extends AccountTestCase
 
         // Verify the move was processed and planet is at new coordinates.
         $this->reloadApplication();
-        $this->planetService->getPlayer()->load($this->planetService->getPlayer()->getId());
-        $updatedPlanet = $this->planetService->getPlayer()->planets->current();
+        $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('Player is null.');
+        }
+        $player->load($player->getId());
+        $updatedPlanet = $player->planets->current();
         $newCoordinates = $updatedPlanet->getPlanetCoordinates();
         $this->assertEquals($emptyCoordinate->galaxy, $newCoordinates->galaxy);
 
@@ -798,8 +851,12 @@ class PlanetMoveTest extends AccountTestCase
 
         // Colonize the target position (create a planet there) so the move fails.
         $foreignPlanet = $this->getNearbyForeignPlanet();
+        $foreignPlayer = $foreignPlanet->getPlayer();
+        if ($foreignPlayer === null) {
+            $this->fail('Foreign player is null.');
+        }
         $planetServiceFactory = resolve(PlanetServiceFactory::class);
-        $blockerPlanet = $planetServiceFactory->createAdditionalPlanetForPlayer($foreignPlanet->getPlayer(), $emptyCoordinate);
+        $blockerPlanet = $planetServiceFactory->createAdditionalPlanetForPlayer($foreignPlayer, $emptyCoordinate);
 
         // Trigger processing — the move should fail because target is occupied.
         $planetMoveService = resolve(PlanetMoveService::class);
@@ -822,6 +879,9 @@ class PlanetMoveTest extends AccountTestCase
 
         // Verify DM was NOT deducted.
         $user = User::find($this->currentUserId);
+        if ($user === null) {
+            $this->fail('User not found.');
+        }
         $this->assertEquals(500000, $user->dark_matter);
 
         // Clean up the blocker planet.

--- a/tests/Feature/ResearchQueueTest.php
+++ b/tests/Feature/ResearchQueueTest.php
@@ -208,21 +208,29 @@ class ResearchQueueTest extends AccountTestCase
         // Assert two planets combined research lab level when second planet doesn't meet requirements.
         $this->playerSetResearchLevel('intergalactic_research_network', 2);
         $this->playerSetResearchLevel('energy_technology', 3);
-        $this->secondPlanetService->setObjectLevel(31, 5); // Research Lab
+        $secondPlanetService = $this->secondPlanetService;
+        if ($secondPlanetService === null) {
+            $this->fail('Second planet service not initialized.');
+        }
+        $secondPlanetService->setObjectLevel(31, 5); // Research Lab
         $this->assertSame(8, $this->planetService->getResearchNetworkLabLevel('shielding_technology'));
 
         // Assert two planets combined research lab level.
-        $this->secondPlanetService->setObjectLevel(31, 10); // Research Lab
+        $secondPlanetService->setObjectLevel(31, 10); // Research Lab
         $this->assertSame(18, $this->planetService->getResearchNetworkLabLevel('shielding_technology'));
 
         // Assert three planets combined research lab level.
-        $thirdPlanetService = $this->planetService->getPlayer()->planets->all()[2];
+        $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('Player not found.');
+        }
+        $thirdPlanetService = $player->planets->all()[2];
         $thirdPlanetService->setObjectLevel(31, 6); // Research Lab
         $this->assertSame(24, $this->planetService->getResearchNetworkLabLevel('shielding_technology'));
 
         // Assert four planets combined research lab level. Forth planet is not counted in as
         // Intergalactic Research Network technology level 2 limits combined planet count to 3.
-        $forthPlanetService = $this->planetService->getPlayer()->planets->all()[3];
+        $forthPlanetService = $player->planets->all()[3];
         $forthPlanetService->setObjectLevel(31, 6); // Research Lab
         $this->assertSame(24, $this->planetService->getResearchNetworkLabLevel('shielding_technology'));
 

--- a/tests/Feature/SidebarWreckFieldIconTest.php
+++ b/tests/Feature/SidebarWreckFieldIconTest.php
@@ -27,15 +27,18 @@ class SidebarWreckFieldIconTest extends AccountTestCase
      */
     public function test_sidebar_shows_wreck_field_icon_for_planet_with_space_dock_when_other_planet_selected(): void
     {
-        $this->assertNotNull($this->secondPlanetService);
+        $secondPlanet = $this->secondPlanetService;
+        if ($secondPlanet === null) {
+            $this->fail('Second planet not found.');
+        }
 
         $this->setPlanetSpaceDock($this->planetService->getPlanetId(), 1);
-        $this->setPlanetSpaceDock($this->secondPlanetService->getPlanetId(), 0);
+        $this->setPlanetSpaceDock($secondPlanet->getPlanetId(), 0);
         $this->createWreckFieldOnPlanet($this->planetService->getPlanetId());
 
         $this->switchToSecondPlanet();
 
-        $response = $this->get('/overview?cp=' . $this->secondPlanetService->getPlanetId());
+        $response = $this->get('/overview?cp=' . $secondPlanet->getPlanetId());
         $response->assertStatus(200);
 
         $html = (string) $response->getContent();
@@ -45,7 +48,7 @@ class SidebarWreckFieldIconTest extends AccountTestCase
             'Wreck field icon should appear on the planet that has both a wreck field and Space Dock, even when another planet is selected.'
         );
         $this->assertFalse(
-            $this->sidebarPlanetHasWreckFieldIcon($html, $this->secondPlanetService->getPlanetId()),
+            $this->sidebarPlanetHasWreckFieldIcon($html, $secondPlanet->getPlanetId()),
             'Wreck field icon should not appear on the selected planet that has no wreck field.'
         );
     }
@@ -56,15 +59,18 @@ class SidebarWreckFieldIconTest extends AccountTestCase
      */
     public function test_sidebar_hides_wreck_field_icon_when_wreck_planet_lacks_space_dock(): void
     {
-        $this->assertNotNull($this->secondPlanetService);
+        $secondPlanet = $this->secondPlanetService;
+        if ($secondPlanet === null) {
+            $this->fail('Second planet not found.');
+        }
 
         $this->setPlanetSpaceDock($this->planetService->getPlanetId(), 0);
-        $this->setPlanetSpaceDock($this->secondPlanetService->getPlanetId(), 1);
+        $this->setPlanetSpaceDock($secondPlanet->getPlanetId(), 1);
         $this->createWreckFieldOnPlanet($this->planetService->getPlanetId());
 
         $this->switchToSecondPlanet();
 
-        $response = $this->get('/overview?cp=' . $this->secondPlanetService->getPlanetId());
+        $response = $this->get('/overview?cp=' . $secondPlanet->getPlanetId());
         $response->assertStatus(200);
 
         $html = (string) $response->getContent();
@@ -74,7 +80,7 @@ class SidebarWreckFieldIconTest extends AccountTestCase
             'Wreck field icon must not appear when the wreck planet has no Space Dock, even if the selected planet does.'
         );
         $this->assertFalse(
-            $this->sidebarPlanetHasWreckFieldIcon($html, $this->secondPlanetService->getPlanetId()),
+            $this->sidebarPlanetHasWreckFieldIcon($html, $secondPlanet->getPlanetId()),
             'Wreck field icon should not appear on the selected planet that has no wreck field.'
         );
     }

--- a/tests/Feature/TechtreeTest.php
+++ b/tests/Feature/TechtreeTest.php
@@ -2,7 +2,9 @@
 
 namespace Tests\Feature;
 
+use OGame\Enums\CharacterClass;
 use OGame\Services\ObjectService;
+use PHPUnit\Framework\AssertionFailedError;
 use Tests\AccountTestCase;
 
 /**
@@ -21,7 +23,7 @@ class TechtreeTest extends AccountTestCase
 
             try {
                 $response->assertStatus(200);
-            } catch (\PHPUnit\Framework\AssertionFailedError $e) {
+            } catch (AssertionFailedError $e) {
                 $this->fail('AJAX techtree info page for "' . $object->title . '" does not return HTTP 200.');
             }
         }
@@ -40,7 +42,7 @@ class TechtreeTest extends AccountTestCase
 
             try {
                 $response->assertStatus(200);
-            } catch (\PHPUnit\Framework\AssertionFailedError $e) {
+            } catch (AssertionFailedError $e) {
                 $this->fail('AJAX techtree applications page for "' . $object->title . '" does not return HTTP 200.');
             }
         }
@@ -60,8 +62,12 @@ class TechtreeTest extends AccountTestCase
         $response->assertDontSee('data-prerequisites-met="true"', false);
 
         // Set character class to Collector (required for Crawler)
-        $user = $this->planetService->getPlayer()->getUser();
-        $user->character_class = \OGame\Enums\CharacterClass::COLLECTOR->value;
+        $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('No player found for planet.');
+        }
+        $user = $player->getUser();
+        $user->character_class = CharacterClass::COLLECTOR->value;
         $user->save();
 
         // User/planet with all levels/prerequisites for laser technology applications.
@@ -110,7 +116,7 @@ class TechtreeTest extends AccountTestCase
             try {
                 $response->assertStatus(200);
                 $response->assertDontSee(['Speed','Cargo Capacity','Fuel usage (Deuterium)']);
-            } catch (\PHPUnit\Framework\AssertionFailedError $e) {
+            } catch (AssertionFailedError $e) {
                 $this->fail('AJAX techinfo applications page for "' . $defenseObject->title . '"');
             }
         }
@@ -130,7 +136,7 @@ class TechtreeTest extends AccountTestCase
             try {
                 $response->assertStatus(200);
                 $response->assertSee(['Speed','Cargo Capacity','Fuel usage (Deuterium)']);
-            } catch (\PHPUnit\Framework\AssertionFailedError $e) {
+            } catch (AssertionFailedError $e) {
                 $this->fail('AJAX techinfo applications page for "' . $nonDefenseObject->title . '"');
             }
         }

--- a/tests/Feature/VacationModeTest.php
+++ b/tests/Feature/VacationModeTest.php
@@ -34,6 +34,9 @@ class VacationModeTest extends FleetDispatchTestCase
         $this->basicSetup();
 
         $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('Player not found.');
+        }
 
         // Verify player is not in vacation mode initially
         $this->assertFalse($player->isInVacationMode());
@@ -64,6 +67,9 @@ class VacationModeTest extends FleetDispatchTestCase
         $this->basicSetup();
 
         $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('Player not found.');
+        }
 
         // Send a fleet to the second planet
         $unitCollection = new UnitCollection();
@@ -85,6 +91,9 @@ class VacationModeTest extends FleetDispatchTestCase
         $this->basicSetup();
 
         $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('Player not found.');
+        }
 
         // Activate vacation mode
         $player->activateVacationMode();
@@ -114,6 +123,9 @@ class VacationModeTest extends FleetDispatchTestCase
         $this->basicSetup();
 
         $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('Player not found.');
+        }
 
         // Activate vacation mode
         $player->activateVacationMode();
@@ -139,6 +151,9 @@ class VacationModeTest extends FleetDispatchTestCase
         // Get a nearby foreign planet
         $otherPlanet = $this->getNearbyForeignPlanet();
         $otherPlayer = $otherPlanet->getPlayer();
+        if ($otherPlayer === null) {
+            $this->fail('Player not found.');
+        }
 
         // Put the other player in vacation mode
         $otherPlayer->activateVacationMode();
@@ -182,6 +197,9 @@ class VacationModeTest extends FleetDispatchTestCase
         $this->basicSetup();
 
         $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('Player not found.');
+        }
 
         // Activate vacation mode
         $player->activateVacationMode();
@@ -192,10 +210,14 @@ class VacationModeTest extends FleetDispatchTestCase
         $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 1);
 
         // Check if missions are possible to own second planet
+        $secondPlanetService = $this->secondPlanetService;
+        if ($secondPlanetService === null) {
+            $this->fail('Second planet service not initialized.');
+        }
         $response = $this->post('/ajax/fleet/dispatch/check-target', [
-            'galaxy' => $this->secondPlanetService->getPlanetCoordinates()->galaxy,
-            'system' => $this->secondPlanetService->getPlanetCoordinates()->system,
-            'position' => $this->secondPlanetService->getPlanetCoordinates()->position,
+            'galaxy' => $secondPlanetService->getPlanetCoordinates()->galaxy,
+            'system' => $secondPlanetService->getPlanetCoordinates()->system,
+            'position' => $secondPlanetService->getPlanetCoordinates()->position,
             'type' => PlanetType::Planet->value,
         ]);
 
@@ -223,6 +245,9 @@ class VacationModeTest extends FleetDispatchTestCase
 
         $planet = $this->planetService;
         $player = $planet->getPlayer();
+        if ($player === null) {
+            $this->fail('Player not found.');
+        }
 
         // Build a metal mine to have some production
         $this->planetSetObjectLevel('metal_mine', 5);
@@ -259,6 +284,9 @@ class VacationModeTest extends FleetDispatchTestCase
 
         $planet = $this->planetService;
         $player = $planet->getPlayer();
+        if ($player === null) {
+            $this->fail('Player not found.');
+        }
 
         // Calculate base income (before building any mines)
         $planet->updateResourceProductionStats();
@@ -331,6 +359,9 @@ class VacationModeTest extends FleetDispatchTestCase
         // Get a nearby foreign planet
         $otherPlanet = $this->getNearbyForeignPlanet();
         $otherPlayer = $otherPlanet->getPlayer();
+        if ($otherPlayer === null) {
+            $this->fail('Player not found.');
+        }
 
         // Put the other player in vacation mode
         $otherPlayer->activateVacationMode();
@@ -373,6 +404,9 @@ class VacationModeTest extends FleetDispatchTestCase
         $this->basicSetup();
 
         $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('Player not found.');
+        }
 
         // Verify player is not in vacation mode
         $this->assertFalse($player->isInVacationMode());
@@ -402,6 +436,9 @@ class VacationModeTest extends FleetDispatchTestCase
         $this->basicSetup();
 
         $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('Player not found.');
+        }
 
         // Activate vacation mode first
         $player->activateVacationMode();
@@ -435,6 +472,9 @@ class VacationModeTest extends FleetDispatchTestCase
 
         $planet = $this->planetService;
         $player = $planet->getPlayer();
+        if ($player === null) {
+            $this->fail('Player not found.');
+        }
 
         // Give planet resources to build
         $this->planetAddResources(new Resources(10000, 10000, 10000, 0));
@@ -496,6 +536,9 @@ class VacationModeTest extends FleetDispatchTestCase
 
         $planet = $this->planetService;
         $player = $planet->getPlayer();
+        if ($player === null) {
+            $this->fail('Player not found.');
+        }
 
         // Get initial unit count before adding to queue
         $initialUnits = $planet->getObjectAmount('light_fighter');
@@ -533,6 +576,9 @@ class VacationModeTest extends FleetDispatchTestCase
 
         $planet = $this->planetService;
         $player = $planet->getPlayer();
+        if ($player === null) {
+            $this->fail('Player not found.');
+        }
 
         // Give planet resources and build research lab
         $this->planetAddResources(new Resources(50000, 50000, 50000, 0));
@@ -591,6 +637,9 @@ class VacationModeTest extends FleetDispatchTestCase
         $this->basicSetup();
 
         $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('Player not found.');
+        }
         $planet = $this->planetService;
 
         // Give planet resources to build
@@ -625,6 +674,9 @@ class VacationModeTest extends FleetDispatchTestCase
         $this->basicSetup();
 
         $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('Player not found.');
+        }
         $planet = $this->planetService;
 
         // Give planet resources and build research lab
@@ -660,6 +712,9 @@ class VacationModeTest extends FleetDispatchTestCase
         $this->basicSetup();
 
         $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('Player not found.');
+        }
         $planet = $this->planetService;
 
         // Give planet resources and build shipyard

--- a/tests/Feature/WreckFieldTest.php
+++ b/tests/Feature/WreckFieldTest.php
@@ -16,7 +16,11 @@ class WreckFieldTest extends AccountTestCase
     private function getWreckFieldService(): WreckFieldService
     {
         $settingsService = resolve(SettingsService::class);
-        return new WreckFieldService($this->planetService->getPlayer(), $settingsService);
+        $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('Player is null.');
+        }
+        return new WreckFieldService($player, $settingsService);
     }
 
     private function getCurrentCoordinate(): Coordinate
@@ -110,6 +114,9 @@ class WreckFieldTest extends AccountTestCase
         $this->assertTrue($result);
 
         $updatedWreckField = $wreckFieldService->getWreckField();
+        if ($updatedWreckField === null) {
+            $this->fail('Wreck field is null.');
+        }
         $this->assertEquals('repairing', $updatedWreckField->status);
         $this->assertNotNull($updatedWreckField->repair_started_at);
         $this->assertNotNull($updatedWreckField->repair_completed_at);
@@ -135,7 +142,15 @@ class WreckFieldTest extends AccountTestCase
         $wreckFieldService->startRepairs(1);
 
         $updatedWreckField = $wreckFieldService->getWreckField();
-        $repairDuration = (int) $updatedWreckField->repair_completed_at->timestamp - (int) $updatedWreckField->repair_started_at->timestamp;
+        if ($updatedWreckField === null) {
+            $this->fail('Wreck field is null.');
+        }
+        $repairCompletedAt = $updatedWreckField->repair_completed_at;
+        $repairStartedAt = $updatedWreckField->repair_started_at;
+        if ($repairCompletedAt === null || $repairStartedAt === null) {
+            $this->fail('Repair timestamps are null.');
+        }
+        $repairDuration = (int) $repairCompletedAt->timestamp - (int) $repairStartedAt->timestamp;
 
         $this->assertEquals(12 * 3600, $repairDuration);
     }
@@ -201,6 +216,9 @@ class WreckFieldTest extends AccountTestCase
         $this->assertEquals(100, $repairedShips[0]['repair_progress']);
 
         $updatedWreckField = $wreckFieldService->getWreckField();
+        if ($updatedWreckField === null) {
+            $this->fail('Wreck field is null.');
+        }
         $this->assertEquals('completed', $updatedWreckField->status);
     }
 
@@ -226,6 +244,9 @@ class WreckFieldTest extends AccountTestCase
         $this->assertTrue($result);
 
         $updatedWreckField = $wreckFieldService->getWreckField();
+        if ($updatedWreckField === null) {
+            $this->fail('Wreck field is null.');
+        }
         $this->assertEquals('burned', $updatedWreckField->status);
     }
 
@@ -336,7 +357,7 @@ class WreckFieldTest extends AccountTestCase
         $wreckField->refresh();
 
         // Check that ships were added
-        $this->assertCount(2, $wreckField->ship_data);
+        $this->assertCount(2, $wreckField->ship_data ?? []);
 
         // Check that expiration was extended
         $this->assertGreaterThan($originalExpiresAt, $wreckField->expires_at);
@@ -345,7 +366,7 @@ class WreckFieldTest extends AccountTestCase
         $lightFighter = null;
         $heavyFighter = null;
 
-        foreach ($wreckField->ship_data as $ship) {
+        foreach ($wreckField->ship_data ?? [] as $ship) {
             if ($ship['machine_name'] === 'light_fighter') {
                 $lightFighter = $ship;
             } elseif ($ship['machine_name'] === 'heavy_fighter') {
@@ -381,7 +402,7 @@ class WreckFieldTest extends AccountTestCase
         $updatedWreckField = $wreckFieldService->createWreckField($coordinate, $newShips, $this->currentUserId);
 
         // Check that ships were combined
-        $this->assertCount(2, $updatedWreckField->ship_data);
+        $this->assertCount(2, $updatedWreckField->ship_data ?? []);
 
         // Check that expiration was RESET (not just extended) - should be much later than original
         $this->assertGreaterThan($originalExpiresAt->addHours(10), $updatedWreckField->expires_at);
@@ -390,7 +411,7 @@ class WreckFieldTest extends AccountTestCase
         $lightFighter = null;
         $heavyFighter = null;
 
-        foreach ($updatedWreckField->ship_data as $ship) {
+        foreach ($updatedWreckField->ship_data ?? [] as $ship) {
             if ($ship['machine_name'] === 'light_fighter') {
                 $lightFighter = $ship;
             } elseif ($ship['machine_name'] === 'heavy_fighter') {
@@ -418,6 +439,9 @@ class WreckFieldTest extends AccountTestCase
 
         $wreckField->refresh();
         $originalRepairCompletionTime = $wreckField->repair_completed_at;
+        if ($originalRepairCompletionTime === null) {
+            $this->fail('Repair completion time is null.');
+        }
 
         // Create another wreck field at the same coordinates while repairs are ongoing
         $newShips = [
@@ -431,18 +455,22 @@ class WreckFieldTest extends AccountTestCase
         $this->assertNotEquals($wreckField->id, $newWreckField->id);
 
         // Check that the new wreck field has only the new ships
-        $this->assertCount(1, $newWreckField->ship_data);
+        $this->assertCount(1, $newWreckField->ship_data ?? []);
         $this->assertEquals(5, $newWreckField->getTotalShips());
 
         // Check that the original wreck field was NOT modified
         $wreckField->refresh();
-        $this->assertCount(1, $wreckField->ship_data);
+        $this->assertCount(1, $wreckField->ship_data ?? []);
         $this->assertEquals(10, $wreckField->getTotalShips());
-        $this->assertEquals($originalRepairCompletionTime->timestamp, $wreckField->repair_completed_at->timestamp);
+        $repairCompletedAt = $wreckField->repair_completed_at;
+        if ($repairCompletedAt === null) {
+            $this->fail('Repair completion time is null.');
+        }
+        $this->assertEquals($originalRepairCompletionTime->timestamp, $repairCompletedAt->timestamp);
 
         // Verify the specific ships in the new wreck field
         $heavyFighter = null;
-        foreach ($newWreckField->ship_data as $ship) {
+        foreach ($newWreckField->ship_data ?? [] as $ship) {
             if ($ship['machine_name'] === 'heavy_fighter') {
                 $heavyFighter = $ship;
             }
@@ -476,7 +504,7 @@ class WreckFieldTest extends AccountTestCase
         $wreckField->refresh();
 
         // Check that ships were added
-        $this->assertCount(2, $wreckField->ship_data);
+        $this->assertCount(2, $wreckField->ship_data ?? []);
 
         // Check that expiration was RESET (should be much later than original)
         $this->assertGreaterThan($originalExpiresAt->addHours(10), $wreckField->expires_at);
@@ -485,7 +513,7 @@ class WreckFieldTest extends AccountTestCase
         $lightFighter = null;
         $heavyFighter = null;
 
-        foreach ($wreckField->ship_data as $ship) {
+        foreach ($wreckField->ship_data ?? [] as $ship) {
             if ($ship['machine_name'] === 'light_fighter') {
                 $lightFighter = $ship;
             } elseif ($ship['machine_name'] === 'heavy_fighter') {
@@ -513,6 +541,9 @@ class WreckFieldTest extends AccountTestCase
 
         $wreckField->refresh();
         $originalRepairCompletionTime = $wreckField->repair_completed_at;
+        if ($originalRepairCompletionTime === null) {
+            $this->fail('Repair completion time is null.');
+        }
 
         // Add new ships using addShipsToOngoingRepairs
         $newShips = [
@@ -524,16 +555,20 @@ class WreckFieldTest extends AccountTestCase
         $wreckField->refresh();
 
         // Check that ships were added
-        $this->assertCount(2, $wreckField->ship_data);
+        $this->assertCount(2, $wreckField->ship_data ?? []);
 
         // Check that repair completion time was NOT modified
-        $this->assertEquals($originalRepairCompletionTime->timestamp, $wreckField->repair_completed_at->timestamp);
+        $repairCompletedAt = $wreckField->repair_completed_at;
+        if ($repairCompletedAt === null) {
+            $this->fail('Repair completion time is null.');
+        }
+        $this->assertEquals($originalRepairCompletionTime->timestamp, $repairCompletedAt->timestamp);
 
         // Verify the specific ships
         $lightFighter = null;
         $heavyFighter = null;
 
-        foreach ($wreckField->ship_data as $ship) {
+        foreach ($wreckField->ship_data ?? [] as $ship) {
             if ($ship['machine_name'] === 'light_fighter') {
                 $lightFighter = $ship;
             } elseif ($ship['machine_name'] === 'heavy_fighter') {

--- a/tests/FleetDispatchTestCase.php
+++ b/tests/FleetDispatchTestCase.php
@@ -65,7 +65,11 @@ abstract class FleetDispatchTestCase extends MoonTestCase
      */
     protected function fleetCheckToSecondPlanet(UnitCollection $units, bool $assertSuccess): void
     {
-        $coordinates = $this->secondPlanetService->getPlanetCoordinates();
+        $secondPlanetService = $this->secondPlanetService;
+        if ($secondPlanetService === null) {
+            $this->fail('Second planet service is not initialized.');
+        }
+        $coordinates = $secondPlanetService->getPlanetCoordinates();
         $this->checkTargetFleet($coordinates, $units, PlanetType::Planet, $assertSuccess);
     }
 
@@ -91,7 +95,11 @@ abstract class FleetDispatchTestCase extends MoonTestCase
      */
     protected function fleetCheckToSecondPlanetDebrisField(UnitCollection $units, bool $assertSuccess): void
     {
-        $coordinates = $this->secondPlanetService->getPlanetCoordinates();
+        $secondPlanetService = $this->secondPlanetService;
+        if ($secondPlanetService === null) {
+            $this->fail('Second planet service is not initialized.');
+        }
+        $coordinates = $secondPlanetService->getPlanetCoordinates();
         $this->checkTargetFleet($coordinates, $units, PlanetType::DebrisField, $assertSuccess);
     }
 
@@ -159,7 +167,11 @@ abstract class FleetDispatchTestCase extends MoonTestCase
      */
     protected function sendMissionToSecondPlanet(UnitCollection $units, Resources $resources, bool $assertStatus = true): void
     {
-        $coordinates = $this->secondPlanetService->getPlanetCoordinates();
+        $secondPlanetService = $this->secondPlanetService;
+        if ($secondPlanetService === null) {
+            $this->fail('Second planet service is not initialized.');
+        }
+        $coordinates = $secondPlanetService->getPlanetCoordinates();
         $this->dispatchFleet($coordinates, $units, $resources, PlanetType::Planet, 0, $assertStatus);
     }
 
@@ -187,7 +199,11 @@ abstract class FleetDispatchTestCase extends MoonTestCase
      */
     protected function sendMissionToSecondPlanetDebrisField(UnitCollection $units, Resources $resources, bool $assertStatus = true): void
     {
-        $coordinates = $this->secondPlanetService->getPlanetCoordinates();
+        $secondPlanetService = $this->secondPlanetService;
+        if ($secondPlanetService === null) {
+            $this->fail('Second planet service is not initialized.');
+        }
+        $coordinates = $secondPlanetService->getPlanetCoordinates();
         $this->dispatchFleet($coordinates, $units, $resources, PlanetType::DebrisField, 0, $assertStatus);
     }
 

--- a/tests/Unit/BuildingQueueServiceTest.php
+++ b/tests/Unit/BuildingQueueServiceTest.php
@@ -6,7 +6,6 @@ use Exception;
 use Illuminate\Support\Facades\DB;
 use OGame\Models\Planet;
 use OGame\Models\Planet\Coordinate;
-use OGame\Models\Resources;
 use OGame\Models\User;
 use OGame\Services\BuildingQueueService;
 use OGame\Services\ObjectService;
@@ -68,6 +67,9 @@ class BuildingQueueServiceTest extends UnitTestCase
         $this->assertCount(1, $queue_items);
 
         $queue_item = $queue_items->first();
+        if ($queue_item === null) {
+            $this->fail('Queue item not found.');
+        }
         $this->assertEquals($building->id, $queue_item->object_id);
         $this->assertEquals($initial_level - 1, $queue_item->object_level_target);
         $this->assertTrue((bool)($queue_item->is_downgrade ?? false), 'is_downgrade should be true');

--- a/tests/Unit/HalvingServiceTest.php
+++ b/tests/Unit/HalvingServiceTest.php
@@ -3,11 +3,14 @@
 namespace Tests\Unit;
 
 use Exception;
+use Illuminate\Support\Facades\Date;
 use OGame\Enums\DarkMatterTransactionType;
 use OGame\Models\BuildingQueue;
 use OGame\Models\DarkMatterTransaction;
+use OGame\Models\Resources;
 use OGame\Models\UnitQueue;
 use OGame\Models\User;
+use OGame\Services\BuildingQueueService;
 use OGame\Services\DarkMatterTransactionService;
 use OGame\Services\HalvingService;
 use OGame\Services\ObjectService;
@@ -24,6 +27,19 @@ class HalvingServiceTest extends AccountTestCase
 
         $transactionService = app(DarkMatterTransactionService::class);
         $this->halvingService = new HalvingService($transactionService);
+    }
+
+    /**
+     * Get the current user model, failing the test if it cannot be found.
+     */
+    private function findCurrentUser(): User
+    {
+        $user = User::find($this->currentUserId);
+        if ($user === null) {
+            $this->fail('Current user not found.');
+        }
+
+        return $user;
     }
 
     /**
@@ -220,7 +236,7 @@ class HalvingServiceTest extends AccountTestCase
     public function testDarkMatterDeductionCorrectness(): void
     {
         // Set up user with sufficient Dark Matter
-        $user = User::find($this->currentUserId);
+        $user = $this->findCurrentUser();
         $user->dark_matter = 100000;
         $user->save();
 
@@ -239,7 +255,7 @@ class HalvingServiceTest extends AccountTestCase
         $initialBalance = $user->dark_matter;
 
         // Calculate expected cost based on remaining time
-        $currentTime = (int)\Carbon\Carbon::now()->timestamp;
+        $currentTime = (int)Date::now()->timestamp;
         $remainingTime = (int)$queueItem->time_end - $currentTime;
         $expectedCost = $this->halvingService->calculateHalvingCost($remainingTime, 'building');
 
@@ -265,7 +281,7 @@ class HalvingServiceTest extends AccountTestCase
     public function testInsufficientBalanceRejection(): void
     {
         // Set up user with insufficient Dark Matter
-        $user = User::find($this->currentUserId);
+        $user = $this->findCurrentUser();
         $user->dark_matter = 100;
         $user->save();
 
@@ -305,7 +321,7 @@ class HalvingServiceTest extends AccountTestCase
     public function testTransactionLoggingOnSuccess(): void
     {
         // Set up user with sufficient Dark Matter
-        $user = User::find($this->currentUserId);
+        $user = $this->findCurrentUser();
         $user->dark_matter = 100000;
         $user->save();
 
@@ -352,7 +368,7 @@ class HalvingServiceTest extends AccountTestCase
     public function testNoTransactionOnFailure(): void
     {
         // Set up user with insufficient Dark Matter
-        $user = User::find($this->currentUserId);
+        $user = $this->findCurrentUser();
         $user->dark_matter = 100;
         $user->save();
 
@@ -364,6 +380,10 @@ class HalvingServiceTest extends AccountTestCase
             ->where('building', 1)
             ->where('processed', 0)
             ->first();
+
+        if ($queueItem === null) {
+            $this->fail('Queue item should exist');
+        }
 
         // Count transactions before
         $transactionCountBefore = DarkMatterTransaction::where('user_id', $this->currentUserId)
@@ -398,7 +418,7 @@ class HalvingServiceTest extends AccountTestCase
         $metalMine = ObjectService::getObjectByMachineName('metal_mine');
 
         // Add to queue via service
-        $buildingQueueService = app(\OGame\Services\BuildingQueueService::class);
+        $buildingQueueService = app(BuildingQueueService::class);
         $buildingQueueService->add($this->planetService, $metalMine->id);
     }
 
@@ -411,7 +431,7 @@ class HalvingServiceTest extends AccountTestCase
     public function testTimeReductionBy50PercentOfOriginalTime(): void
     {
         // Set up user with sufficient Dark Matter
-        $user = User::find($this->currentUserId);
+        $user = $this->findCurrentUser();
         $user->dark_matter = 100000;
         $user->save();
 
@@ -427,7 +447,7 @@ class HalvingServiceTest extends AccountTestCase
         $this->assertNotNull($queueItem, 'Queue item should exist');
 
         // Get remaining time and original duration before halving
-        $currentTime = (int)\Carbon\Carbon::now()->timestamp;
+        $currentTime = (int)Date::now()->timestamp;
         $remainingTimeBefore = (int)$queueItem->time_end - $currentTime;
         $originalDuration = (int)$queueItem->time_duration;
 
@@ -454,7 +474,7 @@ class HalvingServiceTest extends AccountTestCase
     public function testOriginalTimePreservation(): void
     {
         // Set up user with sufficient Dark Matter
-        $user = User::find($this->currentUserId);
+        $user = $this->findCurrentUser();
         $user->dark_matter = 100000;
         $user->save();
 
@@ -494,12 +514,12 @@ class HalvingServiceTest extends AccountTestCase
     public function testOperationIsolation(): void
     {
         // Set up user with sufficient Dark Matter
-        $user = User::find($this->currentUserId);
+        $user = $this->findCurrentUser();
         $user->dark_matter = 100000;
         $user->save();
 
         // Add resources to build multiple buildings
-        $this->planetAddResources(new \OGame\Models\Resources(50000, 50000, 50000, 0));
+        $this->planetAddResources(new Resources(50000, 50000, 50000, 0));
 
         // Add first building to queue
         $this->addBuildingToQueue();
@@ -517,7 +537,7 @@ class HalvingServiceTest extends AccountTestCase
 
         // Add second building to queue (different building)
         $crystalMine = ObjectService::getObjectByMachineName('crystal_mine');
-        $buildingQueueService = app(\OGame\Services\BuildingQueueService::class);
+        $buildingQueueService = app(BuildingQueueService::class);
         $buildingQueueService->add($this->planetService, $crystalMine->id);
 
         // Get the second queue item (not building yet, waiting in queue)
@@ -558,7 +578,7 @@ class HalvingServiceTest extends AccountTestCase
         $this->planetSetObjectLevel('robot_factory', 2);
         $this->planetSetObjectLevel('shipyard', 2);
         $this->playerSetResearchLevel('combustion_drive', 1);
-        $this->planetAddResources(new \OGame\Models\Resources(500000, 500000, 500000, 0));
+        $this->planetAddResources(new Resources(500000, 500000, 500000, 0));
         $this->addShipyardBuildRequest('light_fighter', $amount);
     }
 
@@ -567,7 +587,7 @@ class HalvingServiceTest extends AccountTestCase
      */
     public function testUnitHalvingAwardsHalfUnitsInstantly(): void
     {
-        $user = User::find($this->currentUserId);
+        $user = $this->findCurrentUser();
         $user->dark_matter = 100000;
         $user->save();
 
@@ -597,7 +617,7 @@ class HalvingServiceTest extends AccountTestCase
      */
     public function testUnitHalvingRestructuresQueue(): void
     {
-        $user = User::find($this->currentUserId);
+        $user = $this->findCurrentUser();
         $user->dark_matter = 100000;
         $user->save();
 
@@ -625,7 +645,7 @@ class HalvingServiceTest extends AccountTestCase
      */
     public function testUnitHalvingPreservesTimePerUnit(): void
     {
-        $user = User::find($this->currentUserId);
+        $user = $this->findCurrentUser();
         $user->dark_matter = 100000;
         $user->save();
 
@@ -656,7 +676,7 @@ class HalvingServiceTest extends AccountTestCase
      */
     public function testUnitHalvingWithOddNumberOfUnits(): void
     {
-        $user = User::find($this->currentUserId);
+        $user = $this->findCurrentUser();
         $user->dark_matter = 100000;
         $user->save();
 
@@ -688,7 +708,7 @@ class HalvingServiceTest extends AccountTestCase
      */
     public function testDoubleUnitHalvingIsRejected(): void
     {
-        $user = User::find($this->currentUserId);
+        $user = $this->findCurrentUser();
         $user->dark_matter = 200000;
         $user->save();
 
@@ -719,7 +739,7 @@ class HalvingServiceTest extends AccountTestCase
      */
     public function testUnitHalvingWithTwoUnits(): void
     {
-        $user = User::find($this->currentUserId);
+        $user = $this->findCurrentUser();
         $user->dark_matter = 100000;
         $user->save();
 
@@ -752,7 +772,7 @@ class HalvingServiceTest extends AccountTestCase
      */
     public function testUnitHalvingDeductsDarkMatter(): void
     {
-        $user = User::find($this->currentUserId);
+        $user = $this->findCurrentUser();
         $user->dark_matter = 100000;
         $user->save();
 
@@ -767,7 +787,7 @@ class HalvingServiceTest extends AccountTestCase
         $initialBalance = $user->dark_matter;
 
         // Calculate expected cost based on remaining time
-        $currentTime = (int)\Carbon\Carbon::now()->timestamp;
+        $currentTime = (int)Date::now()->timestamp;
         $remainingTime = (int)$queueItem->time_end - $currentTime;
         $expectedCost = $this->halvingService->calculateHalvingCost($remainingTime, 'unit');
 
@@ -783,7 +803,7 @@ class HalvingServiceTest extends AccountTestCase
      */
     public function testUnitHalvingInsufficientDarkMatter(): void
     {
-        $user = User::find($this->currentUserId);
+        $user = $this->findCurrentUser();
         $user->dark_matter = 100;
         $user->save();
 
@@ -823,7 +843,7 @@ class HalvingServiceTest extends AccountTestCase
      */
     public function testHalveAndCompleteChainedQueueItems(): void
     {
-        $user = User::find($this->currentUserId);
+        $user = $this->findCurrentUser();
         $user->dark_matter = 1000000;
         $user->save();
 
@@ -831,7 +851,7 @@ class HalvingServiceTest extends AccountTestCase
         $this->planetSetObjectLevel('shipyard', 2);
         $this->playerSetResearchLevel('combustion_drive', 1);
 
-        $now      = (int)\Carbon\Carbon::now()->timestamp;
+        $now      = (int)Date::now()->timestamp;
         $duration = 2000; // 1000 units × 2 s/unit
         $objectId = ObjectService::getObjectByMachineName('light_fighter')->id;
         $planetId = $this->planetService->getPlanetId();
@@ -901,7 +921,7 @@ class HalvingServiceTest extends AccountTestCase
      */
     public function testUnitHalvingLogsTransaction(): void
     {
-        $user = User::find($this->currentUserId);
+        $user = $this->findCurrentUser();
         $user->dark_matter = 100000;
         $user->save();
 

--- a/tests/Unit/HamillManoeuvreTest.php
+++ b/tests/Unit/HamillManoeuvreTest.php
@@ -3,11 +3,15 @@
 namespace Tests\Unit;
 
 use Illuminate\Contracts\Container\BindingResolutionException;
+use OGame\Factories\PlanetServiceFactory;
 use OGame\GameMissions\BattleEngine\Models\AttackerFleet;
+use OGame\GameMissions\BattleEngine\Models\DefenderFleet;
 use OGame\GameMissions\BattleEngine\PhpBattleEngine;
 use OGame\GameObjects\Models\Units\UnitCollection;
 use OGame\Models\Resources;
 use OGame\Services\ObjectService;
+use OGame\Services\PlanetService;
+use OGame\Services\PlayerService;
 use OGame\Services\SettingsService;
 use Tests\AccountTestCase;
 
@@ -28,8 +32,11 @@ class HamillManoeuvreTest extends AccountTestCase
         parent::setUp();
 
         // Create a second planet for the same user to act as defender
-        $planetServiceFactory = resolve(\OGame\Factories\PlanetServiceFactory::class);
+        $planetServiceFactory = resolve(PlanetServiceFactory::class);
         $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('Player not found.');
+        }
 
         // Determine a new planet position
         $coordinate = $planetServiceFactory->determineNewPlanetPosition();
@@ -42,15 +49,15 @@ class HamillManoeuvreTest extends AccountTestCase
      * Helper method to create a battle engine with the new multi-attacker architecture.
      *
      * @param UnitCollection $attackerFleet
-     * @param \OGame\Services\PlayerService $player
-     * @param \OGame\Services\PlanetService $defenderPlanet
-     * @param \OGame\Services\SettingsService $settingsService
+     * @param PlayerService $player
+     * @param PlanetService $defenderPlanet
+     * @param SettingsService $settingsService
      * @return PhpBattleEngine
      */
-    private function createBattleEngine(UnitCollection $attackerFleet, \OGame\Services\PlayerService $player, \OGame\Services\PlanetService $defenderPlanet, \OGame\Services\SettingsService $settingsService): PhpBattleEngine
+    private function createBattleEngine(UnitCollection $attackerFleet, PlayerService $player, PlanetService $defenderPlanet, SettingsService $settingsService): PhpBattleEngine
     {
         // Create defenders array with planet's stationary forces
-        $defenders = [\OGame\GameMissions\BattleEngine\Models\DefenderFleet::fromPlanet($defenderPlanet)];
+        $defenders = [DefenderFleet::fromPlanet($defenderPlanet)];
 
         // Convert UnitCollection to AttackerFleet for the new multi-attacker architecture
         $attacker = new AttackerFleet();
@@ -74,6 +81,9 @@ class HamillManoeuvreTest extends AccountTestCase
     {
         // Set up General class player
         $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('Player not found.');
+        }
         $user = $player->getUser();
         $user->character_class = 2; // General class
         $user->save();
@@ -84,6 +94,9 @@ class HamillManoeuvreTest extends AccountTestCase
 
         // Create defender planet with 1 Deathstar
         $defenderPlanet = $this->secondPlanetService;
+        if ($defenderPlanet === null) {
+            $this->fail('Second planet service not initialized.');
+        }
         $defenderPlanet->addUnit('deathstar', 1);
 
         // Create attacker fleet with Light Fighters
@@ -115,6 +128,9 @@ class HamillManoeuvreTest extends AccountTestCase
     {
         // Set up Collector class player
         $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('Player not found.');
+        }
         $user = $player->getUser();
         $user->character_class = 1; // Collector class
         $user->save();
@@ -125,6 +141,9 @@ class HamillManoeuvreTest extends AccountTestCase
 
         // Create defender planet with 1 Deathstar
         $defenderPlanet = $this->secondPlanetService;
+        if ($defenderPlanet === null) {
+            $this->fail('Second planet service not initialized.');
+        }
         $defenderPlanet->addUnit('deathstar', 1);
 
         // Create attacker fleet with Light Fighters
@@ -153,6 +172,9 @@ class HamillManoeuvreTest extends AccountTestCase
     {
         // Set up General class player
         $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('Player not found.');
+        }
         $user = $player->getUser();
         $user->character_class = 2; // General class
         $user->save();
@@ -163,6 +185,9 @@ class HamillManoeuvreTest extends AccountTestCase
 
         // Create defender planet with 1 Deathstar
         $defenderPlanet = $this->secondPlanetService;
+        if ($defenderPlanet === null) {
+            $this->fail('Second planet service not initialized.');
+        }
         $defenderPlanet->addUnit('deathstar', 1);
 
         // Create attacker fleet WITHOUT Light Fighters (use Heavy Fighters instead)
@@ -191,6 +216,9 @@ class HamillManoeuvreTest extends AccountTestCase
     {
         // Set up General class player
         $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('Player not found.');
+        }
         $user = $player->getUser();
         $user->character_class = 2; // General class
         $user->save();
@@ -201,6 +229,9 @@ class HamillManoeuvreTest extends AccountTestCase
 
         // Create defender planet WITHOUT Deathstar
         $defenderPlanet = $this->secondPlanetService;
+        if ($defenderPlanet === null) {
+            $this->fail('Second planet service not initialized.');
+        }
         $defenderPlanet->addUnit('battle_ship', 10);
 
         // Create attacker fleet with Light Fighters
@@ -226,6 +257,9 @@ class HamillManoeuvreTest extends AccountTestCase
     {
         // Set up General class player
         $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('Player not found.');
+        }
         $user = $player->getUser();
         $user->character_class = 2; // General class
         $user->save();
@@ -236,6 +270,9 @@ class HamillManoeuvreTest extends AccountTestCase
 
         // Create defender planet with 3 Deathstars
         $defenderPlanet = $this->secondPlanetService;
+        if ($defenderPlanet === null) {
+            $this->fail('Second planet service not initialized.');
+        }
         $defenderPlanet->addUnit('deathstar', 3);
 
         // Create attacker fleet with Light Fighters


### PR DESCRIPTION
## Description
This PR raises the PHPStan level from 7 to 8, enabling full null-safety enforcement across the codebase.

### Type of Change:
- [ ] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [x] Other (please describe):

## Related Issues
Fixes #121 

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [x] **Automated Refactoring:** Rector has been run and no outstanding issues remain.
- [x] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [x] **Static Analysis:** Code passes PHPStan static code analysis.
- [x] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [x] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [x] **Documentation:** Documentation has been updated to reflect any changes made.

## Additional Information
Add any additional context, screenshots, or explanations to help reviewers understand your PR. If this change introduces any breaking changes or significant impacts, please detail them here.
