### PR TITLE
Fix recycle mission auto-selection on position 16

### DIFF
--- a/resources/js/ingame/e7c74974620fa35b197315ebdbb8c2.js
+++ b/resources/js/ingame/e7c74974620fa35b197315ebdbb8c2.js
@@ -33937,7 +33937,7 @@ FleetDispatcher.prototype.validateMissions = function () {
 };
 
 FleetDispatcher.prototype.refreshMissions = function () {
-  $('#missions>li>a.selected').removeClass('selected'); //select expedition if no mission is selected and if it is the only one available
+  $('#missions>li>a.selected').removeClass('selected');
 
   if (this.isOnlyMissionAvailable(this.fleetHelper.MISSION_EXPEDITION)) {
     if (this.hasMission() === false) {
@@ -33945,6 +33945,10 @@ FleetDispatcher.prototype.refreshMissions = function () {
     }
 
     this.updateExpeditionTime();
+  }
+
+  if (this.isOnlyMissionAvailable(this.fleetHelper.MISSION_RECYCLE) && this.hasMission() === false) {
+    this.selectMission(this.fleetHelper.MISSION_RECYCLE);
   } // refresh mission buttons
 
 


### PR DESCRIPTION
## Summary

Automatically selects the Recycle mission when it is the only available mission for an expedition debris field on position 16.

## Changes

- Add automatic Recycle mission selection when it is the only available mission
- Keep the existing Expedition auto-selection behavior unchanged
- Avoid changing mission selection when multiple missions are available

## Testing

- `git diff --check`
- `node --check resources/js/ingame/e7c74974620fa35b197315ebdbb8c2.js`
- Manually tested with:
  - Pathfinder selected
  - Expedition debris field at position 16
  - Recycle confirmed as the only available mission
  - Recycle automatically selected on Fleet Dispatch II

## Note

`npm run build` was not executed due to the pre-existing legacy CSS syntax issues in the main branch.

Closes #1514