### PR TITLE
Implement technology tab in object popup

### DIFF
--- a/app/Http/Controllers/TechtreeController.php
+++ b/app/Http/Controllers/TechtreeController.php
@@ -80,6 +80,9 @@ class TechtreeController extends OGameController
         } elseif ($tab === 3) {
             return view('ingame.techtree.technology')->with([
                 'object' => $object,
+                'technology_categories' => $this->getTechnologyCategories(
+                    $player->planets->current()
+                ),
             ]);
         } elseif ($tab === 4) {
             return view('ingame.techtree.applications')->with([
@@ -405,6 +408,110 @@ class TechtreeController extends OGameController
             'astrophysics_table' => $astrophysics_table,
             'current_level' => $current_level,
         ]);
+    }
+
+    /**
+     * Returns all game objects grouped by their technology category.
+     *
+     * @param PlanetService $planet
+     * @return array<string, array<int, array{
+     *     object: GameObject,
+     *     requirements: array<int, array{
+     *         object: GameObject,
+     *         current_level: int,
+     *         required_level: int,
+     *         fulfilled: bool
+     *     }>
+     * }>>
+     */
+    private function getTechnologyCategories(PlanetService $planet): array
+    {
+        return [
+            't_ingame.techtree.category_construction' => $this->getTechnologyObjects(
+                [
+                    ...ObjectService::getBuildingObjects(),
+                    ...ObjectService::getStationObjects(),
+                ],
+                $planet
+            ),
+            't_ingame.techtree.category_research' => $this->getTechnologyObjects(
+                ObjectService::getResearchObjects(),
+                $planet
+            ),
+            't_ingame.techtree.category_shipyard' => $this->getTechnologyObjects(
+                ObjectService::getShipObjects(),
+                $planet
+            ),
+            't_ingame.techtree.category_defense' => $this->getTechnologyObjects(
+                ObjectService::getDefenseObjects(),
+                $planet
+            ),
+        ];
+    }
+
+    /**
+     * Builds the technology overview data for the given objects.
+     *
+     * @param array<GameObject> $objects
+     * @param PlanetService $planet
+     * @return array<int, array{
+     *     object: GameObject,
+     *     requirements: array<int, array{
+     *         object: GameObject,
+     *         current_level: int,
+     *         required_level: int,
+     *         fulfilled: bool
+     *     }>
+     * }>
+     */
+    private function getTechnologyObjects(array $objects, PlanetService $planet): array
+    {
+        $technology_objects = [];
+
+        foreach ($objects as $object) {
+            $requirements = [];
+
+            foreach ($object->requirements as $requirement) {
+                $requirement_object = ObjectService::getObjectByMachineName(
+                    $requirement->object_machine_name
+                );
+
+                $current_level = $this->getTechnologyObjectLevel(
+                    $requirement_object,
+                    $planet
+                );
+
+                $requirements[] = [
+                    'object' => $requirement_object,
+                    'current_level' => $current_level,
+                    'required_level' => $requirement->level,
+                    'fulfilled' => $current_level >= $requirement->level,
+                ];
+            }
+
+            $technology_objects[] = [
+                'object' => $object,
+                'requirements' => $requirements,
+            ];
+        }
+
+        return $technology_objects;
+    }
+
+    /**
+     * Returns the current level of a building or research object.
+     */
+    private function getTechnologyObjectLevel(
+        GameObject $object,
+        PlanetService $planet
+    ): int {
+        if ($object->type === GameObjectType::Research) {
+            return $planet->getPlayer()?->getResearchLevel(
+                $object->machine_name
+            ) ?? 0;
+        }
+
+        return $planet->getObjectLevel($object->machine_name);
     }
 
     /**

--- a/resources/lang/en/t_ingame.php
+++ b/resources/lang/en/t_ingame.php
@@ -930,7 +930,6 @@ return [
         'is_requirement_for'                    => 'is a requirement for',
         'level'                                 => 'Level',
 
-        // Categories
         'category_construction' => 'Construction',
         'category_research' => 'Research',
         'category_shipyard' => 'Shipyard',

--- a/resources/lang/en/t_ingame.php
+++ b/resources/lang/en/t_ingame.php
@@ -930,6 +930,12 @@ return [
         'is_requirement_for'                    => 'is a requirement for',
         'level'                                 => 'Level',
 
+        // Categories
+        'category_construction' => 'Construction',
+        'category_research' => 'Research',
+        'category_shipyard' => 'Shipyard',
+        'category_defense' => 'Defense',
+
         // Shared table columns
         'col_level'                             => 'Level',
         'col_difference'                        => 'Difference',

--- a/resources/lang/it/t_ingame.php
+++ b/resources/lang/it/t_ingame.php
@@ -909,7 +909,6 @@ return [
         'is_requirement_for'                    => 'è un requisito per',
         'level'                                 => 'Livello',
 
-        // Categorie
         'category_construction' => 'Costruzione',
         'category_research' => 'Ricerca',
         'category_shipyard' => 'Cantiere navale',

--- a/resources/lang/it/t_ingame.php
+++ b/resources/lang/it/t_ingame.php
@@ -909,6 +909,12 @@ return [
         'is_requirement_for'                    => 'è un requisito per',
         'level'                                 => 'Livello',
 
+        // Categorie
+        'category_construction' => 'Costruzione',
+        'category_research' => 'Ricerca',
+        'category_shipyard' => 'Cantiere navale',
+        'category_defense' => 'Difesa',
+
         // Colonne tabella condivise
         'col_level'                             => 'Livello',
         'col_difference'                        => 'Differenza',

--- a/resources/lang/nl/t_ingame.php
+++ b/resources/lang/nl/t_ingame.php
@@ -909,6 +909,12 @@ return [
         'is_requirement_for'                    => 'is een vereiste voor',
         'level'                                 => 'Niveau',
 
+        // Categorieën
+        'category_construction' => 'Bouw',
+        'category_research' => 'Onderzoek',
+        'category_shipyard' => 'Scheepswerf',
+        'category_defense' => 'Verdediging',
+
         // Gedeelde tabelkolommen
         'col_level'                             => 'Niveau',
         'col_difference'                        => 'Verschil',

--- a/resources/lang/nl/t_ingame.php
+++ b/resources/lang/nl/t_ingame.php
@@ -909,7 +909,6 @@ return [
         'is_requirement_for'                    => 'is een vereiste voor',
         'level'                                 => 'Niveau',
 
-        // Categorieën
         'category_construction' => 'Bouw',
         'category_research' => 'Onderzoek',
         'category_shipyard' => 'Scheepswerf',

--- a/resources/lang/zh-TW/t_ingame.php
+++ b/resources/lang/zh-TW/t_ingame.php
@@ -800,6 +800,11 @@ return [
         'is_requirement_for'                    => '是...的需求',
         'level'                                 => '等級',
 
+        'category_construction' => '建造',
+        'category_research' => '研究',
+        'category_shipyard' => '船塢',
+        'category_defense' => '防禦',
+
         'col_level'                             => '等級',
         'col_difference'                        => '差異',
         'col_diff_per_level'                    => '差異/等級',

--- a/resources/views/ingame/techtree/technology.blade.php
+++ b/resources/views/ingame/techtree/technology.blade.php
@@ -1,10 +1,72 @@
-<div id="technologytree" data-title="{{ __('t_ingame.techtree.page_title') }} - {{ $object->title }}">
-    @include('ingame.techtree.partials.nav', ['currentAction' => 'technologies', 'objectId' => $object->id])
+<div id="technologytree" data-title="{{ __('t_ingame.techtree.page_title') }}">
+    @include('ingame.techtree.partials.nav', [
+        'currentAction' => 'technologies',
+        'objectId' => $object->id,
+    ])
 
-    <div class="content technology">
-        <p class="hint">
-            {{ __('t_ingame.techtree.no_requirements') }}
-        </p>
+    <div class="content technologies">
+        @foreach ($technology_categories as $category_title => $technologies)
+            <h1
+                class="technology-category"
+                role="button"
+                tabindex="0"
+                aria-expanded="false"
+            >
+                {{ __($category_title) }}
+            </h1>
+
+            <ul>
+                @foreach ($technologies as $technology)
+                    @php
+                        $technology_object = $technology['object'];
+                    @endphp
+
+                    <li data-object="{{ $technology_object->machine_name }}">
+                        <a
+                            href="{{ route('techtree.ajax', [
+                                'tab' => 1,
+                                'object_id' => $technology_object->id,
+                            ]) }}"
+                            class="technology sprite_before sprite_small {{ $technology_object->class_name }} overlay tooltipHTML"
+                            data-overlay-same="true"
+                            title="{{ $technology_object->title }}|{{ $technology_object->description }}"
+                        >
+                            {{ $technology_object->title }}
+                        </a>
+
+                        @if (!empty($technology['requirements']))
+                            <a
+                                href="{{ route('techtree.ajax', [
+                                    'tab' => 1,
+                                    'object_id' => $technology_object->id,
+                                ]) }}"
+                                class="prerequisites overlay"
+                                data-overlay-same="true"
+                            >
+                                @foreach ($technology['requirements'] as $requirement)
+                                    <span
+                                        class="{{ $requirement['fulfilled'] ? 'fulfilled' : 'unfulfilled' }}"
+                                        data-requirement="{{ $requirement['object']->machine_name }}"
+                                        data-current-level="{{ $requirement['current_level'] }}"
+                                        data-required-level="{{ $requirement['required_level'] }}"
+                                        data-requirement-met="{{ $requirement['fulfilled'] ? 'true' : 'false' }}"
+                                    >
+                                        {{ $requirement['object']->title }}
+                                        ({{ __('t_ingame.techtree.level') }}
+                                        @if ($requirement['fulfilled'])
+                                            {{ $requirement['required_level'] }}
+                                        @else
+                                            {{ $requirement['current_level'] }}/{{ $requirement['required_level'] }}
+                                        @endif
+                                        )
+                                    </span>
+                                @endforeach
+                            </a>
+                        @endif
+                    </li>
+                @endforeach
+            </ul>
+        @endforeach
     </div>
 </div>
 
@@ -12,6 +74,52 @@
     $(
         function(){
             initOverlayName();
+
+            const $technologyContent = $('#technologytree .content.technologies');
+            const $categoryHeadings = $technologyContent.children('.technology-category');
+            const $categoryLists = $technologyContent.children('ul');
+
+            function closeCategories() {
+                $categoryLists.stop(true, true).hide();
+                $categoryHeadings.attr('aria-expanded', 'false');
+            }
+
+            function openCategory($heading) {
+                $heading
+                    .attr('aria-expanded', 'true')
+                    .next('ul')
+                    .stop(true, true)
+                    .show();
+            }
+
+            closeCategories();
+            openCategory($categoryHeadings.first());
+
+            $categoryHeadings
+                .off('.technologyCategories')
+                .on(
+                    'click.technologyCategories keydown.technologyCategories',
+                    function(event) {
+                        if (
+                            event.type === 'keydown'
+                            && event.key !== 'Enter'
+                            && event.key !== ' '
+                        ) {
+                            return;
+                        }
+
+                        event.preventDefault();
+
+                        const $heading = $(this);
+                        const isOpen = $heading.attr('aria-expanded') === 'true';
+
+                        closeCategories();
+
+                        if (!isOpen) {
+                            openCategory($heading);
+                        }
+                    }
+                );
         }
     );
 </script>

--- a/tests/Feature/TechtreeTest.php
+++ b/tests/Feature/TechtreeTest.php
@@ -141,4 +141,79 @@ class TechtreeTest extends AccountTestCase
             }
         }
     }
+
+    /**
+     * Verify that technology overview popups return HTTP 200 for all objects.
+     */
+    public function testTechtreeTechnologyPopupsHttp200(): void
+    {
+        foreach (ObjectService::getObjects() as $object) {
+            $response = $this->get(
+                'ajax/techtree?tab=3&object_id=' . $object->id
+            );
+
+            try {
+                $response->assertStatus(200);
+            } catch (AssertionFailedError $e) {
+                $this->fail(
+                    'AJAX technology page for "' .
+                    $object->title .
+                    '" does not return HTTP 200.'
+                );
+            }
+        }
+    }
+
+    /**
+     * Verify that technology requirements show their current status.
+     */
+    public function testTechtreeTechnologyPopupRequirementStatus(): void
+    {
+        $object = ObjectService::getObjectByMachineName('metal_mine');
+
+        $this->planetSetObjectLevel('deuterium_synthesizer', 0);
+        $this->playerSetResearchLevel('energy_technology', 0);
+
+        $response = $this->get(
+            'ajax/techtree?tab=3&object_id=' . $object->id
+        );
+
+        $response->assertStatus(200);
+        $response->assertSee('data-object="fusion_plant"', false);
+
+        $response->assertSeeInOrder([
+            'data-requirement="deuterium_synthesizer"',
+            'data-current-level="0"',
+            'data-required-level="5"',
+            'data-requirement-met="false"',
+        ], false);
+
+        $response->assertSeeInOrder([
+            'data-requirement="energy_technology"',
+            'data-current-level="0"',
+            'data-required-level="3"',
+            'data-requirement-met="false"',
+        ], false);
+
+        $this->planetSetObjectLevel('deuterium_synthesizer', 5);
+        $this->playerSetResearchLevel('energy_technology', 3);
+
+        $response = $this->get(
+            'ajax/techtree?tab=3&object_id=' . $object->id
+        );
+
+        $response->assertSeeInOrder([
+            'data-requirement="deuterium_synthesizer"',
+            'data-current-level="5"',
+            'data-required-level="5"',
+            'data-requirement-met="true"',
+        ], false);
+
+        $response->assertSeeInOrder([
+            'data-requirement="energy_technology"',
+            'data-current-level="3"',
+            'data-required-level="3"',
+            'data-requirement-met="true"',
+        ], false);
+    }
 }


### PR DESCRIPTION
## Summary

Implements the Technology tab displayed in the object information popup.

The tab now provides a categorized overview of buildings, research, ships, and defenses, including their prerequisite status and required levels.

## Changes

- Add categorized technology overview for:
  - Construction
  - Research
  - Shipyard
  - Defense
- Display object images and names
- Display fulfilled and unfulfilled prerequisites
- Show current and required levels for unmet prerequisites
- Add accordion behavior for technology categories
- Add translations for all currently supported languages
- Add feature tests for popup availability and prerequisite status

## Testing

- `php artisan test --filter TechtreeTest`
  - 7 tests passed
  - 305 assertions
- `composer run cs -- --test`
  - Passed
- `composer run stan`
  - Passed
- Manually tested the popup and category accordion

## Note

`npm run build` is currently blocked by pre-existing legacy CSS syntax in the main branch, including invalid single-line CSS comments and IE-specific selectors. This pull request does not modify CSS files.

Closes #152