### PR TITLE
Fix Facilities shortcut to open Space Dock

### DIFF
--- a/resources/views/ingame/layouts/main.blade.php
+++ b/resources/views/ingame/layouts/main.blade.php
@@ -552,8 +552,20 @@
                     <li>
                         <span class="menu_icon">
                             @if ($currentPlanet->isMoon() && $currentPlanet->getObjectLevel('jump_gate') > 0)
-                                <a href="{{ route('jumpgate.index') }}" class="overlay tooltipRight js_hideTipOnMobile" target="_self" data-overlay-title="{{ __('t_ingame.layout.menu_jump_gate') }}" title="{{ __('t_ingame.layout.menu_jump_gate') }}">
-                                    <div class="menuImage station highlighted ipiHintable" data-ipi-hint="ipiToolbarJumpgate"></div>
+                                <a href="{{ route('jumpgate.index') }}"
+                                class="overlay tooltipRight js_hideTipOnMobile"
+                                target="_self"
+                                data-overlay-title="{{ __('t_ingame.layout.menu_jump_gate') }}"
+                                title="{{ __('t_ingame.layout.menu_jump_gate') }}">
+                                    <div class="menuImage station highlighted ipiHintable"
+                                        data-ipi-hint="ipiToolbarJumpgate"></div>
+                                </a>
+                            @elseif ($currentPlanet->isPlanet())
+                                <a href="{{ route('facilities.index') }}?openSpaceDock=1"
+                                class="tooltipRight js_hideTipOnMobile"
+                                target="_self"
+                                title="{{ __('t_resources.space_dock.title') }}">
+                                    <div class="menuImage station"></div>
                                 </a>
                             @else
                                 <div class="menuImage station"></div>

--- a/tests/Feature/FacilitiesMenuShortcutTest.php
+++ b/tests/Feature/FacilitiesMenuShortcutTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\AccountTestCase;
+
+class FacilitiesMenuShortcutTest extends AccountTestCase
+{
+    public function test_facilities_menu_shortcut_opens_space_dock_on_planet(): void
+    {
+        $response = $this->get(route('overview.index'));
+
+        $response->assertStatus(200);
+
+        $spaceDockUrl = route('facilities.index') . '?openSpaceDock=1';
+
+        $response->assertSee(
+            'href="' . $spaceDockUrl . '"',
+            false
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Updates the shortcut icon next to Facilities so that, on planets, it opens the Facilities page with the Space Dock selected automatically.

The existing Jump Gate shortcut behavior on moons is preserved.

## Changes

- Make the Facilities shortcut icon clickable on planets
- Redirect the shortcut to `/facilities?openSpaceDock=1`
- Reuse the existing Space Dock auto-open behavior
- Preserve the existing Jump Gate shortcut on moons
- Add regression coverage for the Facilities shortcut

## Testing

- `php artisan test --filter FacilitiesMenuShortcutTest`
  - 1 test passed
  - 7 assertions
- `php artisan test --filter FacilitiesWreckFieldTest`
  - 13 tests passed
  - 118 assertions
- `git diff --check`
- Manually verified on a planet without a wreck field:
  - Facilities shortcut redirects to `/facilities?openSpaceDock=1`
  - Space Dock details open automatically

Closes #1539