### PR TITLE
chore(docker): add .dockerignore to keep .git out of the build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,20 @@
+# Keep the Docker build context (and the resulting image layers) small so
+# `COPY . /var/www/` does not run the CI runner out of disk. Large PRs were
+# failing the preview build with "no space left on device" because the whole
+# ~400MB .git history was being copied into the image.
+
+# Version control & CI metadata — never needed inside the app image
+.git
+.gitattributes
+.github
+
+# Dependencies are provided inside the container, not from the build context:
+#  - vendor/       -> reinstalled at startup by docker/entrypoint.sh (`composer install`)
+#  - node_modules/ -> not needed at runtime; frontend assets are pre-built and
+#                     committed under public/build/
+node_modules
+vendor
+
+# Editor / IDE
+.idea
+.vscode


### PR DESCRIPTION
## Problem

`Dockerfile` builds the image with `COPY . /var/www/`, and the repo has **no `.dockerignore`**, so the entire working tree — including the ~400 MB `.git` directory — is copied into every image. On large PRs this fills the CI runner disk during layer extraction and the **preview environment build fails**:

```
ERROR: failed to extract layer …: write /var/www/.git/objects/pack/pack-….pack: no space left on device
```

## Fix

Add a `.dockerignore` that keeps build-only / never-needed content out of the build context and image:

- **`.git`, `.gitattributes`, `.github`** — version-control / CI metadata, never needed at runtime (this is the big one, ~400 MB).
- **`vendor/`** — reinstalled at container startup by `docker/entrypoint.sh` (`composer install`), so it does not need to be copied in.
- **`node_modules/`** — not needed at runtime; frontend assets are pre-built and committed under `public/build/`.
- **`.idea/`, `.vscode/`** — editor files.

`storage/`, `bootstrap/cache/`, `rust/` and `public/build/` are intentionally left untouched — they are needed at runtime and the first three are already copied explicitly in the `Dockerfile`.

## Effect

Shrinks the build context and resolves the "no space left on device" preview-build failures on large PRs (e.g. #1297). No behavioural change to the app.
