### PR TITLE
Implement battle engine tactical retreat (#294)

### DIFF
--- a/app/Console/Commands/Test/TestBattleEnginePerformance.php
+++ b/app/Console/Commands/Test/TestBattleEnginePerformance.php
@@ -88,6 +88,12 @@ class TestBattleEnginePerformance extends TestCommand
         $this->playerService->setResearchLevel('shielding_technology', 10);
         $this->playerService->setResearchLevel('armor_technology', 10);
 
+        // simulateBattle() evaluates tactical retreat and may deduct deuterium / strip
+        // defending ships. Disable flee so the benchmark measures combat, not retreat.
+        $benchmarkUser = $this->playerService->getUser();
+        $benchmarkUser->tactical_retreat_ratio = 0;
+        $benchmarkUser->save();
+
         // Set up defender planet with provided units
         foreach ($fleets['defender']->units as $unit) {
             $this->currentPlanetService->addUnit($unit->unitObject->machine_name, $unit->amount);

--- a/app/GameMessages/BattleReport.php
+++ b/app/GameMessages/BattleReport.php
@@ -305,6 +305,8 @@ class BattleReport extends GameMessage
         $moonChance = 0;
         $moonCreated = false;
         $hamillManoeuvreTriggered = false;
+        $tacticalRetreatRatio = 1;
+        $tacticalRetreatDefenderFled = false;
 
         if (isset($battleReportModel->general['moon_existed'])) {
             $moonExisted = $battleReportModel->general['moon_existed'];
@@ -317,6 +319,12 @@ class BattleReport extends GameMessage
         }
         if (isset($battleReportModel->general['hamill_manoeuvre_triggered'])) {
             $hamillManoeuvreTriggered = $battleReportModel->general['hamill_manoeuvre_triggered'];
+        }
+        if (isset($battleReportModel->general['tactical_retreat']['ratio'])) {
+            $tacticalRetreatRatio = (int)$battleReportModel->general['tactical_retreat']['ratio'];
+        }
+        if (isset($battleReportModel->general['tactical_retreat']['defender_fled'])) {
+            $tacticalRetreatDefenderFled = (bool)$battleReportModel->general['tactical_retreat']['defender_fled'];
         }
 
         // Load attacker player
@@ -444,6 +452,8 @@ class BattleReport extends GameMessage
             'moon_chance' => $moonChance,
             'moon_created' => $moonCreated,
             'hamill_manoeuvre_triggered' => $hamillManoeuvreTriggered,
+            'tactical_retreat_ratio' => $tacticalRetreatRatio,
+            'tactical_retreat_defender_fled' => $tacticalRetreatDefenderFled,
             'attacker_weapons' => $attacker_weapons,
             'attacker_shields' => $attacker_shields,
             'attacker_armor' => $attacker_armor,

--- a/app/GameMessages/BattleReport.php
+++ b/app/GameMessages/BattleReport.php
@@ -307,6 +307,7 @@ class BattleReport extends GameMessage
         $hamillManoeuvreTriggered = false;
         $tacticalRetreatRatio = 1;
         $tacticalRetreatDefenderFled = false;
+        $tacticalRetreatDeuteriumCost = 0;
 
         if (isset($battleReportModel->general['moon_existed'])) {
             $moonExisted = $battleReportModel->general['moon_existed'];
@@ -325,6 +326,9 @@ class BattleReport extends GameMessage
         }
         if (isset($battleReportModel->general['tactical_retreat']['defender_fled'])) {
             $tacticalRetreatDefenderFled = (bool)$battleReportModel->general['tactical_retreat']['defender_fled'];
+        }
+        if (isset($battleReportModel->general['tactical_retreat']['deuterium_cost'])) {
+            $tacticalRetreatDeuteriumCost = (int)$battleReportModel->general['tactical_retreat']['deuterium_cost'];
         }
 
         // Load attacker player
@@ -454,6 +458,8 @@ class BattleReport extends GameMessage
             'hamill_manoeuvre_triggered' => $hamillManoeuvreTriggered,
             'tactical_retreat_ratio' => $tacticalRetreatRatio,
             'tactical_retreat_defender_fled' => $tacticalRetreatDefenderFled,
+            'tactical_retreat_deuterium_cost' => $tacticalRetreatDeuteriumCost,
+            'tactical_retreat_deuterium_cost_formatted' => AppUtil::formatNumberLong($tacticalRetreatDeuteriumCost),
             'attacker_weapons' => $attacker_weapons,
             'attacker_shields' => $attacker_shields,
             'attacker_armor' => $attacker_armor,

--- a/app/GameMissions/Abstracts/GameMission.php
+++ b/app/GameMissions/Abstracts/GameMission.php
@@ -269,7 +269,7 @@ abstract class GameMission
      * @return FleetMission The created fleet mission.
      * @throws Exception
      */
-    public function start(PlanetService $planet, Coordinate $targetCoordinate, PlanetType $targetType, UnitCollection $units, Resources $resources, float $speedPercent, int $holdingHours = 0, int $parentId = 0): FleetMission
+    public function start(PlanetService $planet, Coordinate $targetCoordinate, PlanetType $targetType, UnitCollection $units, Resources $resources, float $speedPercent, int $holdingHours = 0, int $parentId = 0, bool $retreatAfterDefenderRetreat = false): FleetMission
     {
         $consumption = $this->fleetMissionService->calculateConsumption($planet, $units, $targetCoordinate, $holdingHours, $speedPercent);
         $consumption_resources = new Resources(0, 0, $consumption, 0);
@@ -374,6 +374,7 @@ abstract class GameMission
         $mission->metal = $resources->metal->getRounded();
         $mission->crystal = $resources->crystal->getRounded();
         $mission->deuterium = $resources->deuterium->getRounded();
+        $mission->retreat_after_defender_retreat = $retreatAfterDefenderRetreat;
 
         // Deduct mission resources from the planet.
         $this->deductMissionResources($planet, $deduct_resources, $units);

--- a/app/GameMissions/AttackMission.php
+++ b/app/GameMissions/AttackMission.php
@@ -126,6 +126,7 @@ class AttackMission extends GameMission
                 break;
         }
 
+        $battleEngine->setRetreatAfterDefenderRetreat((bool)$mission->retreat_after_defender_retreat);
         $battleResult = $battleEngine->simulateBattle();
 
         // Set the attacker's origin planet ID on the battle result for the battle report.
@@ -679,6 +680,18 @@ class AttackMission extends GameMission
             'moon_chance' => $battleResult->moonChance,
             'moon_created' => $battleResult->moonCreated,
             'hamill_manoeuvre_triggered' => $battleResult->hamillManoeuvreTriggered,
+            'tactical_retreat' => [
+                'ratio' => $battleResult->tacticalRetreatRatio,
+                'attacker_points' => $battleResult->tacticalRetreatAttackerPoints,
+                'defender_points' => $battleResult->tacticalRetreatDefenderPoints,
+                'defender_fled' => $battleResult->tacticalRetreatDefenderFled,
+                'attacker_also_retreated' => $battleResult->tacticalRetreatAttackerAlsoRetreated,
+                'deuterium_cost' => $battleResult->tacticalRetreatDeuteriumCost,
+                'by' => $battleResult->tacticalRetreatDefenderFled
+                    ? ($battleResult->tacticalRetreatAttackerAlsoRetreated ? 'both' : 'defender')
+                    : 'none',
+                'supremacy' => $battleResult->tacticalRetreatAttackerPoints,
+            ],
         ];
 
         $characterClassService = app(CharacterClassService::class);

--- a/app/GameMissions/BattleEngine/BattleEngine.php
+++ b/app/GameMissions/BattleEngine/BattleEngine.php
@@ -11,6 +11,7 @@ use OGame\GameMissions\BattleEngine\Models\DefenderFleet;
 use OGame\GameMissions\BattleEngine\Models\DefenderFleetResult;
 use OGame\GameMissions\BattleEngine\Services\DefenseRepairService;
 use OGame\GameMissions\BattleEngine\Services\LootService;
+use OGame\GameMissions\BattleEngine\Services\TacticalRetreatService;
 use OGame\GameObjects\Models\Enums\GameObjectType;
 use OGame\GameObjects\Models\Units\UnitCollection;
 use OGame\Models\Resources;
@@ -40,6 +41,11 @@ abstract class BattleEngine
     private int $lootPercentage = 50;
 
     /**
+     * @var bool Whether the attacking initiator withdraws if the defender flees.
+     */
+    protected bool $retreatAfterDefenderRetreat = false;
+
+    /**
      * BattleEngine constructor.
      *
      * @param array<AttackerFleet> $attackers All attacking fleets.
@@ -59,6 +65,16 @@ abstract class BattleEngine
         // Determine loot percentage based on character class and defender status
         $characterClassService = app(CharacterClassService::class);
         $this->lootPercentage = (int)($characterClassService->getInactiveLootPercentage($primaryAttacker->player->getUser()) * 100);
+    }
+
+    /**
+     * Configure whether attackers withdraw without a fight when the defender flees.
+     */
+    public function setRetreatAfterDefenderRetreat(bool $retreatAfterDefenderRetreat): self
+    {
+        $this->retreatAfterDefenderRetreat = $retreatAfterDefenderRetreat;
+
+        return $this;
     }
 
     /**
@@ -161,35 +177,66 @@ abstract class BattleEngine
 
         $result->defenderUnitsResult = clone $result->defenderUnitsStart;
 
-        // Execute the battle rounds, this will handle the actual combat logic.
-        $result->rounds = $this->fightBattleRounds($result);
+        // Evaluate tactical retreat before combat rounds (shared by PHP and Rust engines).
+        $this->applyTacticalRetreat($result);
 
-        // Sanitize the round array to make sure that the remaining attacker and defender units
-        // for every round contain the starting unit types, even if there are no units of that type left.
-        // This is important for the battle report to show all units that were part of the battle on
-        // every round.
-        $result->rounds = $this->sanitizeRoundArray($result->rounds);
-
-        // Get the result of the battle.
-        if (count($result->rounds) > 0) {
-            // Take the remaining ships in the last round as the result.
-            $round = end($result->rounds);
-            $result->attackerUnitsResult = $round->attackerShips;
-            $result->defenderUnitsResult = $round->defenderShips;
+        if ($result->tacticalRetreatAttackerAlsoRetreated) {
+            // Both sides withdraw — no rounds, no losses, no loot from combat.
+            $result->rounds = [];
+            $result->attackerUnitsResult = clone $result->attackerUnitsStart;
+            $result->defenderUnitsResult = clone $result->defenderUnitsStart;
+            foreach ($result->attackerFleetResults as $fleetResult) {
+                $fleetResult->unitsResult = clone $fleetResult->unitsStart;
+                $fleetResult->unitsLost = new UnitCollection();
+                $fleetResult->completelyDestroyed = false;
+                $fleetResult->calculateResourceLoss();
+            }
+            foreach ($result->defenderFleetResults as $fleetResult) {
+                $fleetResult->unitsResult = clone $fleetResult->unitsStart;
+                $fleetResult->unitsLost = new UnitCollection();
+                $fleetResult->completelyDestroyed = false;
+            }
         } else {
-            // If no rounds were fought, the result is the same as the start.
-            $result->attackerUnitsResult = $result->attackerUnitsStart;
-            $result->defenderUnitsResult = $result->defenderUnitsStart;
+            // Execute the battle rounds, this will handle the actual combat logic.
+            $result->rounds = $this->fightBattleRounds($result);
+
+            // Sanitize the round array to make sure that the remaining attacker and defender units
+            // for every round contain the starting unit types, even if there are no units of that type left.
+            // This is important for the battle report to show all units that were part of the battle on
+            // every round.
+            $result->rounds = $this->sanitizeRoundArray($result->rounds);
+
+            // Get the result of the battle.
+            if (count($result->rounds) > 0) {
+                // Take the remaining ships in the last round as the result.
+                $round = end($result->rounds);
+                $result->attackerUnitsResult = $round->attackerShips;
+                $result->defenderUnitsResult = $round->defenderShips;
+            } else {
+                // If no rounds were fought, the result is the same as the start.
+                $result->attackerUnitsResult = $result->attackerUnitsStart;
+                $result->defenderUnitsResult = $result->defenderUnitsStart;
+            }
         }
 
         // Calculate the resources lost by the attacker and defender.
         // Deduct defender's lost units from the defenders planet.
+        // Only subtract unit types present in the start collection — sanitizeRoundArray may
+        // add zero-amount planet ships (e.g. fleed ships still on the planet) to round results.
         $result->attackerUnitsLost = clone $result->attackerUnitsStart;
-        $result->attackerUnitsLost->subtractCollection($result->attackerUnitsResult);
+        foreach ($result->attackerUnitsResult->units as $entry) {
+            if ($result->attackerUnitsLost->hasUnit($entry->unitObject)) {
+                $result->attackerUnitsLost->removeUnit($entry->unitObject, $entry->amount);
+            }
+        }
         $result->attackerResourceLoss = $result->attackerUnitsLost->toResources();
 
         $result->defenderUnitsLost = clone $result->defenderUnitsStart;
-        $result->defenderUnitsLost->subtractCollection($result->defenderUnitsResult);
+        foreach ($result->defenderUnitsResult->units as $entry) {
+            if ($result->defenderUnitsLost->hasUnit($entry->unitObject)) {
+                $result->defenderUnitsLost->removeUnit($entry->unitObject, $entry->amount);
+            }
+        }
 
         // Add Hamill Manoeuvre Deathstar loss if it was triggered
         if ($result->hamillManoeuvreTriggered) {
@@ -242,6 +289,70 @@ abstract class BattleEngine
         }
 
         return $result;
+    }
+
+    /**
+     * Evaluate and apply tactical retreat before combat rounds.
+     * Fleeing ships are removed from combat but remain on the planet.
+     */
+    protected function applyTacticalRetreat(BattleResult $result): void
+    {
+        $service = new TacticalRetreatService();
+        $decision = $service->evaluate(
+            $this->defenderPlanet,
+            $this->attackers,
+            $this->defenders,
+            $this->retreatAfterDefenderRetreat,
+        );
+
+        $result->tacticalRetreatRatio = $decision->ratio;
+        $result->tacticalRetreatAttackerPoints = $decision->attackerPoints;
+        $result->tacticalRetreatDefenderPoints = $decision->defenderPoints;
+        $result->tacticalRetreatDeuteriumCost = $decision->deuteriumCost;
+        $result->tacticalRetreatFleeingUnits = $decision->fleeingUnits;
+        $result->tacticalRetreatDefenderFled = $decision->defenderFled;
+        $result->tacticalRetreatAttackerAlsoRetreated = $decision->attackerAlsoRetreated;
+
+        if (!$decision->defenderFled) {
+            return;
+        }
+
+        // Deduct flee deuterium before loot calculation so cargo theft uses updated stocks.
+        if ($decision->deuteriumCost > 0) {
+            $this->defenderPlanet->deductResources(new Resources(0, 0, $decision->deuteriumCost, 0));
+        }
+
+        // Strip fleeing ships from the planet-owner defender fleet (ACS defend fleets stay).
+        foreach ($this->defenders as $defenderFleet) {
+            if ($defenderFleet->fleetMissionId !== 0) {
+                continue;
+            }
+
+            foreach ($decision->fleeingUnits->units as $entry) {
+                if ($defenderFleet->units->hasUnit($entry->unitObject)) {
+                    $defenderFleet->units->removeUnit($entry->unitObject, $entry->amount, true);
+                }
+            }
+        }
+
+        // Rebuild aggregated defender start units and planet-owner fleet result start.
+        $result->defenderUnitsStart = new UnitCollection();
+        foreach ($this->defenders as $defenderFleet) {
+            $result->defenderUnitsStart->addCollection($defenderFleet->units);
+        }
+        $result->defenderUnitsResult = clone $result->defenderUnitsStart;
+
+        foreach ($result->defenderFleetResults as $fleetResult) {
+            if ($fleetResult->fleetMissionId !== 0) {
+                continue;
+            }
+            foreach ($this->defenders as $defenderFleet) {
+                if ($defenderFleet->fleetMissionId === 0) {
+                    $fleetResult->unitsStart = clone $defenderFleet->units;
+                    break;
+                }
+            }
+        }
     }
 
     /**

--- a/app/GameMissions/BattleEngine/BattleEngine.php
+++ b/app/GameMissions/BattleEngine/BattleEngine.php
@@ -222,7 +222,7 @@ abstract class BattleEngine
         // Calculate the resources lost by the attacker and defender.
         // Deduct defender's lost units from the defenders planet.
         // Only subtract unit types present in the start collection — sanitizeRoundArray may
-        // add zero-amount planet ships (e.g. fleed ships still on the planet) to round results.
+        // still add zero-amount unit types that participated in combat but were wiped out.
         $result->attackerUnitsLost = clone $result->attackerUnitsStart;
         foreach ($result->attackerUnitsResult->units as $entry) {
             if ($result->attackerUnitsLost->hasUnit($entry->unitObject)) {
@@ -252,7 +252,10 @@ abstract class BattleEngine
         $result->repairedDefenses = $defenseRepairService->calculateRepairedDefenses($result->defenderUnitsLost);
 
         // Determine winner of battle.
-        if ($result->defenderUnitsResult->getAmount() === 0) {
+        // Attacker withdrawal after defender flee is not a combat win — never grant loot.
+        if ($result->tacticalRetreatAttackerAlsoRetreated) {
+            $result->loot = new Resources(0, 0, 0, 0);
+        } elseif ($result->defenderUnitsResult->getAmount() === 0) {
             // ---
             // [WIN] - If attacker wins:
             // ---
@@ -772,6 +775,13 @@ abstract class BattleEngine
     {
         $combinedAttackerFleet = $this->getAttackerFleet();
 
+        // Use post-retreat combat fleets so ships that fled are not padded into rounds
+        // as zero-amount "destroyed" units (they remain on the planet outside combat).
+        $combatDefenderUnits = new UnitCollection();
+        foreach ($this->defenders as $defenderFleet) {
+            $combatDefenderUnits->addCollection($defenderFleet->units);
+        }
+
         foreach ($rounds as $round) {
             // Ensure all attacker units are present in the round
             foreach ($combinedAttackerFleet->units as $unit) {
@@ -780,8 +790,8 @@ abstract class BattleEngine
                 }
             }
 
-            // Ensure all defender units are present in the round
-            foreach ($this->defenderPlanet->getShipUnits()->units as $unit) {
+            // Ensure all combat defender units are present in the round
+            foreach ($combatDefenderUnits->units as $unit) {
                 if (!$round->defenderShips->hasUnit($unit->unitObject)) {
                     $round->defenderShips->addUnit($unit->unitObject, 0);
                 }

--- a/app/GameMissions/BattleEngine/Models/BattleResult.php
+++ b/app/GameMissions/BattleEngine/Models/BattleResult.php
@@ -152,4 +152,39 @@ class BattleResult
      * has a small chance to instantly destroy one Deathstar at the start of battle.
      */
     public bool $hamillManoeuvreTriggered = false;
+
+    /**
+     * @var int Attacker supremacy ratio displayed as 1:N in the combat report.
+     */
+    public int $tacticalRetreatRatio = 1;
+
+    /**
+     * @var int Raw attacker retreat-weighted fleet points.
+     */
+    public int $tacticalRetreatAttackerPoints = 0;
+
+    /**
+     * @var int Raw defender retreat-weighted fleet points.
+     */
+    public int $tacticalRetreatDefenderPoints = 0;
+
+    /**
+     * @var bool Whether the defending planet fleet fled before combat.
+     */
+    public bool $tacticalRetreatDefenderFled = false;
+
+    /**
+     * @var bool Whether the attacker also withdrew without fighting after defender flee.
+     */
+    public bool $tacticalRetreatAttackerAlsoRetreated = false;
+
+    /**
+     * @var int Deuterium spent (or that would be spent) for the tactical retreat.
+     */
+    public int $tacticalRetreatDeuteriumCost = 0;
+
+    /**
+     * @var UnitCollection|null Ships that fled combat but remain on the defender planet.
+     */
+    public ?UnitCollection $tacticalRetreatFleeingUnits = null;
 }

--- a/app/GameMissions/BattleEngine/Models/TacticalRetreatDecision.php
+++ b/app/GameMissions/BattleEngine/Models/TacticalRetreatDecision.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace OGame\GameMissions\BattleEngine\Models;
+
+use OGame\GameObjects\Models\Units\UnitCollection;
+
+/**
+ * Result of evaluating whether a defending fleet should tactically retreat.
+ */
+class TacticalRetreatDecision
+{
+    /**
+     * @param int $attackerPoints Retreat-weighted attacker fleet points.
+     * @param int $defenderPoints Retreat-weighted defender fleet points.
+     * @param int $ratio Display ratio (attacker supremacy as 1:N).
+     * @param bool $defenderFled Whether the defending planet fleet fled.
+     * @param bool $attackerAlsoRetreated Whether the attacker withdrew without fighting.
+     * @param int $deuteriumCost Deuterium required (and spent if fled).
+     * @param UnitCollection $fleeingUnits Ships that leave combat but stay on the planet.
+     * @param string $blockedReason Empty when flee succeeded or was not eligible for ratio reasons.
+     */
+    public function __construct(
+        public int $attackerPoints,
+        public int $defenderPoints,
+        public int $ratio,
+        public bool $defenderFled,
+        public bool $attackerAlsoRetreated,
+        public int $deuteriumCost,
+        public UnitCollection $fleeingUnits,
+        public string $blockedReason = '',
+    ) {
+    }
+}

--- a/app/GameMissions/BattleEngine/Services/TacticalRetreatService.php
+++ b/app/GameMissions/BattleEngine/Services/TacticalRetreatService.php
@@ -16,17 +16,37 @@ use OGame\Services\PlayerService;
 
 /**
  * Evaluates OGame tactical retreat (fleet flee) before combat rounds.
+ *
+ * Authentic OGame rules (Gameforge patch notes / in-game tooltips):
+ * - Flee from a power ratio of 5:1 (3:1 with Admiral), i.e. attackerPoints >= threshold * defenderPoints
+ * - Civil ships count at 25% (rounded down); defenses / probes / sats / crawlers do not count
+ * - Deathstars count for points but cannot flee (they remain in combat)
+ * - ACS defend fleets count for points but cannot flee
+ * - Deuterium cost = 1.5 × fuel for a 100% flight to a neighbouring planet position (slot)
+ * - Ends at 500,000 general points; inactive fleets do not flee; honourable fights do not flee
+ *   (honour system not yet implemented in OGameX)
  */
 class TacticalRetreatService
 {
     private const int POINTS_CUTOFF = 500000;
 
     /**
-     * Ship types that never contribute to retreat points and never flee.
+     * Ship types that contribute 0 retreat points (and also cannot flee).
      *
      * @var list<string>
      */
-    private const array NON_FLEEING_SHIPS = [
+    private const array ZERO_POINT_SHIPS = [
+        'espionage_probe',
+        'solar_satellite',
+        'crawler',
+    ];
+
+    /**
+     * Ship types that cannot flee (may still contribute retreat points).
+     *
+     * @var list<string>
+     */
+    private const array CANNOT_FLEE = [
         'deathstar',
         'espionage_probe',
         'solar_satellite',
@@ -56,7 +76,8 @@ class TacticalRetreatService
 
     /**
      * Calculate retreat-weighted fleet points for a unit collection.
-     * Combat ships: 100% of points. Civil ships: 25%. Excluded types: 0%. Defenses: 0%.
+     * Combat ships (incl. Deathstars): 100%. Civil ships: 25% (floored with total).
+     * Probes, sats, crawlers, defenses: 0%.
      */
     public function calculateFleetPoints(UnitCollection $units): int
     {
@@ -69,7 +90,7 @@ class TacticalRetreatService
             if ($entry->amount <= 0) {
                 continue;
             }
-            if (in_array($machineName, self::NON_FLEEING_SHIPS, true)) {
+            if (in_array($machineName, self::ZERO_POINT_SHIPS, true)) {
                 continue;
             }
 
@@ -78,6 +99,7 @@ class TacticalRetreatService
             if (isset($militaryMachineNames[$machineName])) {
                 $resourcesSpent += $rawPrice;
             } elseif (isset($civilMachineNames[$machineName])) {
+                // Civil ships at 25%, rounded down via final floor(/1000).
                 $resourcesSpent += $rawPrice * 0.25;
             }
             // Defenses and anything else: ignored.
@@ -102,7 +124,7 @@ class TacticalRetreatService
             if (!isset($shipMachineNames[$machineName])) {
                 continue;
             }
-            if (in_array($machineName, self::NON_FLEEING_SHIPS, true)) {
+            if (in_array($machineName, self::CANNOT_FLEE, true)) {
                 continue;
             }
             $fleeing->addUnit($entry->unitObject, $entry->amount);
@@ -127,7 +149,10 @@ class TacticalRetreatService
     }
 
     /**
-     * Deuterium cost to flee: 1.5 × fuel for a 100% flight to a neighboring system.
+     * Deuterium cost to flee: 1.5 × fuel for a 100% flight to a neighbouring planet position.
+     *
+     * Official Gameforge wording: "neighbouring position" / "neighbouring slot"
+     * (same system, adjacent planet slot) — not a neighbouring system.
      */
     public function calculateFleeDeuteriumCost(PlanetService $planet, UnitCollection $fleeingUnits): int
     {
@@ -141,12 +166,15 @@ class TacticalRetreatService
         }
 
         $coords = $planet->getPlanetCoordinates();
-        $neighborSystem = $coords->system + 1;
-        if ($neighborSystem > UniverseConstants::MAX_SYSTEM_COUNT) {
-            $neighborSystem = UniverseConstants::MIN_SYSTEM;
+        $neighborPosition = $coords->position + 1;
+        if ($neighborPosition > UniverseConstants::MAX_PLANET_POSITION) {
+            $neighborPosition = $coords->position - 1;
+        }
+        if ($neighborPosition < UniverseConstants::MIN_PLANET_POSITION) {
+            $neighborPosition = UniverseConstants::MIN_PLANET_POSITION;
         }
 
-        $neighbor = new Coordinate($coords->galaxy, $neighborSystem, $coords->position);
+        $neighbor = new Coordinate($coords->galaxy, $coords->system, $neighborPosition);
 
         $fleetMissionService = resolve(FleetMissionService::class, ['player' => $player]);
         $baseConsumption = (int)$fleetMissionService->calculateConsumption($planet, $fleeingUnits, $neighbor, 0, 10.0);
@@ -233,7 +261,7 @@ class TacticalRetreatService
         $decision->deuteriumCost = $deuteriumCost;
         $decision->fleeingUnits = $fleeingUnits;
 
-        // Flee when attackerPoints >= threshold * defenderPoints.
+        // Gameforge: "From a ratio of 5:1" / "reaches 5:1"; community simulators use >=.
         // With 0 defender fleet points, any positive attacker force meets the threshold.
         $requiredAttackerPoints = $threshold * $defenderPoints;
         if ($attackerPoints < $requiredAttackerPoints || ($defenderPoints === 0 && $attackerPoints <= 0)) {
@@ -255,6 +283,7 @@ class TacticalRetreatService
 
     /**
      * Resolve the defender's configured retreat threshold (0, 3, or 5).
+     * OGame only offers Never / 5:1 / 3:1 (Admiral) — no other ratios.
      */
     public function resolveRetreatThreshold(PlayerService $defenderPlayer): int
     {

--- a/app/GameMissions/BattleEngine/Services/TacticalRetreatService.php
+++ b/app/GameMissions/BattleEngine/Services/TacticalRetreatService.php
@@ -1,0 +1,281 @@
+<?php
+
+namespace OGame\GameMissions\BattleEngine\Services;
+
+use OGame\GameConstants\UniverseConstants;
+use OGame\GameMissions\BattleEngine\Models\AttackerFleet;
+use OGame\GameMissions\BattleEngine\Models\DefenderFleet;
+use OGame\GameMissions\BattleEngine\Models\TacticalRetreatDecision;
+use OGame\GameObjects\Models\Units\UnitCollection;
+use OGame\Models\Highscore;
+use OGame\Models\Planet\Coordinate;
+use OGame\Services\FleetMissionService;
+use OGame\Services\ObjectService;
+use OGame\Services\PlanetService;
+use OGame\Services\PlayerService;
+
+/**
+ * Evaluates OGame tactical retreat (fleet flee) before combat rounds.
+ */
+class TacticalRetreatService
+{
+    private const int POINTS_CUTOFF = 500000;
+
+    /**
+     * Ship types that never contribute to retreat points and never flee.
+     *
+     * @var list<string>
+     */
+    private const array EXCLUDED_FROM_POINTS = [
+        'deathstar',
+        'espionage_probe',
+        'solar_satellite',
+        'crawler',
+    ];
+
+    /**
+     * Ship types that cannot flee (even if they somehow had points).
+     *
+     * @var list<string>
+     */
+    private const array CANNOT_FLEE = [
+        'deathstar',
+        'espionage_probe',
+        'solar_satellite',
+        'crawler',
+    ];
+
+    /**
+     * Calculate retreat-weighted fleet points for a unit collection.
+     * Combat ships: 100% of points. Civil ships: 25%. Excluded types: 0%. Defenses: 0%.
+     */
+    public function calculateFleetPoints(UnitCollection $units): int
+    {
+        $resourcesSpent = 0.0;
+
+        $militaryMachineNames = [];
+        foreach (ObjectService::getMilitaryShipObjects() as $ship) {
+            $militaryMachineNames[$ship->machine_name] = true;
+        }
+
+        $civilMachineNames = [];
+        foreach (ObjectService::getCivilShipObjects() as $ship) {
+            $civilMachineNames[$ship->machine_name] = true;
+        }
+
+        foreach ($units->units as $entry) {
+            $machineName = $entry->unitObject->machine_name;
+            if ($entry->amount <= 0) {
+                continue;
+            }
+            if (in_array($machineName, self::EXCLUDED_FROM_POINTS, true)) {
+                continue;
+            }
+
+            $rawPrice = ObjectService::getObjectRawPrice($machineName)->multiply($entry->amount)->sum();
+
+            if (isset($militaryMachineNames[$machineName])) {
+                $resourcesSpent += $rawPrice;
+            } elseif (isset($civilMachineNames[$machineName])) {
+                $resourcesSpent += $rawPrice * 0.25;
+            }
+            // Defenses and anything else: ignored.
+        }
+
+        return (int)floor($resourcesSpent / 1000);
+    }
+
+    /**
+     * Extract ships that are allowed to flee from a unit collection.
+     */
+    public function extractFleeingUnits(UnitCollection $units): UnitCollection
+    {
+        $fleeing = new UnitCollection();
+
+        $shipMachineNames = [];
+        foreach (ObjectService::getShipObjects() as $ship) {
+            $shipMachineNames[$ship->machine_name] = true;
+        }
+
+        foreach ($units->units as $entry) {
+            $machineName = $entry->unitObject->machine_name;
+            if ($entry->amount <= 0) {
+                continue;
+            }
+            if (!isset($shipMachineNames[$machineName])) {
+                continue;
+            }
+            if (in_array($machineName, self::CANNOT_FLEE, true)) {
+                continue;
+            }
+            $fleeing->addUnit($entry->unitObject, $entry->amount);
+        }
+
+        return $fleeing;
+    }
+
+    /**
+     * Display ratio of attacker supremacy as N in "1:N". Minimum 1.
+     */
+    public function calculateSupremacyRatio(int $attackerPoints, int $defenderPoints): int
+    {
+        if ($attackerPoints <= 0) {
+            return 1;
+        }
+        if ($defenderPoints <= 0) {
+            return max(1, $attackerPoints);
+        }
+
+        return max(1, (int)floor($attackerPoints / $defenderPoints));
+    }
+
+    /**
+     * Deuterium cost to flee: 1.5 × fuel for a 100% flight to a neighboring system.
+     */
+    public function calculateFleeDeuteriumCost(PlanetService $planet, UnitCollection $fleeingUnits): int
+    {
+        if ($fleeingUnits->getAmount() === 0) {
+            return 0;
+        }
+
+        $player = $planet->getPlayer();
+        if ($player === null) {
+            return 0;
+        }
+
+        $coords = $planet->getPlanetCoordinates();
+        $neighborSystem = $coords->system + 1;
+        if ($neighborSystem > UniverseConstants::MAX_SYSTEM_COUNT) {
+            $neighborSystem = UniverseConstants::MIN_SYSTEM;
+        }
+
+        $neighbor = new Coordinate($coords->galaxy, $neighborSystem, $coords->position);
+
+        $fleetMissionService = resolve(FleetMissionService::class, ['player' => $player]);
+        $baseConsumption = (int)$fleetMissionService->calculateConsumption($planet, $fleeingUnits, $neighbor, 0, 10.0);
+
+        return (int)ceil($baseConsumption * 1.5);
+    }
+
+    /**
+     * Evaluate whether the defending planet fleet should flee before combat.
+     *
+     * @param array<AttackerFleet> $attackers
+     * @param array<DefenderFleet> $defenders
+     */
+    public function evaluate(
+        PlanetService $defenderPlanet,
+        array $attackers,
+        array $defenders,
+        bool $retreatAfterDefenderRetreat,
+    ): TacticalRetreatDecision {
+        $attackerUnits = new UnitCollection();
+        foreach ($attackers as $attacker) {
+            $attackerUnits->addCollection($attacker->units);
+        }
+
+        $defenderPointsUnits = new UnitCollection();
+        $planetOwnerFleet = null;
+        foreach ($defenders as $defender) {
+            $defenderPointsUnits->addCollection($defender->units);
+            if ($defender->fleetMissionId === 0) {
+                $planetOwnerFleet = $defender;
+            }
+        }
+
+        $attackerPoints = $this->calculateFleetPoints($attackerUnits);
+        $defenderPoints = $this->calculateFleetPoints($defenderPointsUnits);
+        $ratio = $this->calculateSupremacyRatio($attackerPoints, $defenderPoints);
+
+        $emptyFleeing = new UnitCollection();
+        $decision = new TacticalRetreatDecision(
+            $attackerPoints,
+            $defenderPoints,
+            $ratio,
+            false,
+            false,
+            0,
+            $emptyFleeing,
+        );
+
+        $defenderPlayer = $defenderPlanet->getPlayer();
+        if ($defenderPlayer === null || $planetOwnerFleet === null) {
+            $decision->blockedReason = 'no_defender';
+            return $decision;
+        }
+
+        $threshold = $this->resolveRetreatThreshold($defenderPlayer);
+        if ($threshold === 0) {
+            $decision->blockedReason = 'disabled';
+            return $decision;
+        }
+
+        if ($this->getGeneralPoints($defenderPlayer) >= self::POINTS_CUTOFF) {
+            $decision->blockedReason = 'points_cutoff';
+            return $decision;
+        }
+
+        if ($defenderPlayer->isInactive()) {
+            $decision->blockedReason = 'inactive';
+            return $decision;
+        }
+
+        $fleeingUnits = $this->extractFleeingUnits($planetOwnerFleet->units);
+        if ($fleeingUnits->getAmount() === 0) {
+            $decision->blockedReason = 'nothing_to_flee';
+            return $decision;
+        }
+
+        $deuteriumCost = $this->calculateFleeDeuteriumCost($defenderPlanet, $fleeingUnits);
+        $decision->deuteriumCost = $deuteriumCost;
+        $decision->fleeingUnits = $fleeingUnits;
+
+        // Flee when attackerPoints >= threshold * defenderPoints.
+        // With 0 defender fleet points, any positive attacker force meets the threshold.
+        $requiredAttackerPoints = $threshold * $defenderPoints;
+        if ($attackerPoints < $requiredAttackerPoints || ($defenderPoints === 0 && $attackerPoints <= 0)) {
+            $decision->blockedReason = 'ratio_not_met';
+            return $decision;
+        }
+
+        $availableDeuterium = (int)$defenderPlanet->getResources()->deuterium->get();
+        if ($availableDeuterium < $deuteriumCost) {
+            $decision->blockedReason = 'insufficient_deuterium';
+            return $decision;
+        }
+
+        $decision->defenderFled = true;
+        $decision->attackerAlsoRetreated = $retreatAfterDefenderRetreat;
+
+        return $decision;
+    }
+
+    /**
+     * Resolve the defender's configured retreat threshold (0, 3, or 5).
+     */
+    public function resolveRetreatThreshold(PlayerService $defenderPlayer): int
+    {
+        $ratio = (int)($defenderPlayer->getUser()->tactical_retreat_ratio ?? 5);
+
+        if ($ratio === 3) {
+            // Admiral required for 3:1; fall back to 5:1 if not available.
+            if (!$defenderPlayer->hasAdmiral()) {
+                return 5;
+            }
+            return 3;
+        }
+
+        if ($ratio === 0) {
+            return 0;
+        }
+
+        return 5;
+    }
+
+    private function getGeneralPoints(PlayerService $player): int
+    {
+        $highscore = Highscore::where('player_id', $player->getId())->first();
+
+        return (int)($highscore->general ?? 0);
+    }
+}

--- a/app/GameMissions/BattleEngine/Services/TacticalRetreatService.php
+++ b/app/GameMissions/BattleEngine/Services/TacticalRetreatService.php
@@ -7,9 +7,9 @@ use OGame\GameMissions\BattleEngine\Models\AttackerFleet;
 use OGame\GameMissions\BattleEngine\Models\DefenderFleet;
 use OGame\GameMissions\BattleEngine\Models\TacticalRetreatDecision;
 use OGame\GameObjects\Models\Units\UnitCollection;
-use OGame\Models\Highscore;
 use OGame\Models\Planet\Coordinate;
 use OGame\Services\FleetMissionService;
+use OGame\Services\NPCPlayerService;
 use OGame\Services\ObjectService;
 use OGame\Services\PlanetService;
 use OGame\Services\PlayerService;
@@ -26,7 +26,7 @@ class TacticalRetreatService
      *
      * @var list<string>
      */
-    private const array EXCLUDED_FROM_POINTS = [
+    private const array NON_FLEEING_SHIPS = [
         'deathstar',
         'espionage_probe',
         'solar_satellite',
@@ -34,16 +34,25 @@ class TacticalRetreatService
     ];
 
     /**
-     * Ship types that cannot flee (even if they somehow had points).
+     * Cached military ship machine names (machine_name => true).
      *
-     * @var list<string>
+     * @var array<string, true>|null
      */
-    private const array CANNOT_FLEE = [
-        'deathstar',
-        'espionage_probe',
-        'solar_satellite',
-        'crawler',
-    ];
+    private static ?array $militaryShipNames = null;
+
+    /**
+     * Cached civil ship machine names (machine_name => true).
+     *
+     * @var array<string, true>|null
+     */
+    private static ?array $civilShipNames = null;
+
+    /**
+     * Cached all ship machine names (machine_name => true).
+     *
+     * @var array<string, true>|null
+     */
+    private static ?array $allShipNames = null;
 
     /**
      * Calculate retreat-weighted fleet points for a unit collection.
@@ -52,23 +61,15 @@ class TacticalRetreatService
     public function calculateFleetPoints(UnitCollection $units): int
     {
         $resourcesSpent = 0.0;
-
-        $militaryMachineNames = [];
-        foreach (ObjectService::getMilitaryShipObjects() as $ship) {
-            $militaryMachineNames[$ship->machine_name] = true;
-        }
-
-        $civilMachineNames = [];
-        foreach (ObjectService::getCivilShipObjects() as $ship) {
-            $civilMachineNames[$ship->machine_name] = true;
-        }
+        $militaryMachineNames = $this->militaryShipNames();
+        $civilMachineNames = $this->civilShipNames();
 
         foreach ($units->units as $entry) {
             $machineName = $entry->unitObject->machine_name;
             if ($entry->amount <= 0) {
                 continue;
             }
-            if (in_array($machineName, self::EXCLUDED_FROM_POINTS, true)) {
+            if (in_array($machineName, self::NON_FLEEING_SHIPS, true)) {
                 continue;
             }
 
@@ -91,11 +92,7 @@ class TacticalRetreatService
     public function extractFleeingUnits(UnitCollection $units): UnitCollection
     {
         $fleeing = new UnitCollection();
-
-        $shipMachineNames = [];
-        foreach (ObjectService::getShipObjects() as $ship) {
-            $shipMachineNames[$ship->machine_name] = true;
-        }
+        $shipMachineNames = $this->allShipNames();
 
         foreach ($units->units as $entry) {
             $machineName = $entry->unitObject->machine_name;
@@ -105,7 +102,7 @@ class TacticalRetreatService
             if (!isset($shipMachineNames[$machineName])) {
                 continue;
             }
-            if (in_array($machineName, self::CANNOT_FLEE, true)) {
+            if (in_array($machineName, self::NON_FLEEING_SHIPS, true)) {
                 continue;
             }
             $fleeing->addUnit($entry->unitObject, $entry->amount);
@@ -204,13 +201,19 @@ class TacticalRetreatService
             return $decision;
         }
 
+        // Expedition NPC battles reuse the battle engine; NPCs must never flee.
+        if ($defenderPlayer instanceof NPCPlayerService || $defenderPlayer->getId() <= 0) {
+            $decision->blockedReason = 'npc';
+            return $decision;
+        }
+
         $threshold = $this->resolveRetreatThreshold($defenderPlayer);
         if ($threshold === 0) {
             $decision->blockedReason = 'disabled';
             return $decision;
         }
 
-        if ($this->getGeneralPoints($defenderPlayer) >= self::POINTS_CUTOFF) {
+        if ($defenderPlayer->getCachedGeneralScore() >= self::POINTS_CUTOFF) {
             $decision->blockedReason = 'points_cutoff';
             return $decision;
         }
@@ -272,10 +275,48 @@ class TacticalRetreatService
         return 5;
     }
 
-    private function getGeneralPoints(PlayerService $player): int
+    /**
+     * @return array<string, true>
+     */
+    private function militaryShipNames(): array
     {
-        $highscore = Highscore::where('player_id', $player->getId())->first();
+        if (self::$militaryShipNames === null) {
+            self::$militaryShipNames = [];
+            foreach (ObjectService::getMilitaryShipObjects() as $ship) {
+                self::$militaryShipNames[$ship->machine_name] = true;
+            }
+        }
 
-        return (int)($highscore->general ?? 0);
+        return self::$militaryShipNames;
+    }
+
+    /**
+     * @return array<string, true>
+     */
+    private function civilShipNames(): array
+    {
+        if (self::$civilShipNames === null) {
+            self::$civilShipNames = [];
+            foreach (ObjectService::getCivilShipObjects() as $ship) {
+                self::$civilShipNames[$ship->machine_name] = true;
+            }
+        }
+
+        return self::$civilShipNames;
+    }
+
+    /**
+     * @return array<string, true>
+     */
+    private function allShipNames(): array
+    {
+        if (self::$allShipNames === null) {
+            self::$allShipNames = [];
+            foreach (ObjectService::getShipObjects() as $ship) {
+                self::$allShipNames[$ship->machine_name] = true;
+            }
+        }
+
+        return self::$allShipNames;
     }
 }

--- a/app/GameMissions/MoonDestructionMission.php
+++ b/app/GameMissions/MoonDestructionMission.php
@@ -445,6 +445,18 @@ class MoonDestructionMission extends GameMission
             'moon_existed' => true,
             'moon_chance' => 0,
             'moon_created' => false,
+            'tactical_retreat' => [
+                'ratio' => $battleResult->tacticalRetreatRatio,
+                'attacker_points' => $battleResult->tacticalRetreatAttackerPoints,
+                'defender_points' => $battleResult->tacticalRetreatDefenderPoints,
+                'defender_fled' => $battleResult->tacticalRetreatDefenderFled,
+                'attacker_also_retreated' => $battleResult->tacticalRetreatAttackerAlsoRetreated,
+                'deuterium_cost' => $battleResult->tacticalRetreatDeuteriumCost,
+                'by' => $battleResult->tacticalRetreatDefenderFled
+                    ? ($battleResult->tacticalRetreatAttackerAlsoRetreated ? 'both' : 'defender')
+                    : 'none',
+                'supremacy' => $battleResult->tacticalRetreatAttackerPoints,
+            ],
         ];
 
         $report->attacker = [

--- a/app/Http/Controllers/FleetController.php
+++ b/app/Http/Controllers/FleetController.php
@@ -11,6 +11,7 @@ use OGame\Factories\GameMissionFactory;
 use OGame\Factories\PlanetServiceFactory;
 use OGame\GameConstants\UniverseConstants;
 use OGame\GameMessages\FleetUnionInvite as FleetUnionInviteMessage;
+use OGame\GameMissions\BattleEngine\Services\TacticalRetreatService;
 use OGame\GameObjects\Models\Units\UnitCollection;
 use OGame\Models\Enums\PlanetType;
 use OGame\Models\FleetMission;
@@ -86,6 +87,14 @@ class FleetController extends OGameController
         // Get active fleet unions this player can join (buddy/ally of creator, not full, not expired)
         $availableUnions = $this->getAvailableUnionsForPlayer($player, $fleetUnionService);
 
+        $tacticalRetreatService = new TacticalRetreatService();
+        $fleeableUnits = $tacticalRetreatService->extractFleeingUnits($planet->getShipUnits());
+        $tacticalRetreatDeuteriumCost = $tacticalRetreatService->calculateFleeDeuteriumCost($planet, $fleeableUnits);
+        $tacticalRetreatRatio = (int)($player->getUser()->tactical_retreat_ratio ?? 5);
+        if ($tacticalRetreatRatio === 3 && !$player->hasAdmiral()) {
+            $tacticalRetreatRatio = 5;
+        }
+
         return view('ingame.fleet.index')->with([
             'player' => $player,
             'planet' => $planet,
@@ -104,6 +113,9 @@ class FleetController extends OGameController
             'expeditionSlotsMax' => $player->getExpeditionSlotsMax(),
             'fleetSpeedIncrement' => $fleetSpeedIncrement,
             'availableUnions' => $availableUnions,
+            'tacticalRetreatRatio' => $tacticalRetreatRatio,
+            'tacticalRetreatDeuteriumCost' => $tacticalRetreatDeuteriumCost,
+            'hasAdmiral' => $player->hasAdmiral(),
         ]);
     }
 
@@ -582,7 +594,19 @@ class FleetController extends OGameController
         }
 
         try {
-            $fleetMission = $fleetMissionService->createNewFromPlanet($planet, $target_coordinate, $planetType, $mission_type, $units, $resources, $speed_percent, $holding_hours);
+            $retreatAfterDefenderRetreat = (bool)request()->input('retreatAfterDefenderRetreat');
+            $fleetMission = $fleetMissionService->createNewFromPlanet(
+                $planet,
+                $target_coordinate,
+                $planetType,
+                $mission_type,
+                $units,
+                $resources,
+                $speed_percent,
+                $holding_hours,
+                0,
+                $retreatAfterDefenderRetreat
+            );
 
             // Join the fleet union if requested
             if ($union !== null) {
@@ -1388,6 +1412,38 @@ class FleetController extends OGameController
         return response()->json([
             'success' => true,
             'message' => 'Template deleted successfully.',
+        ]);
+    }
+
+    /**
+     * Persist the player's tactical retreat preference (Never / 5:1 / 3:1).
+     */
+    public function updateTacticalRetreat(Request $request, PlayerService $player): JsonResponse
+    {
+        $ratio = (int)$request->input('tacticalRetreatState', $request->input('tacticalRetreat', 5));
+
+        if (!in_array($ratio, [0, 3, 5], true)) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Invalid tactical retreat setting.',
+            ], 422);
+        }
+
+        if ($ratio === 3 && !$player->hasAdmiral()) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Admiral is required for the 3:1 tactical retreat setting.',
+            ], 422);
+        }
+
+        $user = $player->getUser();
+        $user->tactical_retreat_ratio = $ratio;
+        $user->save();
+
+        return response()->json([
+            'success' => true,
+            'tacticalRetreatRatio' => $ratio,
+            'newAjaxToken' => csrf_token(),
         ]);
     }
 }

--- a/app/Models/FleetMission.php
+++ b/app/Models/FleetMission.php
@@ -43,6 +43,7 @@ use Illuminate\Support\Carbon;
  * @property int $processed
  * @property int $processed_hold
  * @property int $canceled
+ * @property bool $retreat_after_defender_retreat
  * @property array|null $wreck_field_data
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
@@ -111,6 +112,7 @@ class FleetMission extends Model
      */
     protected $casts = [
         'wreck_field_data' => 'array',
+        'retreat_after_defender_retreat' => 'boolean',
     ];
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -41,6 +41,7 @@ use Spatie\Permission\Traits\HasRoles;
  * @property Carbon|null $updated_at
  * @property int|null $planet_current
  * @property int $dark_matter
+ * @property int $tactical_retreat_ratio
  * @property Carbon|null $dark_matter_last_regen
  * @property bool $vacation_mode
  * @property Carbon|null $vacation_mode_activated_at

--- a/app/Services/FleetMissionService.php
+++ b/app/Services/FleetMissionService.php
@@ -531,13 +531,13 @@ class FleetMissionService
      * @return FleetMission
      * @throws Exception
      */
-    public function createNewFromPlanet(PlanetService $planet, Coordinate $targetCoordinate, PlanetType $targetType, int $missionType, UnitCollection $units, Resources $resources, float $speedPercent, int $holdingHours = 0, int $parent_id = 0): FleetMission
+    public function createNewFromPlanet(PlanetService $planet, Coordinate $targetCoordinate, PlanetType $targetType, int $missionType, UnitCollection $units, Resources $resources, float $speedPercent, int $holdingHours = 0, int $parent_id = 0, bool $retreatAfterDefenderRetreat = false): FleetMission
     {
         $missionObject = $this->gameMissionFactory->getMissionById($missionType, [
             'fleetMissionService' => $this,
             'messageService' => $this->messageService,
         ]);
-        return $missionObject->start($planet, $targetCoordinate, $targetType, $units, $resources, $speedPercent, $holdingHours, $parent_id);
+        return $missionObject->start($planet, $targetCoordinate, $targetType, $units, $resources, $speedPercent, $holdingHours, $parent_id, $retreatAfterDefenderRetreat);
     }
 
     /**

--- a/database/migrations/2026_08_12_000001_add_tactical_retreat_ratio_to_users_table.php
+++ b/database/migrations/2026_08_12_000001_add_tactical_retreat_ratio_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            // Defender preference: 0 = never, 5 = 5:1, 3 = 3:1 (Admiral).
+            $table->unsignedTinyInteger('tactical_retreat_ratio')->default(5)->after('dark_matter');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('tactical_retreat_ratio');
+        });
+    }
+};

--- a/database/migrations/2026_08_12_000002_add_retreat_after_defender_retreat_to_fleet_missions_table.php
+++ b/database/migrations/2026_08_12_000002_add_retreat_after_defender_retreat_to_fleet_missions_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('fleet_missions', function (Blueprint $table) {
+            $table->boolean('retreat_after_defender_retreat')->default(false)->after('canceled');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('fleet_missions', function (Blueprint $table) {
+            $table->dropColumn('retreat_after_defender_retreat');
+        });
+    }
+};

--- a/resources/lang/en/t_ingame.php
+++ b/resources/lang/en/t_ingame.php
@@ -661,6 +661,7 @@ return [
         'battle_retreat_tooltip'  => 'Please note that Deathstars, Espionage Probes, Solar Satellites and any fleet on a ACS Defence mission cannot flee. Tactical retreats are also deactivated in honourable battles. A retreat may also have been manually deactivated or prevented by a lack of deuterium. Bandits and players with more than 500,000 points never retreat.',
         'battle_no_flee'         => 'The defending fleet did not flee.',
         'battle_fled'            => 'The defending fleet has fled from the battle.',
+        'battle_flee_deuterium'  => 'Deuterium cost: :amount',
         'battle_rounds'          => 'Rounds',
         'battle_start'           => 'Start',
         'battle_player_from'     => 'from',

--- a/resources/lang/en/t_ingame.php
+++ b/resources/lang/en/t_ingame.php
@@ -660,6 +660,7 @@ return [
         'battle_hamill'          => 'A Light Fighter destroyed one Deathstar before the battle began!',
         'battle_retreat_tooltip'  => 'Please note that Deathstars, Espionage Probes, Solar Satellites and any fleet on a ACS Defence mission cannot flee. Tactical retreats are also deactivated in honourable battles. A retreat may also have been manually deactivated or prevented by a lack of deuterium. Bandits and players with more than 500,000 points never retreat.',
         'battle_no_flee'         => 'The defending fleet did not flee.',
+        'battle_fled'            => 'The defending fleet has fled from the battle.',
         'battle_rounds'          => 'Rounds',
         'battle_start'           => 'Start',
         'battle_player_from'     => 'from',

--- a/resources/lang/fr/t_ingame.php
+++ b/resources/lang/fr/t_ingame.php
@@ -510,6 +510,7 @@ return [
         'battle_retreat_tooltip' => 'Veuillez noter que les Deathstars, les sondes d\'espionnage, les satellites solaires et toute flotte en mission de défense ACS ne peuvent pas fuir. Les retraites tactiques sont également désactivées dans les batailles honorables. Une retraite peut également avoir été désactivée manuellement ou empêchée par un manque de deutérium. Les bandits et les joueurs avec plus de 500 000 points ne reculent jamais.',
         'battle_no_flee' => 'La flotte en défense n\'a pas fui.',
         'battle_fled' => 'La flotte en défense a fui le combat.',
+        'battle_flee_deuterium' => 'Coût en deutérium : :amount',
         'battle_rounds' => 'Tours',
         'battle_start' => 'Commencer',
         'battle_player_from' => 'depuis',

--- a/resources/lang/fr/t_ingame.php
+++ b/resources/lang/fr/t_ingame.php
@@ -509,6 +509,7 @@ return [
         'battle_hamill' => 'Un chasseur léger a détruit une étoile de la mort avant le début de la bataille !',
         'battle_retreat_tooltip' => 'Veuillez noter que les Deathstars, les sondes d\'espionnage, les satellites solaires et toute flotte en mission de défense ACS ne peuvent pas fuir. Les retraites tactiques sont également désactivées dans les batailles honorables. Une retraite peut également avoir été désactivée manuellement ou empêchée par un manque de deutérium. Les bandits et les joueurs avec plus de 500 000 points ne reculent jamais.',
         'battle_no_flee' => 'La flotte en défense n\'a pas fui.',
+        'battle_fled' => 'La flotte en défense a fui le combat.',
         'battle_rounds' => 'Tours',
         'battle_start' => 'Commencer',
         'battle_player_from' => 'depuis',

--- a/resources/lang/it/t_ingame.php
+++ b/resources/lang/it/t_ingame.php
@@ -639,6 +639,7 @@ return [
         'battle_hamill'          => 'Un Caccia Leggero ha distrutto un Incrociatore Stellare prima dell\'inizio della battaglia!',
         'battle_retreat_tooltip'  => 'Le Stelle della Morte, le sonde spia, i satelliti solari e qualsiasi flotta in missione di difesa ACS non possono fuggire. Le ritirate tattiche sono disattivate anche nei combattimenti onorevoli. Una ritirata può anche essere stata disattivata manualmente o impedita dalla mancanza di deuterio. I banditi e i giocatori con più di 500.000 punti non si ritirano mai.',
         'battle_no_flee'         => 'La flotta in difesa non è fuggita.',
+        'battle_fled'            => 'La flotta in difesa è fuggita dal combattimento.',
         'battle_rounds'          => 'Round',
         'battle_start'           => 'Inizio',
         'battle_player_from'     => 'da',

--- a/resources/lang/it/t_ingame.php
+++ b/resources/lang/it/t_ingame.php
@@ -640,6 +640,7 @@ return [
         'battle_retreat_tooltip'  => 'Le Stelle della Morte, le sonde spia, i satelliti solari e qualsiasi flotta in missione di difesa ACS non possono fuggire. Le ritirate tattiche sono disattivate anche nei combattimenti onorevoli. Una ritirata può anche essere stata disattivata manualmente o impedita dalla mancanza di deuterio. I banditi e i giocatori con più di 500.000 punti non si ritirano mai.',
         'battle_no_flee'         => 'La flotta in difesa non è fuggita.',
         'battle_fled'            => 'La flotta in difesa è fuggita dal combattimento.',
+        'battle_flee_deuterium'  => 'Costo in deuterio: :amount',
         'battle_rounds'          => 'Round',
         'battle_start'           => 'Inizio',
         'battle_player_from'     => 'da',

--- a/resources/lang/nl/t_ingame.php
+++ b/resources/lang/nl/t_ingame.php
@@ -640,6 +640,7 @@ return [
         'battle_retreat_tooltip'  => 'Let op: Dodestarren, Spionagesondes, Zonne-energiesatellieten en elke vloot op een ACS-verdedigingsmissie kunnen niet vluchten. Tactische terugtrekkingen zijn ook gedeactiveerd in eervolle gevechten. Een terugtrekking kan ook handmatig zijn gedeactiveerd of verhinderd door een gebrek aan deuterium. Bandieten en spelers met meer dan 500.000 punten trekken zich nooit terug.',
         'battle_no_flee'         => 'De verdedigende vloot is niet gevlucht.',
         'battle_fled'            => 'De verdedigende vloot is van het gevecht gevlucht.',
+        'battle_flee_deuterium'  => 'Deuteriumkosten: :amount',
         'battle_rounds'          => 'Rondes',
         'battle_start'           => 'Start',
         'battle_player_from'     => 'van',

--- a/resources/lang/nl/t_ingame.php
+++ b/resources/lang/nl/t_ingame.php
@@ -639,6 +639,7 @@ return [
         'battle_hamill'          => 'Een Lichte Jager heeft een Dodestar vernietigd voordat de strijd begon!',
         'battle_retreat_tooltip'  => 'Let op: Dodestarren, Spionagesondes, Zonne-energiesatellieten en elke vloot op een ACS-verdedigingsmissie kunnen niet vluchten. Tactische terugtrekkingen zijn ook gedeactiveerd in eervolle gevechten. Een terugtrekking kan ook handmatig zijn gedeactiveerd of verhinderd door een gebrek aan deuterium. Bandieten en spelers met meer dan 500.000 punten trekken zich nooit terug.',
         'battle_no_flee'         => 'De verdedigende vloot is niet gevlucht.',
+        'battle_fled'            => 'De verdedigende vloot is van het gevecht gevlucht.',
         'battle_rounds'          => 'Rondes',
         'battle_start'           => 'Start',
         'battle_player_from'     => 'van',

--- a/resources/lang/zh-TW/t_ingame.php
+++ b/resources/lang/zh-TW/t_ingame.php
@@ -558,6 +558,7 @@ return [
         'battle_hamill'          => '一架輕型戰鬥機在戰鬥開始前摧毀了一艘死星！',
         'battle_retreat_tooltip'  => '請注意，死星、間諜探測器、太陽能衛星和任何執行 ACS 防守任務的艦隊無法逃脫。戰術撤退在光榮的戰鬥中也被停用。撤退也可能被手動停用或因重氫不足而無法進行。土匪和積分超過 500,000 的玩家從不撤退。',
         'battle_no_flee'         => '防守艦隊沒有逃脫。',
+        'battle_fled'            => '防守艦隊已從戰鬥中逃脫。',
         'battle_rounds'          => '回合',
         'battle_start'           => '開始',
         'battle_player_from'     => '來自',

--- a/resources/lang/zh-TW/t_ingame.php
+++ b/resources/lang/zh-TW/t_ingame.php
@@ -559,6 +559,7 @@ return [
         'battle_retreat_tooltip'  => '請注意，死星、間諜探測器、太陽能衛星和任何執行 ACS 防守任務的艦隊無法逃脫。戰術撤退在光榮的戰鬥中也被停用。撤退也可能被手動停用或因重氫不足而無法進行。土匪和積分超過 500,000 的玩家從不撤退。',
         'battle_no_flee'         => '防守艦隊沒有逃脫。',
         'battle_fled'            => '防守艦隊已從戰鬥中逃脫。',
+        'battle_flee_deuterium'  => '重氫消耗：:amount',
         'battle_rounds'          => '回合',
         'battle_start'           => '開始',
         'battle_player_from'     => '來自',

--- a/resources/views/ingame/fleet/index.blade.php
+++ b/resources/views/ingame/fleet/index.blade.php
@@ -839,7 +839,8 @@ Use the Admiral to enable your fleets to retreat from forces three times bigger 
 <br />
 The &amp;#96;tactical retreat&amp;#96; option ends with 500,000 points." href="javascript:void(0);"
                                class="tooltipHTML tooltipRight help"></a>
-                            <form class="fleft" name="tacticalRetreat" method="POST" action="">
+                            <form class="fleft" name="tacticalRetreat" method="POST" action="{{ route('fleet.tacticalretreat') }}">
+                            @csrf
                             <span class="tooltipHTML tooltipRight" title="Tactical retreat|Fleets are able to automatically retreat if they are attacked by a superior force five times stronger than themselves. The crucial factor in this are the attacker&amp;#96;s fleet points in comparison to your fleet points. Defense facilities are not considered.<br />
 <br />
 Civil ships only count 25%, solar satellites and espionage probes are not considered. <br />
@@ -853,24 +854,29 @@ Use the Admiral to enable your fleets to retreat from forces three times bigger 
 The &amp;#96;tactical retreat&amp;#96; option ends with 500,000 points.">
                                 Tactical retreat:
                             </span>
-                                <input onclick="ajaxFormSubmit('tacticalRetreat', '{{ route('overview.index') }}#TODO_tacticalRetreat&amp;tacticalRetreatState=0');"
-                                       type="radio" name="tacticalRetreat" value="0">
+                                <input onclick="ajaxFormSubmit('tacticalRetreat', '{{ route('fleet.tacticalretreat') }}?tacticalRetreatState=0');"
+                                       type="radio" name="tacticalRetreat" value="0" {{ ($tacticalRetreatRatio ?? 5) === 0 ? 'checked' : '' }}>
                                 Never
-                                <input onclick="ajaxFormSubmit('tacticalRetreat', '{{ route('overview.index') }}#TODO_tacticalRetreat&amp;tacticalRetreatState=5');"
-                                       checked="&quot;checked&quot;" type="radio" name="tacticalRetreat" value="5"> 5:1
+                                <input onclick="ajaxFormSubmit('tacticalRetreat', '{{ route('fleet.tacticalretreat') }}?tacticalRetreatState=5');"
+                                       type="radio" name="tacticalRetreat" value="5" {{ ($tacticalRetreatRatio ?? 5) === 5 ? 'checked' : '' }}> 5:1
+@if ($hasAdmiral ?? false)
+                                <input onclick="ajaxFormSubmit('tacticalRetreat', '{{ route('fleet.tacticalretreat') }}?tacticalRetreatState=3');"
+                                       type="radio" name="tacticalRetreat" value="3" {{ ($tacticalRetreatRatio ?? 5) === 3 ? 'checked' : '' }}> 3:1
+@else
                                 <input type="radio" disabled="disabled" name="tacticalRetreat">
                                 <a href="{{ route('premium.index', ['openDetail' => '3']) }}"
                                    class="disabled tooltipHTML"
                                    title="Tactical retreat|Use the Admiral to enable your fleets to retreat from forces three times bigger than your own.">
                                     3:1
                                 </a>
+@endif
                             </form>
                         </div>
                         <div class="fleft tooltip" title="Show Deuterium usage per tactical retreat">
                         <span>
                             Deuterium consumption:
                         </span>
-                            5
+                            {{ $tacticalRetreatDeuteriumCost ?? 0 }}
                         </div>
                         <br class="clearfloat">
                     </div>

--- a/resources/views/ingame/messages/templates/battle_report_full.blade.php
+++ b/resources/views/ingame/messages/templates/battle_report_full.blade.php
@@ -85,7 +85,7 @@
             {{ __('t_ingame.messages.battle_tactical_retreat') }}:<span class="middlemark"> 1:{{ $tactical_retreat_ratio ?? 1 }}</span>
         </p>
         <p class="fleft">
-            <span class="icon_info tooltip" style="margin: 5px" data-tooltip-title="{{ __('t_ingame.messages.battle_retreat_tooltip') }}"> {{ ($tactical_retreat_defender_fled ?? false) ? __('t_ingame.messages.battle_fled') : __('t_ingame.messages.battle_no_flee') }}</span>
+            <span class="icon_info tooltip" style="margin: 5px" data-tooltip-title="{{ __('t_ingame.messages.battle_retreat_tooltip') }}"> {{ ($tactical_retreat_defender_fled ?? false) ? __('t_ingame.messages.battle_fled') : __('t_ingame.messages.battle_no_flee') }}@if (($tactical_retreat_defender_fled ?? false) && ($tactical_retreat_deuterium_cost ?? 0) > 0) {{ __('t_ingame.messages.battle_flee_deuterium', ['amount' => $tactical_retreat_deuterium_cost_formatted]) }}@endif</span>
         </p>
         <!-- Rundenpagenator -->
         <ul class="combat_round_list">

--- a/resources/views/ingame/messages/templates/battle_report_full.blade.php
+++ b/resources/views/ingame/messages/templates/battle_report_full.blade.php
@@ -82,10 +82,10 @@
 <div class="messageDetails">
     <div class="detailReport" data-combatreportid="8196210">
         <p class="detail_txt fleft">
-            {{ __('t_ingame.messages.battle_tactical_retreat') }}:<span class="middlemark"> 1:100</span>
+            {{ __('t_ingame.messages.battle_tactical_retreat') }}:<span class="middlemark"> 1:{{ $tactical_retreat_ratio ?? 1 }}</span>
         </p>
         <p class="fleft">
-            <span class="icon_info tooltip" style="margin: 5px" data-tooltip-title="{{ __('t_ingame.messages.battle_retreat_tooltip') }}"> {{ __('t_ingame.messages.battle_no_flee') }}</span>
+            <span class="icon_info tooltip" style="margin: 5px" data-tooltip-title="{{ __('t_ingame.messages.battle_retreat_tooltip') }}"> {{ ($tactical_retreat_defender_fled ?? false) ? __('t_ingame.messages.battle_fled') : __('t_ingame.messages.battle_no_flee') }}</span>
         </p>
         <!-- Rundenpagenator -->
         <ul class="combat_round_list">

--- a/routes/web.php
+++ b/routes/web.php
@@ -125,6 +125,7 @@ Route::middleware(['auth', 'banned', 'globalgame', 'locale', 'firstlogin'])->gro
     Route::post('/ajax/fleet/dispatch/send-fleet', [FleetController::class, 'dispatchSendFleet'])->name('fleet.dispatch.sendfleet');
     Route::post('/ajax/fleet/dispatch/send-mini-fleet', [FleetController::class, 'dispatchSendMiniFleet'])->name('fleet.dispatch.sendminifleet');
     Route::post('/ajax/fleet/dispatch/recall-fleet', [FleetController::class, 'dispatchRecallFleet'])->name('fleet.dispatch.recallfleet');
+    Route::post('/ajax/fleet/tactical-retreat', [FleetController::class, 'updateTacticalRetreat'])->name('fleet.tacticalretreat');
 
     // ACS Fleet Unions
     Route::post('/ajax/fleet/union/create', [FleetController::class, 'createUnion'])->name('fleet.union.create');

--- a/tests/Feature/FleetDispatch/FleetDispatchTacticalRetreatTest.php
+++ b/tests/Feature/FleetDispatch/FleetDispatchTacticalRetreatTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Tests\Feature\FleetDispatch;
+
+use OGame\GameMissions\AttackMission;
+use OGame\GameObjects\Models\Units\UnitCollection;
+use OGame\Models\BattleReport;
+use OGame\Models\Enums\PlanetType;
+use OGame\Models\Resources;
+use OGame\Services\FleetMissionService;
+use OGame\Services\ObjectService;
+use Tests\FleetDispatchTestCase;
+
+/**
+ * Feature coverage for tactical retreat during attack missions.
+ */
+class FleetDispatchTacticalRetreatTest extends FleetDispatchTestCase
+{
+    protected int $missionType = 1;
+
+    protected string $missionName = 'Attack';
+
+    protected function basicSetup(): void
+    {
+        $this->planetAddUnit('light_fighter', 200);
+        $this->planetAddUnit('small_cargo', 5);
+        $this->planetAddResources(new Resources(5000, 5000, 1000000, 0));
+    }
+
+    public function testTacticalRetreatPersistsRatioAndFleeInBattleReport(): void
+    {
+        $this->basicSetup();
+
+        $foreignPlanet = $this->getNearbyForeignPlanet();
+        $fightersBefore = $foreignPlanet->getObjectAmount('light_fighter');
+        $foreignPlanet->addUnit('light_fighter', 5);
+        $foreignPlanet->addUnit('rocket_launcher', 20);
+        $foreignPlanet->addResources(new Resources(0, 0, 100000, 0));
+
+        $unitCollection = new UnitCollection();
+        $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 100);
+
+        $this->dispatchFleet(
+            $foreignPlanet->getPlanetCoordinates(),
+            $unitCollection,
+            new Resources(0, 0, 0, 0),
+            PlanetType::Planet
+        );
+
+        $fleetMissionService = resolve(FleetMissionService::class, ['player' => $this->planetService->getPlayer()]);
+        $duration = $fleetMissionService->calculateFleetMissionDuration(
+            $this->planetService,
+            $foreignPlanet->getPlanetCoordinates(),
+            $unitCollection,
+            resolve(AttackMission::class)
+        );
+
+        $this->travel($duration + 1)->seconds();
+        $this->reloadApplication();
+        $this->get('/overview')->assertStatus(200);
+
+        $report = BattleReport::query()->orderByDesc('id')->first();
+        $this->assertNotNull($report, 'Expected a battle report after the attack');
+        $this->assertArrayHasKey('tactical_retreat', $report->general);
+        $this->assertTrue($report->general['tactical_retreat']['defender_fled']);
+        $this->assertGreaterThanOrEqual(5, $report->general['tactical_retreat']['ratio']);
+        $this->assertEquals('defender', $report->general['tactical_retreat']['by']);
+
+        // Fleeing ships remain on the defender planet.
+        $foreignPlanet->reloadPlanet();
+        $this->assertEquals($fightersBefore + 5, $foreignPlanet->getObjectAmount('light_fighter'));
+    }
+
+    public function testTacticalRetreatPreferenceCanBeUpdated(): void
+    {
+        $response = $this->post('/ajax/fleet/tactical-retreat', [
+            'tacticalRetreatState' => 0,
+            '_token' => csrf_token(),
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJson(['success' => true, 'tacticalRetreatRatio' => 0]);
+
+        $this->planetPlayer()->getUser()->refresh();
+        $this->assertEquals(0, $this->planetPlayer()->getUser()->tactical_retreat_ratio);
+    }
+
+    public function testRetreatAfterDefenderRetreatIsStoredOnMission(): void
+    {
+        $this->basicSetup();
+
+        $foreignPlanet = $this->getNearbyForeignPlanet();
+        $unitCollection = new UnitCollection();
+        $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 1);
+        $unitsArray = [];
+        foreach ($unitCollection->units as $unit) {
+            $unitsArray['am' . $unit->unitObject->id] = $unit->amount;
+        }
+
+        $coordinates = $foreignPlanet->getPlanetCoordinates();
+        $post = $this->post('/ajax/fleet/dispatch/send-fleet', [
+            'galaxy' => $coordinates->galaxy,
+            'system' => $coordinates->system,
+            'position' => $coordinates->position,
+            'type' => PlanetType::Planet->value,
+            'mission' => $this->missionType,
+            'metal' => 0,
+            'crystal' => 0,
+            'deuterium' => 0,
+            '_token' => csrf_token(),
+            'holdingtime' => 0,
+            'speed' => 10,
+            'retreatAfterDefenderRetreat' => 1,
+            ...$unitsArray,
+        ]);
+
+        $post->assertStatus(200);
+        $post->assertJson(['success' => true]);
+
+        $mission = \OGame\Models\FleetMission::query()->orderByDesc('id')->first();
+        $this->assertNotNull($mission);
+        $this->assertTrue((bool)$mission->retreat_after_defender_retreat);
+    }
+
+    private function planetPlayer(): \OGame\Services\PlayerService
+    {
+        $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('Planet has no player.');
+        }
+
+        return $player;
+    }
+}

--- a/tests/Feature/FleetDispatch/FleetDispatchTacticalRetreatTest.php
+++ b/tests/Feature/FleetDispatch/FleetDispatchTacticalRetreatTest.php
@@ -32,10 +32,24 @@ class FleetDispatchTacticalRetreatTest extends FleetDispatchTestCase
         $this->basicSetup();
 
         $foreignPlanet = $this->getNearbyForeignPlanet();
-        $fightersBefore = $foreignPlanet->getObjectAmount('light_fighter');
+        // Isolate from leftover units on shared foreign planets across the suite.
+        foreach ($foreignPlanet->getShipUnits()->units as $entry) {
+            if ($entry->amount > 0) {
+                $foreignPlanet->removeUnit($entry->unitObject->machine_name, $entry->amount, false);
+            }
+        }
+        $foreignPlanet->save();
+
         $foreignPlanet->addUnit('light_fighter', 5);
         $foreignPlanet->addUnit('rocket_launcher', 20);
         $foreignPlanet->addResources(new Resources(0, 0, 100000, 0));
+
+        $defenderPlayer = $foreignPlanet->getPlayer();
+        $this->assertNotNull($defenderPlayer);
+        $user = $defenderPlayer->getUser();
+        $user->tactical_retreat_ratio = 5;
+        $user->time = (string) now()->timestamp;
+        $user->save();
 
         $unitCollection = new UnitCollection();
         $unitCollection->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 100);
@@ -72,7 +86,7 @@ class FleetDispatchTacticalRetreatTest extends FleetDispatchTestCase
 
         // Fleeing ships remain on the defender planet.
         $foreignPlanet->reloadPlanet();
-        $this->assertEquals($fightersBefore + 5, $foreignPlanet->getObjectAmount('light_fighter'));
+        $this->assertEquals(5, $foreignPlanet->getObjectAmount('light_fighter'));
     }
 
     public function testTacticalRetreatPreferenceCanBeUpdated(): void

--- a/tests/Feature/FleetDispatch/FleetDispatchTacticalRetreatTest.php
+++ b/tests/Feature/FleetDispatch/FleetDispatchTacticalRetreatTest.php
@@ -31,15 +31,9 @@ class FleetDispatchTacticalRetreatTest extends FleetDispatchTestCase
     {
         $this->basicSetup();
 
-        $foreignPlanet = $this->getNearbyForeignPlanet();
-        // Isolate from leftover units on shared foreign planets across the suite.
-        foreach ($foreignPlanet->getShipUnits()->units as $entry) {
-            if ($entry->amount > 0) {
-                $foreignPlanet->removeUnit($entry->unitObject->machine_name, $entry->amount, false);
-            }
-        }
-        $foreignPlanet->save();
-
+        // Use a freshly created hostile planet so leftover ships/resources from
+        // earlier suite tests cannot change the 5:1 ratio or remaining fleet.
+        $foreignPlanet = $this->getNearbyForeignCleanPlanet();
         $foreignPlanet->addUnit('light_fighter', 5);
         $foreignPlanet->addUnit('rocket_launcher', 20);
         $foreignPlanet->addResources(new Resources(0, 0, 100000, 0));
@@ -73,7 +67,14 @@ class FleetDispatchTacticalRetreatTest extends FleetDispatchTestCase
         $this->reloadApplication();
         $this->get('/overview')->assertStatus(200);
 
-        $report = BattleReport::query()->orderByDesc('id')->first();
+        $coords = $foreignPlanet->getPlanetCoordinates();
+        $report = BattleReport::query()
+            ->where('planet_galaxy', $coords->galaxy)
+            ->where('planet_system', $coords->system)
+            ->where('planet_position', $coords->position)
+            ->where('planet_user_id', $defenderPlayer->getId())
+            ->orderByDesc('id')
+            ->first();
         $this->assertNotNull($report, 'Expected a battle report after the attack');
 
         $general = $report->general;

--- a/tests/Feature/FleetDispatch/FleetDispatchTacticalRetreatTest.php
+++ b/tests/Feature/FleetDispatch/FleetDispatchTacticalRetreatTest.php
@@ -61,10 +61,14 @@ class FleetDispatchTacticalRetreatTest extends FleetDispatchTestCase
 
         $report = BattleReport::query()->orderByDesc('id')->first();
         $this->assertNotNull($report, 'Expected a battle report after the attack');
-        $this->assertArrayHasKey('tactical_retreat', $report->general);
-        $this->assertTrue($report->general['tactical_retreat']['defender_fled']);
-        $this->assertGreaterThanOrEqual(5, $report->general['tactical_retreat']['ratio']);
-        $this->assertEquals('defender', $report->general['tactical_retreat']['by']);
+
+        $general = $report->general;
+        $this->assertIsArray($general);
+        $this->assertArrayHasKey('tactical_retreat', $general);
+        $this->assertIsArray($general['tactical_retreat']);
+        $this->assertTrue($general['tactical_retreat']['defender_fled']);
+        $this->assertGreaterThanOrEqual(5, $general['tactical_retreat']['ratio']);
+        $this->assertEquals('defender', $general['tactical_retreat']['by']);
 
         // Fleeing ships remain on the defender planet.
         $foreignPlanet->reloadPlanet();

--- a/tests/Feature/FleetDispatch/ReaperDebrisCollectionTest.php
+++ b/tests/Feature/FleetDispatch/ReaperDebrisCollectionTest.php
@@ -83,6 +83,14 @@ class ReaperDebrisCollectionTest extends FleetDispatchTestCase
         $units->addUnit(ObjectService::getShipObjectByMachineName('reaper'), 10);
         $foreignPlanet = $this->sendMissionToOtherPlayerPlanet($units, new Resources(0, 0, 0, 0));
 
+        // Disable tactical retreat so defender ships stay and create debris.
+        $foreignPlayer = $foreignPlanet->getPlayer();
+        if ($foreignPlayer === null) {
+            $this->fail('Foreign planet has no player.');
+        }
+        $foreignPlayer->getUser()->tactical_retreat_ratio = 0;
+        $foreignPlayer->getUser()->save();
+
         // Clear foreign planet units from previous tests to ensure isolation
         $foreignPlanet->removeUnits($foreignPlanet->getShipUnits(), true);
         $foreignPlanet->removeUnits($foreignPlanet->getDefenseUnits(), true);
@@ -201,6 +209,14 @@ class ReaperDebrisCollectionTest extends FleetDispatchTestCase
         $units->addUnit(ObjectService::getShipObjectByMachineName('reaper'), 10);
         $foreignPlanet = $this->sendMissionToOtherPlayerPlanet($units, new Resources(0, 0, 0, 0));
 
+        // Disable tactical retreat so defender ships stay and create debris.
+        $foreignPlayer = $foreignPlanet->getPlayer();
+        if ($foreignPlayer === null) {
+            $this->fail('Foreign planet has no player.');
+        }
+        $foreignPlayer->getUser()->tactical_retreat_ratio = 0;
+        $foreignPlayer->getUser()->save();
+
         // Clear foreign planet units from previous tests to ensure isolation
         $foreignPlanet->removeUnits($foreignPlanet->getShipUnits(), true);
         $foreignPlanet->removeUnits($foreignPlanet->getDefenseUnits(), true);
@@ -279,6 +295,14 @@ class ReaperDebrisCollectionTest extends FleetDispatchTestCase
         $units = new UnitCollection();
         $units->addUnit(ObjectService::getShipObjectByMachineName('light_fighter'), 200);
         $foreignPlanet = $this->sendMissionToOtherPlayerPlanet($units, new Resources(0, 0, 0, 0));
+
+        // Disable tactical retreat so defender ships stay in combat.
+        $foreignPlayer = $foreignPlanet->getPlayer();
+        if ($foreignPlayer === null) {
+            $this->fail('Foreign planet has no player.');
+        }
+        $foreignPlayer->getUser()->tactical_retreat_ratio = 0;
+        $foreignPlayer->getUser()->save();
 
         // Clear foreign planet units from previous tests to ensure isolation
         $foreignPlanet->removeUnits($foreignPlanet->getShipUnits(), true);

--- a/tests/Unit/BattleEngine/PhpTacticalRetreatTest.php
+++ b/tests/Unit/BattleEngine/PhpTacticalRetreatTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Unit\BattleEngine;
+
+use OGame\GameMissions\BattleEngine\BattleEngine;
+use OGame\GameMissions\BattleEngine\PhpBattleEngine;
+
+/**
+ * PHP battle-engine coverage for tactical retreat.
+ */
+class PhpTacticalRetreatTest extends TacticalRetreatTestAbstract
+{
+    /**
+     * @return class-string<BattleEngine>
+     */
+    protected function battleEngineClass(): string
+    {
+        return PhpBattleEngine::class;
+    }
+}

--- a/tests/Unit/BattleEngine/RustTacticalRetreatTest.php
+++ b/tests/Unit/BattleEngine/RustTacticalRetreatTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Unit\BattleEngine;
+
+use OGame\GameMissions\BattleEngine\BattleEngine;
+use OGame\GameMissions\BattleEngine\RustBattleEngine;
+
+/**
+ * Rust battle-engine coverage for tactical retreat.
+ */
+class RustTacticalRetreatTest extends TacticalRetreatTestAbstract
+{
+    /**
+     * @return class-string<BattleEngine>
+     */
+    protected function battleEngineClass(): string
+    {
+        return RustBattleEngine::class;
+    }
+}

--- a/tests/Unit/BattleEngine/TacticalRetreatTest.php
+++ b/tests/Unit/BattleEngine/TacticalRetreatTest.php
@@ -234,6 +234,59 @@ class TacticalRetreatTest extends AccountTestCase
         $this->assertEquals(0, $result->defenderUnitsLost->getAmountByMachineName('rocket_launcher'));
     }
 
+    public function testAttackerRetreatGrantsNoLootWhenOnlyShipsFled(): void
+    {
+        $settingsService = resolve(SettingsService::class);
+        $defenderPlanet = $this->prepareDefenderPlanet([
+            'light_fighter' => 5,
+            'deuterium' => 100000,
+        ]);
+        $defenderPlanet->addResources(new Resources(50000, 50000, 0, 0));
+
+        $attackerFleet = new UnitCollection();
+        $attackerFleet->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 100);
+
+        $engine = $this->createBattleEngine($attackerFleet, $this->attackerPlayer(), $defenderPlanet, $settingsService);
+        $engine->setRetreatAfterDefenderRetreat(true);
+        $result = $engine->simulateBattle();
+
+        $this->assertTrue($result->tacticalRetreatDefenderFled);
+        $this->assertTrue($result->tacticalRetreatAttackerAlsoRetreated);
+        $this->assertEquals(0, $result->defenderUnitsResult->getAmount());
+        $this->assertEquals(0, $result->loot->sum(), 'Mutual retreat must not award loot even with empty combat defender side');
+    }
+
+    public function testFleedShipsAreNotPaddedIntoCombatRoundsAsDestroyed(): void
+    {
+        $settingsService = resolve(SettingsService::class);
+        $defenderPlanet = $this->prepareDefenderPlanet([
+            'light_fighter' => 5,
+            'rocket_launcher' => 100,
+            'deuterium' => 100000,
+        ]);
+
+        $attackerFleet = new UnitCollection();
+        $attackerFleet->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 100);
+
+        $engine = $this->createBattleEngine($attackerFleet, $this->attackerPlayer(), $defenderPlanet, $settingsService);
+        $result = $engine->simulateBattle();
+
+        $this->assertTrue($result->tacticalRetreatDefenderFled);
+        $this->assertNotEmpty($result->rounds);
+
+        foreach ($result->rounds as $round) {
+            $this->assertEquals(
+                0,
+                $round->defenderShips->getAmountByMachineName('light_fighter'),
+                'Fleed ships must not appear in combat rounds'
+            );
+            $this->assertFalse(
+                $round->defenderShips->hasUnit(ObjectService::getUnitObjectByMachineName('light_fighter')),
+                'Fleed ships must not be padded into round unit lists'
+            );
+        }
+    }
+
     /**
      * @param array<string, int> $attributes
      */

--- a/tests/Unit/BattleEngine/TacticalRetreatTest.php
+++ b/tests/Unit/BattleEngine/TacticalRetreatTest.php
@@ -71,7 +71,7 @@ class TacticalRetreatTest extends AccountTestCase
         $attackerFleet = new UnitCollection();
         $attackerFleet->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 100);
 
-        $engine = $this->createBattleEngine($attackerFleet, $this->planetService->getPlayer(), $defenderPlanet, $settingsService);
+        $engine = $this->createBattleEngine($attackerFleet, $this->attackerPlayer(), $defenderPlanet, $settingsService);
         $result = $engine->simulateBattle();
 
         $this->assertTrue($result->tacticalRetreatDefenderFled, 'Defender should flee at 5:1+ supremacy');
@@ -104,7 +104,7 @@ class TacticalRetreatTest extends AccountTestCase
         $attackerFleet = new UnitCollection();
         $attackerFleet->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 100);
 
-        $engine = $this->createBattleEngine($attackerFleet, $this->planetService->getPlayer(), $defenderPlanet, $settingsService);
+        $engine = $this->createBattleEngine($attackerFleet, $this->attackerPlayer(), $defenderPlanet, $settingsService);
         $result = $engine->simulateBattle();
 
         $this->assertFalse($result->tacticalRetreatDefenderFled, 'Flee should fail without deuterium');
@@ -128,7 +128,7 @@ class TacticalRetreatTest extends AccountTestCase
         $attackerFleet = new UnitCollection();
         $attackerFleet->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 100);
 
-        $engine = $this->createBattleEngine($attackerFleet, $this->planetService->getPlayer(), $defenderPlanet, $settingsService);
+        $engine = $this->createBattleEngine($attackerFleet, $this->attackerPlayer(), $defenderPlanet, $settingsService);
         $result = $engine->simulateBattle();
 
         $this->assertFalse($result->tacticalRetreatDefenderFled, 'Flee should be disabled when preference is never');
@@ -162,7 +162,7 @@ class TacticalRetreatTest extends AccountTestCase
         $attackerFleet = new UnitCollection();
         $attackerFleet->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 100);
 
-        $engine = $this->createBattleEngine($attackerFleet, $this->planetService->getPlayer(), $defenderPlanet, $settingsService);
+        $engine = $this->createBattleEngine($attackerFleet, $this->attackerPlayer(), $defenderPlanet, $settingsService);
         $result = $engine->simulateBattle();
 
         $this->assertFalse($result->tacticalRetreatDefenderFled, 'Players at 500k+ points must not flee');
@@ -174,6 +174,9 @@ class TacticalRetreatTest extends AccountTestCase
         $defenderPlanet = $this->prepareDefenderPlanet([
             'deuterium' => 100000,
         ]);
+        $defenderPlayer = $defenderPlanet->getPlayer();
+        $this->assertNotNull($defenderPlayer);
+        $attackerPlayer = $this->attackerPlayer();
 
         $acsUnits = new UnitCollection();
         $acsUnits->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 5);
@@ -181,9 +184,9 @@ class TacticalRetreatTest extends AccountTestCase
         $defenders = [DefenderFleet::fromPlanet($defenderPlanet)];
         $acsDefend = new DefenderFleet();
         $acsDefend->units = $acsUnits;
-        $acsDefend->player = $defenderPlanet->getPlayer();
+        $acsDefend->player = $defenderPlayer;
         $acsDefend->fleetMissionId = 999;
-        $acsDefend->ownerId = $defenderPlanet->getPlayer()->getId();
+        $acsDefend->ownerId = $defenderPlayer->getId();
         $acsDefend->fleetMission = null;
         $defenders[] = $acsDefend;
 
@@ -192,9 +195,9 @@ class TacticalRetreatTest extends AccountTestCase
 
         $attacker = new AttackerFleet();
         $attacker->units = $attackerFleet;
-        $attacker->player = $this->planetService->getPlayer();
+        $attacker->player = $attackerPlayer;
         $attacker->fleetMissionId = 1;
-        $attacker->ownerId = $this->planetService->getPlayer()->getId();
+        $attacker->ownerId = $attackerPlayer->getId();
         $attacker->cargoResources = new Resources(0, 0, 0, 0);
         $attacker->isInitiator = true;
         $attacker->fleetMission = null;
@@ -218,7 +221,7 @@ class TacticalRetreatTest extends AccountTestCase
         $attackerFleet = new UnitCollection();
         $attackerFleet->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 100);
 
-        $engine = $this->createBattleEngine($attackerFleet, $this->planetService->getPlayer(), $defenderPlanet, $settingsService);
+        $engine = $this->createBattleEngine($attackerFleet, $this->attackerPlayer(), $defenderPlanet, $settingsService);
         $engine->setRetreatAfterDefenderRetreat(true);
         $result = $engine->simulateBattle();
 
@@ -254,6 +257,16 @@ class TacticalRetreatTest extends AccountTestCase
         }
 
         return $secondPlanet;
+    }
+
+    private function attackerPlayer(): PlayerService
+    {
+        $player = $this->planetService->getPlayer();
+        if ($player === null) {
+            $this->fail('Attacker planet has no player.');
+        }
+
+        return $player;
     }
 
     private function createBattleEngine(

--- a/tests/Unit/BattleEngine/TacticalRetreatTest.php
+++ b/tests/Unit/BattleEngine/TacticalRetreatTest.php
@@ -41,15 +41,29 @@ class TacticalRetreatTest extends AccountTestCase
         $this->assertEquals(45, $this->service->calculateFleetPoints($units));
     }
 
-    public function testExcludedShipsAndDefensesDoNotCount(): void
+    public function testZeroPointShipsAndDefensesDoNotCount(): void
     {
         $units = new UnitCollection();
-        $units->addUnit(ObjectService::getUnitObjectByMachineName('deathstar'), 1);
         $units->addUnit(ObjectService::getUnitObjectByMachineName('espionage_probe'), 100);
         $units->addUnit(ObjectService::getUnitObjectByMachineName('solar_satellite'), 50);
+        $units->addUnit(ObjectService::getUnitObjectByMachineName('crawler'), 20);
         $units->addUnit(ObjectService::getUnitObjectByMachineName('rocket_launcher'), 200);
 
         $this->assertEquals(0, $this->service->calculateFleetPoints($units));
+    }
+
+    public function testDeathstarCountsForPointsButCannotFlee(): void
+    {
+        $units = new UnitCollection();
+        $units->addUnit(ObjectService::getUnitObjectByMachineName('deathstar'), 1);
+        $units->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 5);
+
+        // Deathstar is a combat ship for ratio points (10M resources → 10000 pts) but cannot flee.
+        $this->assertEquals(10000 + 20, $this->service->calculateFleetPoints($units));
+
+        $fleeing = $this->service->extractFleeingUnits($units);
+        $this->assertEquals(0, $fleeing->getAmountByMachineName('deathstar'));
+        $this->assertEquals(5, $fleeing->getAmountByMachineName('light_fighter'));
     }
 
     public function testSupremacyRatioRounding(): void
@@ -57,6 +71,83 @@ class TacticalRetreatTest extends AccountTestCase
         $this->assertEquals(5, $this->service->calculateSupremacyRatio(100, 20));
         $this->assertEquals(1, $this->service->calculateSupremacyRatio(0, 20));
         $this->assertEquals(10, $this->service->calculateSupremacyRatio(10, 0));
+    }
+
+    public function testFleeTriggersAtExactFiveToOneRatio(): void
+    {
+        $settingsService = resolve(SettingsService::class);
+        // 4 LF defender = 16 points; 20 LF attacker = 80 points → exact 5:1
+        $defenderPlanet = $this->prepareDefenderPlanet([
+            'light_fighter' => 4,
+            'deuterium' => 100000,
+        ]);
+
+        $attackerFleet = new UnitCollection();
+        $attackerFleet->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 20);
+
+        $engine = $this->createBattleEngine($attackerFleet, $this->attackerPlayer(), $defenderPlanet, $settingsService);
+        $result = $engine->simulateBattle();
+
+        $this->assertEquals(5, $result->tacticalRetreatRatio);
+        $this->assertTrue(
+            $result->tacticalRetreatDefenderFled,
+            'OGame flees from a 5:1 ratio (attackerPoints >= 5 * defenderPoints)'
+        );
+    }
+
+    public function testFleeDoesNotTriggerJustBelowFiveToOne(): void
+    {
+        $settingsService = resolve(SettingsService::class);
+        // 5 LF defender = 20 points; 99 LF attacker = 396 points → 19.8:1 floored display 19, but 396 < 100
+        // Use 4 LF = 16 pts; 79 LF = 316 pts → 316 < 80, ratio floor 19 but below threshold
+        $defenderPlanet = $this->prepareDefenderPlanet([
+            'light_fighter' => 4,
+            'deuterium' => 100000,
+        ]);
+
+        $attackerFleet = new UnitCollection();
+        $attackerFleet->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 19);
+
+        $engine = $this->createBattleEngine($attackerFleet, $this->attackerPlayer(), $defenderPlanet, $settingsService);
+        $result = $engine->simulateBattle();
+
+        $this->assertEquals(76, $result->tacticalRetreatAttackerPoints);
+        $this->assertEquals(16, $result->tacticalRetreatDefenderPoints);
+        $this->assertFalse(
+            $result->tacticalRetreatDefenderFled,
+            '19 LF vs 4 LF is 76:16 which is below exact 5:1 (80 required)'
+        );
+    }
+
+    public function testFleeDeuteriumUsesNeighboringPlanetSlotNotSystem(): void
+    {
+        $defenderPlanet = $this->prepareDefenderPlanet([
+            'light_fighter' => 10,
+            'deuterium' => 100000,
+        ]);
+        $coords = $defenderPlanet->getPlanetCoordinates();
+        $neighborPosition = $coords->position + 1;
+        if ($neighborPosition > 15) {
+            $neighborPosition = $coords->position - 1;
+        }
+
+        $fleeing = new UnitCollection();
+        $fleeing->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 10);
+
+        $player = $defenderPlanet->getPlayer();
+        $this->assertNotNull($player);
+        $fleetMissionService = resolve(\OGame\Services\FleetMissionService::class, ['player' => $player]);
+
+        $neighborSlot = new \OGame\Models\Planet\Coordinate($coords->galaxy, $coords->system, $neighborPosition);
+        $neighborSystem = new \OGame\Models\Planet\Coordinate($coords->galaxy, $coords->system + 1, $coords->position);
+
+        $slotCost = (int)ceil($fleetMissionService->calculateConsumption($defenderPlanet, $fleeing, $neighborSlot, 0, 10.0) * 1.5);
+        $systemCost = (int)ceil($fleetMissionService->calculateConsumption($defenderPlanet, $fleeing, $neighborSystem, 0, 10.0) * 1.5);
+
+        $actual = $this->service->calculateFleeDeuteriumCost($defenderPlanet, $fleeing);
+
+        $this->assertEquals($slotCost, $actual, 'Flee fuel must use neighbouring planet slot');
+        $this->assertNotEquals($systemCost, $actual, 'Flee fuel must not use neighbouring system distance');
     }
 
     public function testDefenderFleetFleesWhenRatioMet(): void

--- a/tests/Unit/BattleEngine/TacticalRetreatTest.php
+++ b/tests/Unit/BattleEngine/TacticalRetreatTest.php
@@ -1,0 +1,278 @@
+<?php
+
+namespace Tests\Unit\BattleEngine;
+
+use OGame\GameMissions\BattleEngine\Models\AttackerFleet;
+use OGame\GameMissions\BattleEngine\Models\DefenderFleet;
+use OGame\GameMissions\BattleEngine\PhpBattleEngine;
+use OGame\GameMissions\BattleEngine\Services\TacticalRetreatService;
+use OGame\GameObjects\Models\Units\UnitCollection;
+use OGame\Models\Highscore;
+use OGame\Models\Resources;
+use OGame\Services\ObjectService;
+use OGame\Services\PlanetService;
+use OGame\Services\PlayerService;
+use OGame\Services\SettingsService;
+use Tests\AccountTestCase;
+
+/**
+ * Tests for tactical retreat point weighting, gates, and battle integration.
+ */
+class TacticalRetreatTest extends AccountTestCase
+{
+    protected int $userPlanetAmount = 2;
+
+    private TacticalRetreatService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new TacticalRetreatService();
+    }
+
+    public function testCombatShipsCountFullPointsAndCivilShipsQuarter(): void
+    {
+        $units = new UnitCollection();
+        // Light fighter: 4000 resources → 4 points each → 40 points for 10
+        $units->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 10);
+        // Small cargo: 4000 resources * 25% → 1 point each → 5 points for 5
+        $units->addUnit(ObjectService::getUnitObjectByMachineName('small_cargo'), 5);
+
+        $this->assertEquals(45, $this->service->calculateFleetPoints($units));
+    }
+
+    public function testExcludedShipsAndDefensesDoNotCount(): void
+    {
+        $units = new UnitCollection();
+        $units->addUnit(ObjectService::getUnitObjectByMachineName('deathstar'), 1);
+        $units->addUnit(ObjectService::getUnitObjectByMachineName('espionage_probe'), 100);
+        $units->addUnit(ObjectService::getUnitObjectByMachineName('solar_satellite'), 50);
+        $units->addUnit(ObjectService::getUnitObjectByMachineName('rocket_launcher'), 200);
+
+        $this->assertEquals(0, $this->service->calculateFleetPoints($units));
+    }
+
+    public function testSupremacyRatioRounding(): void
+    {
+        $this->assertEquals(5, $this->service->calculateSupremacyRatio(100, 20));
+        $this->assertEquals(1, $this->service->calculateSupremacyRatio(0, 20));
+        $this->assertEquals(10, $this->service->calculateSupremacyRatio(10, 0));
+    }
+
+    public function testDefenderFleetFleesWhenRatioMet(): void
+    {
+        $settingsService = resolve(SettingsService::class);
+        $defenderPlanet = $this->prepareDefenderPlanet([
+            'light_fighter' => 5,
+            'rocket_launcher' => 10,
+            'deuterium' => 100000,
+        ]);
+
+        $attackerFleet = new UnitCollection();
+        $attackerFleet->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 100);
+
+        $engine = $this->createBattleEngine($attackerFleet, $this->planetService->getPlayer(), $defenderPlanet, $settingsService);
+        $result = $engine->simulateBattle();
+
+        $this->assertTrue($result->tacticalRetreatDefenderFled, 'Defender should flee at 5:1+ supremacy');
+        $this->assertGreaterThanOrEqual(5, $result->tacticalRetreatRatio);
+        $this->assertFalse($result->tacticalRetreatAttackerAlsoRetreated);
+        $this->assertEquals(5, $result->tacticalRetreatFleeingUnits?->getAmountByMachineName('light_fighter'));
+        // Fleeing fighters must not count as combat losses.
+        $this->assertEquals(0, $result->defenderUnitsLost->getAmountByMachineName('light_fighter'));
+        // Defenses remain in the combat composition after flee.
+        $this->assertEquals(10, $result->defenderUnitsStart->getAmountByMachineName('rocket_launcher'));
+        $this->assertGreaterThan(0, $result->tacticalRetreatDeuteriumCost);
+    }
+
+    public function testInsufficientDeuteriumPreventsFlee(): void
+    {
+        $settingsService = resolve(SettingsService::class);
+        $defenderPlanet = $this->prepareDefenderPlanet([
+            'light_fighter' => 5,
+            'deuterium' => 0,
+        ]);
+        // Drain any leftover resources.
+        $resources = $defenderPlanet->getResources();
+        $defenderPlanet->deductResources(new Resources(
+            (int)$resources->metal->get(),
+            (int)$resources->crystal->get(),
+            (int)$resources->deuterium->get(),
+            0
+        ));
+
+        $attackerFleet = new UnitCollection();
+        $attackerFleet->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 100);
+
+        $engine = $this->createBattleEngine($attackerFleet, $this->planetService->getPlayer(), $defenderPlanet, $settingsService);
+        $result = $engine->simulateBattle();
+
+        $this->assertFalse($result->tacticalRetreatDefenderFled, 'Flee should fail without deuterium');
+        $this->assertEquals(5, $result->defenderUnitsStart->getAmountByMachineName('light_fighter'));
+        $this->assertEquals(5, $result->defenderUnitsLost->getAmountByMachineName('light_fighter'));
+    }
+
+    public function testNeverPreferencePreventsFlee(): void
+    {
+        $settingsService = resolve(SettingsService::class);
+        $defenderPlanet = $this->prepareDefenderPlanet([
+            'light_fighter' => 5,
+            'deuterium' => 100000,
+        ]);
+        $defenderPlayer = $defenderPlanet->getPlayer();
+        $this->assertNotNull($defenderPlayer);
+        $user = $defenderPlayer->getUser();
+        $user->tactical_retreat_ratio = 0;
+        $user->save();
+
+        $attackerFleet = new UnitCollection();
+        $attackerFleet->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 100);
+
+        $engine = $this->createBattleEngine($attackerFleet, $this->planetService->getPlayer(), $defenderPlanet, $settingsService);
+        $result = $engine->simulateBattle();
+
+        $this->assertFalse($result->tacticalRetreatDefenderFled, 'Flee should be disabled when preference is never');
+        $this->assertEquals(5, $result->defenderUnitsLost->getAmountByMachineName('light_fighter'));
+    }
+
+    public function testPointsCutoffPreventsFlee(): void
+    {
+        $settingsService = resolve(SettingsService::class);
+        $defenderPlanet = $this->prepareDefenderPlanet([
+            'light_fighter' => 5,
+            'deuterium' => 100000,
+        ]);
+        $defenderPlayer = $defenderPlanet->getPlayer();
+        $this->assertNotNull($defenderPlayer);
+
+        Highscore::updateOrCreate(
+            ['player_id' => $defenderPlayer->getId()],
+            [
+                'general' => 500000,
+                'economy' => 0,
+                'research' => 0,
+                'military' => 0,
+                'general_rank' => 1,
+                'economy_rank' => 1,
+                'research_rank' => 1,
+                'military_rank' => 1,
+            ]
+        );
+
+        $attackerFleet = new UnitCollection();
+        $attackerFleet->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 100);
+
+        $engine = $this->createBattleEngine($attackerFleet, $this->planetService->getPlayer(), $defenderPlanet, $settingsService);
+        $result = $engine->simulateBattle();
+
+        $this->assertFalse($result->tacticalRetreatDefenderFled, 'Players at 500k+ points must not flee');
+    }
+
+    public function testAcsDefendFleetDoesNotFlee(): void
+    {
+        $settingsService = resolve(SettingsService::class);
+        $defenderPlanet = $this->prepareDefenderPlanet([
+            'deuterium' => 100000,
+        ]);
+
+        $acsUnits = new UnitCollection();
+        $acsUnits->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 5);
+
+        $defenders = [DefenderFleet::fromPlanet($defenderPlanet)];
+        $acsDefend = new DefenderFleet();
+        $acsDefend->units = $acsUnits;
+        $acsDefend->player = $defenderPlanet->getPlayer();
+        $acsDefend->fleetMissionId = 999;
+        $acsDefend->ownerId = $defenderPlanet->getPlayer()->getId();
+        $acsDefend->fleetMission = null;
+        $defenders[] = $acsDefend;
+
+        $attackerFleet = new UnitCollection();
+        $attackerFleet->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 100);
+
+        $attacker = new AttackerFleet();
+        $attacker->units = $attackerFleet;
+        $attacker->player = $this->planetService->getPlayer();
+        $attacker->fleetMissionId = 1;
+        $attacker->ownerId = $this->planetService->getPlayer()->getId();
+        $attacker->cargoResources = new Resources(0, 0, 0, 0);
+        $attacker->isInitiator = true;
+        $attacker->fleetMission = null;
+
+        $engine = new PhpBattleEngine([$attacker], $defenderPlanet, $defenders, $settingsService);
+        $result = $engine->simulateBattle();
+
+        $this->assertFalse($result->tacticalRetreatDefenderFled);
+        $this->assertEquals(0, $result->defenderUnitsResult->getAmountByMachineName('light_fighter'));
+    }
+
+    public function testAttackerAlsoRetreatsWhenConfigured(): void
+    {
+        $settingsService = resolve(SettingsService::class);
+        $defenderPlanet = $this->prepareDefenderPlanet([
+            'light_fighter' => 5,
+            'rocket_launcher' => 50,
+            'deuterium' => 100000,
+        ]);
+
+        $attackerFleet = new UnitCollection();
+        $attackerFleet->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 100);
+
+        $engine = $this->createBattleEngine($attackerFleet, $this->planetService->getPlayer(), $defenderPlanet, $settingsService);
+        $engine->setRetreatAfterDefenderRetreat(true);
+        $result = $engine->simulateBattle();
+
+        $this->assertTrue($result->tacticalRetreatDefenderFled);
+        $this->assertTrue($result->tacticalRetreatAttackerAlsoRetreated);
+        $this->assertCount(0, $result->rounds);
+        $this->assertEquals(0, $result->loot->sum());
+        $this->assertEquals(100, $result->attackerUnitsResult->getAmountByMachineName('light_fighter'));
+        $this->assertEquals(50, $result->defenderUnitsResult->getAmountByMachineName('rocket_launcher'));
+        $this->assertEquals(0, $result->defenderUnitsLost->getAmountByMachineName('rocket_launcher'));
+    }
+
+    /**
+     * @param array<string, int> $attributes
+     */
+    private function prepareDefenderPlanet(array $attributes): PlanetService
+    {
+        $secondPlanet = $this->secondPlanetService;
+        if ($secondPlanet === null) {
+            $this->fail('Second planet not initialized');
+        }
+
+        $deuterium = $attributes['deuterium'] ?? 10000;
+        $secondPlanet->addResources(new Resources(10000, 10000, $deuterium, 0));
+
+        foreach ($attributes as $key => $value) {
+            if (in_array($key, ['metal', 'crystal', 'deuterium'], true)) {
+                continue;
+            }
+            if ($value > 0) {
+                $secondPlanet->addUnit($key, $value);
+            }
+        }
+
+        return $secondPlanet;
+    }
+
+    private function createBattleEngine(
+        UnitCollection $attackerFleet,
+        PlayerService $player,
+        PlanetService $defenderPlanet,
+        SettingsService $settingsService
+    ): PhpBattleEngine {
+        $defenders = [DefenderFleet::fromPlanet($defenderPlanet)];
+
+        $attacker = new AttackerFleet();
+        $attacker->units = $attackerFleet;
+        $attacker->player = $player;
+        $attacker->fleetMissionId = 1;
+        $attacker->ownerId = $player->getId();
+        $attacker->cargoResources = new Resources(0, 0, 0, 0);
+        $attacker->isInitiator = true;
+        $attacker->fleetMission = null;
+
+        return new PhpBattleEngine([$attacker], $defenderPlanet, $defenders, $settingsService);
+    }
+}

--- a/tests/Unit/BattleEngine/TacticalRetreatTestAbstract.php
+++ b/tests/Unit/BattleEngine/TacticalRetreatTestAbstract.php
@@ -2,13 +2,21 @@
 
 namespace Tests\Unit\BattleEngine;
 
+use OGame\Factories\PlanetServiceFactory;
+use OGame\Factories\PlayerServiceFactory;
+use OGame\GameConstants\UniverseConstants;
+use OGame\GameMissions\BattleEngine\BattleEngine;
 use OGame\GameMissions\BattleEngine\Models\AttackerFleet;
 use OGame\GameMissions\BattleEngine\Models\DefenderFleet;
-use OGame\GameMissions\BattleEngine\PhpBattleEngine;
+use OGame\GameMissions\BattleEngine\Models\TacticalRetreatDecision;
 use OGame\GameMissions\BattleEngine\Services\TacticalRetreatService;
 use OGame\GameObjects\Models\Units\UnitCollection;
 use OGame\Models\Highscore;
+use OGame\Models\Planet\Coordinate;
 use OGame\Models\Resources;
+use OGame\Services\FleetMissionService;
+use OGame\Services\NPCPlanetService;
+use OGame\Services\NPCPlayerService;
 use OGame\Services\ObjectService;
 use OGame\Services\PlanetService;
 use OGame\Services\PlayerService;
@@ -17,12 +25,21 @@ use Tests\AccountTestCase;
 
 /**
  * Tests for tactical retreat point weighting, gates, and battle integration.
+ *
+ * Battle-engine integration tests run for both PHP and Rust via subclasses,
+ * matching BattleEngineTestAbstract. Service-level tests live here too so
+ * blockedReason gates are asserted against the shared evaluator.
  */
-class TacticalRetreatTest extends AccountTestCase
+abstract class TacticalRetreatTestAbstract extends AccountTestCase
 {
     protected int $userPlanetAmount = 2;
 
     private TacticalRetreatService $service;
+
+    /**
+     * @return class-string<BattleEngine>
+     */
+    abstract protected function battleEngineClass(): string;
 
     protected function setUp(): void
     {
@@ -98,8 +115,7 @@ class TacticalRetreatTest extends AccountTestCase
     public function testFleeDoesNotTriggerJustBelowFiveToOne(): void
     {
         $settingsService = resolve(SettingsService::class);
-        // 5 LF defender = 20 points; 99 LF attacker = 396 points → 19.8:1 floored display 19, but 396 < 100
-        // Use 4 LF = 16 pts; 79 LF = 316 pts → 316 < 80, ratio floor 19 but below threshold
+        // 4 LF defender = 16 points; 19 LF attacker = 76 points → 76 < 80 required for exact 5:1
         $defenderPlanet = $this->prepareDefenderPlanet([
             'light_fighter' => 4,
             'deuterium' => 100000,
@@ -127,7 +143,7 @@ class TacticalRetreatTest extends AccountTestCase
         ]);
         $coords = $defenderPlanet->getPlanetCoordinates();
         $neighborPosition = $coords->position + 1;
-        if ($neighborPosition > 15) {
+        if ($neighborPosition > UniverseConstants::MAX_PLANET_POSITION) {
             $neighborPosition = $coords->position - 1;
         }
 
@@ -136,10 +152,10 @@ class TacticalRetreatTest extends AccountTestCase
 
         $player = $defenderPlanet->getPlayer();
         $this->assertNotNull($player);
-        $fleetMissionService = resolve(\OGame\Services\FleetMissionService::class, ['player' => $player]);
+        $fleetMissionService = resolve(FleetMissionService::class, ['player' => $player]);
 
-        $neighborSlot = new \OGame\Models\Planet\Coordinate($coords->galaxy, $coords->system, $neighborPosition);
-        $neighborSystem = new \OGame\Models\Planet\Coordinate($coords->galaxy, $coords->system + 1, $coords->position);
+        $neighborSlot = new Coordinate($coords->galaxy, $coords->system, $neighborPosition);
+        $neighborSystem = new Coordinate($coords->galaxy, $coords->system + 1, $coords->position);
 
         $slotCost = (int)ceil($fleetMissionService->calculateConsumption($defenderPlanet, $fleeing, $neighborSlot, 0, 10.0) * 1.5);
         $systemCost = (int)ceil($fleetMissionService->calculateConsumption($defenderPlanet, $fleeing, $neighborSystem, 0, 10.0) * 1.5);
@@ -259,6 +275,90 @@ class TacticalRetreatTest extends AccountTestCase
         $this->assertFalse($result->tacticalRetreatDefenderFled, 'Players at 500k+ points must not flee');
     }
 
+    public function testNpcDefenderBlockedReasonPreventsFlee(): void
+    {
+        $basePlanet = $this->prepareDefenderPlanet([
+            'light_fighter' => 5,
+            'deuterium' => 100000,
+        ]);
+
+        $npcFleet = new UnitCollection();
+        $npcFleet->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 5);
+
+        $npcPlayer = new NPCPlayerService('pirate', 0, 0, 0);
+        $npcPlanet = new NPCPlanetService(
+            resolve(PlayerServiceFactory::class),
+            resolve(SettingsService::class),
+            $npcPlayer,
+            $npcFleet,
+            $basePlanet->getPlanetId()
+        );
+
+        $attackerFleet = new UnitCollection();
+        $attackerFleet->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 100);
+
+        $decision = $this->evaluateRetreat($npcPlanet, $attackerFleet);
+        $this->assertSame('npc', $decision->blockedReason);
+        $this->assertFalse($decision->defenderFled);
+
+        $engine = $this->createBattleEngine($attackerFleet, $this->attackerPlayer(), $npcPlanet, resolve(SettingsService::class));
+        $result = $engine->simulateBattle();
+        $this->assertFalse($result->tacticalRetreatDefenderFled, 'Expedition NPC fleets must never flee');
+        $this->assertEquals(5, $result->defenderUnitsLost->getAmountByMachineName('light_fighter'));
+    }
+
+    public function testInactiveDefenderBlockedReasonPreventsFlee(): void
+    {
+        $defenderPlanet = $this->prepareDefenderPlanet([
+            'light_fighter' => 5,
+            'deuterium' => 100000,
+        ]);
+        $defenderPlayer = $defenderPlanet->getPlayer();
+        $this->assertNotNull($defenderPlayer);
+        $user = $defenderPlayer->getUser();
+        $user->time = (string) now()->subDays(8)->timestamp;
+        $user->save();
+
+        $attackerFleet = new UnitCollection();
+        $attackerFleet->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 100);
+
+        $decision = $this->evaluateRetreat($defenderPlanet, $attackerFleet);
+        $this->assertSame('inactive', $decision->blockedReason);
+        $this->assertFalse($decision->defenderFled);
+
+        $engine = $this->createBattleEngine($attackerFleet, $this->attackerPlayer(), $defenderPlanet, resolve(SettingsService::class));
+        $result = $engine->simulateBattle();
+        $this->assertFalse($result->tacticalRetreatDefenderFled, 'Inactive fleets must not flee');
+        $this->assertEquals(5, $result->defenderUnitsLost->getAmountByMachineName('light_fighter'));
+    }
+
+    public function testMoonStationedFleetFleesViaSharedBattleEngine(): void
+    {
+        $secondPlanet = $this->secondPlanetService;
+        if ($secondPlanet === null) {
+            $this->fail('Second planet not initialized');
+        }
+
+        $planetServiceFactory = resolve(PlanetServiceFactory::class);
+        $moon = $planetServiceFactory->createMoonForPlanet($secondPlanet, 2000000, 20);
+        $moon->addResources(new Resources(10000, 10000, 100000, 0));
+        $moon->addUnit('light_fighter', 5);
+        $moon->save();
+
+        $attackerFleet = new UnitCollection();
+        $attackerFleet->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 100);
+
+        $engine = $this->createBattleEngine($attackerFleet, $this->attackerPlayer(), $moon, resolve(SettingsService::class));
+        $result = $engine->simulateBattle();
+
+        $this->assertTrue(
+            $result->tacticalRetreatDefenderFled,
+            'Moon-stationed fleets currently flee because MoonDestructionMission shares simulateBattle()'
+        );
+        $this->assertEquals(5, $result->tacticalRetreatFleeingUnits?->getAmountByMachineName('light_fighter'));
+        $this->assertEquals(0, $result->defenderUnitsLost->getAmountByMachineName('light_fighter'));
+    }
+
     public function testAcsDefendFleetDoesNotFlee(): void
     {
         $settingsService = resolve(SettingsService::class);
@@ -284,16 +384,8 @@ class TacticalRetreatTest extends AccountTestCase
         $attackerFleet = new UnitCollection();
         $attackerFleet->addUnit(ObjectService::getUnitObjectByMachineName('light_fighter'), 100);
 
-        $attacker = new AttackerFleet();
-        $attacker->units = $attackerFleet;
-        $attacker->player = $attackerPlayer;
-        $attacker->fleetMissionId = 1;
-        $attacker->ownerId = $attackerPlayer->getId();
-        $attacker->cargoResources = new Resources(0, 0, 0, 0);
-        $attacker->isInitiator = true;
-        $attacker->fleetMission = null;
-
-        $engine = new PhpBattleEngine([$attacker], $defenderPlanet, $defenders, $settingsService);
+        $engineClass = $this->battleEngineClass();
+        $engine = new $engineClass([$this->makeAttackerFleet($attackerFleet, $attackerPlayer)], $defenderPlanet, $defenders, $settingsService);
         $result = $engine->simulateBattle();
 
         $this->assertFalse($result->tacticalRetreatDefenderFled);
@@ -413,14 +505,20 @@ class TacticalRetreatTest extends AccountTestCase
         return $player;
     }
 
-    private function createBattleEngine(
-        UnitCollection $attackerFleet,
-        PlayerService $player,
-        PlanetService $defenderPlanet,
-        SettingsService $settingsService
-    ): PhpBattleEngine {
+    private function evaluateRetreat(PlanetService $defenderPlanet, UnitCollection $attackerFleet): TacticalRetreatDecision
+    {
         $defenders = [DefenderFleet::fromPlanet($defenderPlanet)];
 
+        return $this->service->evaluate(
+            $defenderPlanet,
+            [$this->makeAttackerFleet($attackerFleet, $this->attackerPlayer())],
+            $defenders,
+            false,
+        );
+    }
+
+    private function makeAttackerFleet(UnitCollection $attackerFleet, PlayerService $player): AttackerFleet
+    {
         $attacker = new AttackerFleet();
         $attacker->units = $attackerFleet;
         $attacker->player = $player;
@@ -430,6 +528,22 @@ class TacticalRetreatTest extends AccountTestCase
         $attacker->isInitiator = true;
         $attacker->fleetMission = null;
 
-        return new PhpBattleEngine([$attacker], $defenderPlanet, $defenders, $settingsService);
+        return $attacker;
+    }
+
+    private function createBattleEngine(
+        UnitCollection $attackerFleet,
+        PlayerService $player,
+        PlanetService $defenderPlanet,
+        SettingsService $settingsService
+    ): BattleEngine {
+        $engineClass = $this->battleEngineClass();
+
+        return new $engineClass(
+            [$this->makeAttackerFleet($attackerFleet, $player)],
+            $defenderPlanet,
+            [DefenderFleet::fromPlanet($defenderPlanet)],
+            $settingsService
+        );
     }
 }


### PR DESCRIPTION
## Summary

* Implements OGame tactical retreat in the shared battle engine: supremacy ratio, flee gates, deuterium cost, and optional attacker return-on-retreat
* Persists defender preference (`users.tactical_retreat_ratio`) and attack option (`fleet_missions.retreat_after_defender_retreat`), and wires the fleet UI
* Replaces the static battle-report `1:100` / “did not flee” with real ratio and flee status
* Aligned to authentic OGame behavior (Gameforge / simulators): Deathstars count for points but cannot flee; flee deuterium uses neighbouring **planet slot**; threshold uses `>=` (e.g. exact 5:1 flees)

Closes #294

### Behavior notes

* **Moon destruction** uses the same `simulateBattle()`, so moon-stationed fleets currently flee. Flee fuel is still 1.5× a neighbouring **planet slot** computed from the moon’s coordinates. This matches the shared engine; there is no separate moon-destruction exception. Covered by `testMoonStationedFleetFleesViaSharedBattleEngine`. Moon destruction battle reports now persist the same `tactical_retreat` payload as attacks.
* **`ogamex:test:battle-engine-performance`** sets the fixture player’s retreat preference to Never so defending ships cannot flee mid-benchmark and invalidate timing.

### Follow-ups (out of scope here)

* Honourable-combat / bandit no-flee gates → #1560 (blocked on honour system #742)
* Stale battle-report `data-raw-*` mock client metadata → #1561 (visible PHP ratio/flee text is already correct)

## Test plan

* [x] `php artisan test --filter='TacticalRetreat|PhpBattleEngineTest|HamillManoeuvreTest|FleetDispatchAttackTest::testDispatchFleetCombatReport'` (61 passed; Pint + PHPStan clean)
* [x] Preview https://pr-1551.preview.ogamex.dev @ `35f63e4`: preference persist; flee at 5:1; Never = no flee; inactive no flee; mutual retreat (0 rounds / 0 loot); defenses-only combat
* [ ] Manual UI glance: Fleet Never / 5:1 radios, “Return upon retreat by defenders” checkbox, Admiral 3:1 when available
* Attack a much weaker fleet and confirm the report shows a real `1:N` ratio, flee text, and the deuterium cost when the defender flees
* Confirm fleed ships remain on the defender planet while defenses can still fight
* Toggle Never / 5:1 on the fleet page and confirm preference persists
* Send an attack with “Return upon retreat by defenders” and confirm both sides withdraw without combat rounds