### PR TITLE
fix: build and test rust on macos and cross-platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ yarn-error.log
 rust/*/target
 # Compiled rust apps (rust modules are recompiled during container start)
 storage/rust-libs/*.so
+storage/rust-libs/*.dylib
+storage/rust-libs/*.dll

--- a/app/GameMissions/BattleEngine/RustBattleEngine.php
+++ b/app/GameMissions/BattleEngine/RustBattleEngine.php
@@ -11,6 +11,7 @@ use OGame\GameObjects\Models\Units\UnitCollection;
 use OGame\Services\CharacterClassService;
 use OGame\Services\ObjectService;
 use OGame\Services\PlanetService;
+use OGame\Services\RustFfiLibrary;
 use OGame\Services\SettingsService;
 use RuntimeException;
 use stdClass;
@@ -45,7 +46,7 @@ class RustBattleEngine extends BattleEngine
 
         $this->ffi = FFI::cdef(
             "char* fight_battle_rounds(const char* input_json);",
-            base_path('storage/rust-libs/libbattle_engine_ffi.so')
+            RustFfiLibrary::path('battle_engine_ffi')
         );
     }
 

--- a/app/Services/RustFfiLibrary.php
+++ b/app/Services/RustFfiLibrary.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace OGame\Services;
+
+/**
+ * Resolves the file system path to compiled Rust shared libraries.
+ *
+ * Rust produces platform specific shared library file names:
+ * - Linux:   lib<name>.so
+ * - macOS:   lib<name>.dylib
+ * - Windows: <name>.dll
+ *
+ * PHP's FFI loads whatever file it is pointed at, so this helper ensures the
+ * correct file is referenced regardless of the operating system PHP runs on.
+ */
+class RustFfiLibrary
+{
+    /**
+     * Get the full path to a compiled Rust library within storage/rust-libs.
+     *
+     * @param string $name Library name without "lib" prefix or extension (e.g. "battle_engine_ffi").
+     * @return string
+     */
+    public static function path(string $name): string
+    {
+        return base_path('storage/rust-libs/' . self::filename($name));
+    }
+
+    /**
+     * Build the platform specific file name for a Rust library.
+     *
+     * @param string $name
+     * @return string
+     */
+    public static function filename(string $name): string
+    {
+        return match (PHP_OS_FAMILY) {
+            'Windows' => $name . '.dll',
+            'Darwin' => "lib{$name}.dylib",
+            default => "lib{$name}.so",
+        };
+    }
+}

--- a/rust/README.md
+++ b/rust/README.md
@@ -23,8 +23,10 @@ cd rust
 # Compile the rust packages
 cargo build --release
 # Copy the compiled rust package to the storage/rust-libs directory.
-# These .so files are called by Laravel.
-cp target/release/lib*_ffi.so ../../storage/rust-libs
+# The shared library extension differs per OS. The compile.sh script
+# (above) detects this automatically; manually, use:
+#   Linux:  cp target/release/lib*_ffi.so ../../storage/rust-libs
+#   macOS:  cp target/release/lib*_ffi.dylib ../../storage/rust-libs
 ```
 
 ## Debugging Rust code

--- a/rust/compile.sh
+++ b/rust/compile.sh
@@ -1,5 +1,26 @@
 #!/bin/sh
 
+# Determine the shared library extension for the current platform.
+# PHP loads these libraries through FFI, which accepts any extension, but
+# Rust uses a platform specific one by default.
+case "$(uname -s)" in
+    Darwin)
+        LIB_EXT="dylib"
+        LIB_PREFIX="lib"
+        ;;
+    MINGW*|MSYS*|CYGWIN*)
+        LIB_EXT="dll"
+        LIB_PREFIX=""
+        ;;
+    *)
+        LIB_EXT="so"
+        LIB_PREFIX="lib"
+        ;;
+esac
+
+BATTLE_ENGINE_LIB="${LIB_PREFIX}battle_engine_ffi.${LIB_EXT}"
+TEST_FFI_LIB="${LIB_PREFIX}test_ffi.${LIB_EXT}"
+
 # Compile the rust workspace
 echo "Compiling Rust workspace..."
 if ! cargo build "--manifest-path=rust/Cargo.toml" "--release"; then
@@ -8,18 +29,18 @@ if ! cargo build "--manifest-path=rust/Cargo.toml" "--release"; then
 fi
 
 # Copy the compiled rust libraries to the storage/rust-libs directory.
-# The .so files are called by Laravel.
-if [ -f rust/target/release/libbattle_engine_ffi.so ]; then
-    cp rust/target/release/libbattle_engine_ffi.so storage/rust-libs/
-    echo "Copied libbattle_engine_ffi.so"
+# These shared libraries are called by Laravel.
+if [ -f "rust/target/release/${BATTLE_ENGINE_LIB}" ]; then
+    cp "rust/target/release/${BATTLE_ENGINE_LIB}" storage/rust-libs/
+    echo "Copied ${BATTLE_ENGINE_LIB}"
 else
-    echo "ERROR: libbattle_engine_ffi.so not found after compilation!"
+    echo "ERROR: ${BATTLE_ENGINE_LIB} not found after compilation!"
     exit 1
 fi
 
-if [ -f rust/target/release/libtest_ffi.so ]; then
-    cp rust/target/release/libtest_ffi.so storage/rust-libs/
-    echo "Copied libtest_ffi.so"
+if [ -f "rust/target/release/${TEST_FFI_LIB}" ]; then
+    cp "rust/target/release/${TEST_FFI_LIB}" storage/rust-libs/
+    echo "Copied ${TEST_FFI_LIB}"
 fi
 
 echo "Rust compilation completed successfully!"

--- a/tests/Unit/RustFfiTest.php
+++ b/tests/Unit/RustFfiTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit;
 
 use FFI;
+use OGame\Services\RustFfiLibrary;
 use Tests\UnitTestCase;
 
 class RustFfiTest extends UnitTestCase
@@ -12,8 +13,8 @@ class RustFfiTest extends UnitTestCase
      */
     public function testRustFfiInterface(): void
     {
-        // Path to your .so file
-        $libPath = base_path('storage/rust-libs/libtest_ffi.so');
+        // Resolve the platform-specific shared library path.
+        $libPath = RustFfiLibrary::path('test_ffi');
 
         // Define the function signature in C syntax
         $ffi = FFI::cdef("


### PR DESCRIPTION
## Description
Makes Rust FFI library loading cross-platform by resolving the platform-specific shared library extension at runtime.

Fixes #1556 

Previously the PHP code hardcoded `libbattle_engine_ffi.so` and `libtest_ffi.so`, and `rust/compile.sh` only copied `.so` files. This worked inside the Linux Docker container, but `cargo build --release` on macOS produces `.dylib` (and Windows produces `.dll`), so local development on macOS failed to load the Rust libraries.

Changes:
- Added `app/Services/RustFfiLibrary.php` to resolve the correct library filename based on `PHP_OS_FAMILY` (`.so` on Linux, `.dylib` on macOS, `.dll` on Windows).
- Updated `app/GameMissions/BattleEngine/RustBattleEngine.php` and `tests/Unit/RustFfiTest.php` to use the new resolver instead of hardcoded `.so` paths.
- Updated `rust/compile.sh` to detect the platform via `uname -s` and copy the correct library extension.
- Updated `.gitignore` to ignore `.dylib` and `.dll` build artifacts in addition to `.so`.
- Updated `rust/README.md` with platform-specific copy instructions.

### Type of Change:
- [ ] Bug fix
- [x] Feature enhancement
- [x] Documentation update
- [ ] Other (please describe):

## Related Issues
None

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [x] **Automated Refactoring:** Rector has been run and no outstanding issues remain.
- [x] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [x] **Static Analysis:** Code passes PHPStan static code analysis.
- [x] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [x] **CSS & JS Build:** N/A — no JS/CSS files were changed.
- [x] **Documentation:** Documentation has been updated to reflect any changes made.

## Additional Information
Verified on macOS (PHP 8.5 + FFI enabled):
- `./rust/compile.sh` detects Darwin and copies `libbattle_engine_ffi.dylib` and `libtest_ffi.dylib` into `storage/rust-libs/`.
- `RustFfiTest` passes (`1 passed, 1 assertion`), and a direct FFI smoke test returns `Hello from Rust!` from `libtest_ffi.dylib`.

Linux behavior is unchanged (`.so` inside the Docker container). Windows resolves to `.dll` for the MSVC toolchain; the GNU toolchain keeps a `lib` prefix and is not specially handled (see `RustFfiLibrary::filename()`).