### PR TITLE
fix(battle-engine): fix FFI memory leak, rewrite Rust engine v2 for p…

### DIFF
--- a/app/GameMissions/BattleEngine/Models/BattleUnit.php
+++ b/app/GameMissions/BattleEngine/Models/BattleUnit.php
@@ -10,21 +10,22 @@ use OGame\GameObjects\Models\UnitObject;
 class BattleUnit
 {
     /**
-     * @var int The original hull plating of the unit. This is the structural integrity of the unit divided by 10.
+     * @var float The original hull plating of the unit. This is the structural integrity of the unit divided by 10.
      */
-    public int $originalHullPlating;
+    public float $originalHullPlating;
 
     /**
-     * @var int The current health points of the unit. Hull plating = structural integrity / 10.
+     * @var float The current health points of the unit. Hull plating = structural integrity / 10.
      */
-    public int $currentHullPlating;
+    public float $currentHullPlating;
 
     /**
-     * @var int The shield points of the unit.
+     * @var float The shield points of the unit.
      *
-     * Damage is first applied to the shield, then to the hull plating. After every round of combat, the shield regenerates.
+     * Damage is first applied to the shield, then to the hull plating. After every round of combat, the shield
+     * regenerates. Stored as float because shield damage is dealt in multiples of 1% of the max shield.
      */
-    public int $currentShieldPoints;
+    public float $currentShieldPoints;
 
     /**
      * Create a new BattleUnit object.
@@ -60,6 +61,6 @@ class BattleUnit
         }
 
         $explosionChance = (1 - $hullPercentage) * 100;
-        return rand(0, 100) < $explosionChance;
+        return rand(0, 100) < (int)$explosionChance;
     }
 }

--- a/app/GameMissions/BattleEngine/PhpBattleEngine.php
+++ b/app/GameMissions/BattleEngine/PhpBattleEngine.php
@@ -6,6 +6,7 @@ use OGame\GameMissions\BattleEngine\Models\BattleResult;
 use OGame\GameMissions\BattleEngine\Models\BattleResultRound;
 use OGame\GameMissions\BattleEngine\Models\BattleUnit;
 use OGame\GameObjects\Models\Units\UnitCollection;
+use OGame\GameObjects\Models\Units\UnitEntry;
 use OGame\Services\CharacterClassService;
 use OGame\Services\SettingsService;
 
@@ -20,6 +21,21 @@ use OGame\Services\SettingsService;
  */
 class PhpBattleEngine extends BattleEngine
 {
+    /**
+     * Damage absorbed by the attacker's shields in the round that is currently being fought.
+     *
+     * Shields absorb fractional amounts (they deplete in whole percentiles of the max shield),
+     * so the total is accumulated as float and truncated only once at the end of the round.
+     * The Rust engine sums the same value as f64 and truncates once, so both engines report
+     * the same absorbed damage.
+     */
+    private float $absorbedDamageAttackerRound = 0.0;
+
+    /**
+     * Damage absorbed by the defender's shields in the round that is currently being fought.
+     */
+    private float $absorbedDamageDefenderRound = 0.0;
+
     /**
      * Fight the battle in max 6 rounds.
      *
@@ -105,8 +121,8 @@ class PhpBattleEngine extends BattleEngine
             $round = new BattleResultRound();
             $round->defenderLossesInRound = new UnitCollection();
             $round->attackerLossesInRound = new UnitCollection();
-            $round->absorbedDamageAttacker = 0;
-            $round->absorbedDamageDefender = 0;
+            $this->absorbedDamageAttackerRound = 0.0;
+            $this->absorbedDamageDefenderRound = 0.0;
 
             // Initialize per-fleet tracking for this round
             $round->attackerLossesInRoundPerFleet = [];
@@ -144,6 +160,10 @@ class PhpBattleEngine extends BattleEngine
                     $rapidfire = $this->attackUnit(false, $round, $unit, $targetUnit);
                 } while ($rapidfire);
             }
+
+            // All shots have been fired: truncate the absorbed damage totals once for the report.
+            $round->absorbedDamageAttacker = (int)$this->absorbedDamageAttackerRound;
+            $round->absorbedDamageDefender = (int)$this->absorbedDamageDefenderRound;
 
             // After all units have attacked each other, clean up the round. This removes destroyed units
             // and applies shield regeneration.
@@ -222,8 +242,8 @@ class PhpBattleEngine extends BattleEngine
     /**
      * Return the unit entries of a fleet ordered by ascending unit id.
      *
-     * @param array<\OGame\GameObjects\Models\Units\UnitEntry> $units
-     * @return array<\OGame\GameObjects\Models\Units\UnitEntry>
+     * @param array<UnitEntry> $units
+     * @return array<UnitEntry>
      */
     private function sortedByUnitId(array $units): array
     {
@@ -287,7 +307,7 @@ class PhpBattleEngine extends BattleEngine
         if ($isAttacker) {
             $round->hitsAttacker += 1;
             $round->fullStrengthAttacker += $damage;
-            $round->absorbedDamageDefender += $shieldAbsorption;
+            $this->absorbedDamageDefenderRound += $shieldAbsorption;
 
             // Track per-fleet statistics for multi-attacker battles
             if (isset($round->hitsPerAttackerFleet[$attacker->fleetMissionId])) {
@@ -297,7 +317,7 @@ class PhpBattleEngine extends BattleEngine
         } else {
             $round->hitsDefender += 1;
             $round->fullStrengthDefender += $damage;
-            $round->absorbedDamageAttacker += $shieldAbsorption;
+            $this->absorbedDamageAttackerRound += $shieldAbsorption;
         }
 
         // Rapidfire: if the attacker has a rapidfire bonus against the defender, roll a dice to see if the

--- a/app/GameMissions/BattleEngine/PhpBattleEngine.php
+++ b/app/GameMissions/BattleEngine/PhpBattleEngine.php
@@ -32,9 +32,13 @@ class PhpBattleEngine extends BattleEngine
 
         // Convert attacker units to BattleUnit objects to keep track of hull plating and shields.
         // Each attacker fleet uses its own player's tech levels.
+        // Units are ordered by fleet (slot) order and ascending unit id within each fleet: units
+        // fire in this deterministic order, matching the original game. This makes ACS
+        // shield-stripping tactics work (e.g. fleet 1's destroyers break a Deathstar's shield
+        // so fleet 2's light fighters no longer bounce in the same round).
         $attackerUnits = [];
         foreach ($this->attackers as $attackerFleet) {
-            foreach ($attackerFleet->units->units as $unit) {
+            foreach ($this->sortedByUnitId($attackerFleet->units->units) as $unit) {
                 // Create new object for each unique unit in this fleet.
                 // Use THIS fleet owner's tech levels for calculations
                 $structuralIntegrity = $unit->unitObject->properties->structural_integrity->calculate($attackerFleet->player)->totalValue;
@@ -52,7 +56,7 @@ class PhpBattleEngine extends BattleEngine
         $defenderUnits = [];
         // Create BattleUnits for each defending fleet separately to preserve ownership and tech levels
         foreach ($this->defenders as $defenderFleet) {
-            foreach ($defenderFleet->units->units as $unit) {
+            foreach ($this->sortedByUnitId($defenderFleet->units->units) as $unit) {
                 // Create new object for each unique unit type in this fleet
                 // Use THIS fleet owner's tech levels for calculations
                 $structuralIntegrity = $unit->unitObject->properties->structural_integrity->calculate($defenderFleet->player)->totalValue;
@@ -216,6 +220,18 @@ class PhpBattleEngine extends BattleEngine
     }
 
     /**
+     * Return the unit entries of a fleet ordered by ascending unit id.
+     *
+     * @param array<\OGame\GameObjects\Models\Units\UnitEntry> $units
+     * @return array<\OGame\GameObjects\Models\Units\UnitEntry>
+     */
+    private function sortedByUnitId(array $units): array
+    {
+        usort($units, fn ($a, $b) => $a->unitObject->id <=> $b->unitObject->id);
+        return $units;
+    }
+
+    /**
      * Let one unit attack another unit and apply the damage to the defending unit.
      *
      * @param bool $isAttacker True if the attacker is attacking, false if the defender is attacking. This is used
@@ -231,28 +247,38 @@ class PhpBattleEngine extends BattleEngine
         // Calculate the damage dealt by the attacker to the defender.
         $damage = $attacker->attackPower;
         $shieldAbsorption = 0;
+        $bounced = false;
 
-        if ($damage < (0.01 * $defender->originalShieldPoints)) {
-            // If the damage is less than 1% of the shield points, the attack is bounced and no damage is dealt.
-            return false;
-        }
-
-        if ($defender->currentShieldPoints > 0 && $damage <= $defender->currentShieldPoints) {
-            // If the defender has a shield, first apply damage to the shield.
-            $shieldAbsorption = $damage;
-            $defender->currentShieldPoints -= $damage;
-        } elseif ($defender->currentShieldPoints > 0 && $damage > $defender->currentShieldPoints) {
-            // If the shield is destroyed, apply the remaining damage to the hull plating.
-            $shieldAbsorption = $defender->currentShieldPoints;
-            $defender->currentHullPlating -= $damage - $defender->currentShieldPoints;
-            $defender->currentShieldPoints = 0;
+        if ($defender->currentHullPlating <= 0) {
+            // Target was already destroyed earlier this round: the shot is wasted.
+            // It still counts towards the round statistics and still rolls rapidfire.
+        } elseif ($defender->currentShieldPoints <= 0) {
+            // Shield is stripped: full damage goes to the hull, however weak the shot.
+            $defender->currentHullPlating = max(0, $defender->currentHullPlating - $damage);
         } else {
-            // No shield, apply damage directly to the hull plating.
-            $defender->currentHullPlating -= $damage;
+            // Shield damage is dealt in whole multiples of 1% of the max shield, matching the
+            // original game. A shot weaker than 1% of max shield depletes zero multiples: it is
+            // fully absorbed without effect (the classic "bounce" rule).
+            $shieldPercentile = 0.01 * $defender->originalShieldPoints;
+            $depletedPercentiles = floor($damage / $shieldPercentile);
+            if ($defender->currentShieldPoints < $depletedPercentiles * $shieldPercentile) {
+                // Shield breaks: the overflow beyond the remaining shield hits the hull.
+                $shieldAbsorption = $defender->currentShieldPoints;
+                $hullDamage = $damage - $defender->currentShieldPoints;
+                $defender->currentHullPlating = max(0, $defender->currentHullPlating - $hullDamage);
+                $defender->currentShieldPoints = 0;
+            } else {
+                // Shot fully absorbed; the shield only loses whole percentiles.
+                $defender->currentShieldPoints -= $depletedPercentiles * $shieldPercentile;
+                $shieldAbsorption = $damage;
+                $bounced = $depletedPercentiles == 0;
+            }
         }
 
         // If the defender's hull integrity is less than 70%, the unit can explode randomly.
-        if ($defender->damagedHullExplosion()) {
+        // Bounced shots never trigger the roll, otherwise massed weak shots could explode a
+        // damaged unit straight through an intact shield.
+        if (!$bounced && $defender->currentHullPlating > 0 && $defender->damagedHullExplosion()) {
             // Hull was damaged and dice roll was successful, destroy the unit.
             $defender->currentShieldPoints = 0;
             $defender->currentHullPlating = 0;

--- a/app/GameMissions/BattleEngine/RustBattleEngine.php
+++ b/app/GameMissions/BattleEngine/RustBattleEngine.php
@@ -43,7 +43,8 @@ class RustBattleEngine extends BattleEngine
         parent::__construct($attackers, $defenderPlanet, $defenders, $settings);
 
         $this->ffi = FFI::cdef(
-            "char* fight_battle_rounds(const char* input_json);",
+            "char* fight_battle_rounds(const char* input_json);
+            void free_battle_result(char* ptr);",
             base_path('storage/rust-libs/libbattle_engine_ffi.so')
         );
     }
@@ -69,6 +70,11 @@ class RustBattleEngine extends BattleEngine
         // @phpstan-ignore-next-line
         $outputPtr = $this->ffi->fight_battle_rounds($inputJson);
         $output = FFI::string($outputPtr);
+
+        // Free the Rust-allocated result buffer. Without this every battle
+        // leaks its output for the lifetime of the PHP process.
+        // @phpstan-ignore-next-line
+        $this->ffi->free_battle_result($outputPtr);
 
         // Parse JSON response
         $battleOutput = json_decode($output, true);

--- a/app/GameObjects/Models/UnitObject.php
+++ b/app/GameObjects/Models/UnitObject.php
@@ -35,8 +35,9 @@ abstract class UnitObject extends GameObject
     {
         foreach ($this->rapidfire as $rapidfire) {
             if ($rapidfire->object_machine_name == $object->machine_name) {
-                // If chance is 85%, it means that 85 out of 100 times, rapidfire will be successful.
-                return (random_int(1, 10000) / 100) <= $rapidfire->getChance();
+                // Rapidfire continues with probability (n - 1) / n, matching the original game.
+                // For example amount 4 means 3/4 = 75% chance.
+                return random_int(1, $rapidfire->amount) > 1;
             }
         }
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7,14 +7,13 @@ name = "battle_engine_debug"
 version = "0.1.0"
 dependencies = [
  "battle_engine_ffi",
- "libc",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "battle_engine_ffi"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "memory-stats",
  "rand",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -6,3 +6,10 @@ members = [
     "battle_engine_debug",
     "test_ffi",
 ]
+
+# Optimize the release build for runtime performance: fat LTO and a single
+# codegen unit let LLVM inline and optimize across crate boundaries, which
+# measurably speeds up the battle hot loop at the cost of longer compile times.
+[profile.release]
+lto = "fat"
+codegen-units = 1

--- a/rust/battle_engine_debug/Cargo.toml
+++ b/rust/battle_engine_debug/Cargo.toml
@@ -7,4 +7,11 @@ edition = "2021"
 battle_engine_ffi = { path = "../battle_engine_ffi" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-libc = "0.2"
+
+[features]
+# Opt-in peak-memory tracking for debugging. Must NOT be a default dependency
+# feature: cargo feature unification would silently enable it for the
+# battle_engine_ffi cdylib in a workspace-wide `cargo build`, shipping the
+# /proc/self/smaps polling (and its heavy per-battle cost) to production.
+# Enable explicitly with: cargo build -p battle_engine_debug --features memory-metrics
+memory-metrics = ["battle_engine_ffi/memory-metrics"]

--- a/rust/battle_engine_debug/src/main.rs
+++ b/rust/battle_engine_debug/src/main.rs
@@ -1,78 +1,68 @@
 use battle_engine_ffi;
 use serde_json::Result;
-use libc;
 
+/// Debug driver for the battle engine.
+///
+/// Usage: battle_engine_debug <input.json> [iterations]
+///
+/// Runs the battle engine on the given input file. With iterations > 1 it
+/// repeats the battle and reports the average time per battle, which is
+/// useful for benchmarking and profiling (e.g. with perf).
+///
+/// Example input file content (current multi-fleet format):
+///
+/// {
+///     "attacker_fleets": [{
+///         "fleet_mission_id": 1,
+///         "owner_id": 1,
+///         "units": {
+///             "204": {"unit_id": 204, "amount": 100, "attack_power": 50,
+///                     "shield_points": 10, "hull_plating": 400,
+///                     "rapidfire": {"210": 5, "212": 5}}
+///         }
+///     }],
+///     "defender_fleets": [{
+///         "fleet_mission_id": 2,
+///         "owner_id": 2,
+///         "units": {
+///             "401": {"unit_id": 401, "amount": 100, "attack_power": 80,
+///                     "shield_points": 20, "hull_plating": 200,
+///                     "rapidfire": {}}
+///         }
+///     }]
+/// }
 fn main() -> Result<()> {
-
-    /*
-    Input with defender units without rapidfire.
-    {"attacker_units":{"206": {"unit_id":206,"amount":30,"shield_points":50,"attack_power":400,"hull_plating":2700,"rapidfire":{"210":5,"212":5,"204":6,"401":10}}},"defender_units":{"401": {"unit_id":401,"amount":500,"shield_points":20,"attack_power":80,"hull_plating":200,"rapidfire":{}}}}
-
-    Example input:
-     {
-        "attacker_units": {
-            "202": {
-                "unit_id": 202,
-                "amount": 5,
-                "shield_points": 10,
-                "attack_power": 5,
-                "hull_plating": 400,
-                "rapidfire": {
-                    "210": 5,
-                    "212": 5
-                }
-            },
-            "204": {
-                "unit_id": 204,
-                "amount": 75,
-                "shield_points": 10,
-                "attack_power": 50,
-                "hull_plating": 400,
-                "rapidfire": {
-                    "210": 5,
-                    "212": 5
-                }
-            }
-        },
-        "defender_units": {
-            "401": {
-                "unit_id": 401,
-                "amount": 100,
-                "shield_points": 20,
-                "attack_power": 80,
-                "hull_plating": 200,
-                "rapidfire": {}
-            }
-        }
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() < 2 {
+        eprintln!("Usage: battle_engine_debug <input.json> [iterations]");
+        std::process::exit(1);
     }
+    let json_input = std::fs::read_to_string(&args[1]).expect("cannot read input file");
+    let iterations: usize = if args.len() > 2 { args[2].parse().expect("invalid iteration count") } else { 1 };
 
-    This has caused eternal loop before:
-    {"attacker_units":{"204": {"unit_id":204,"amount":5000,"shield_points":10,"attack_power":50,"hull_plating":400,"rapidfire":{"210":5,"212":5}}},"defender_units":{"408": {"unit_id":408,"amount":1,"shield_points":10000,"attack_power":1,"hull_plating":10000,"rapidfire":{}}}}
-
-    10M units battle for memory usage debug:
-    {"attacker_units":{"204": {"unit_id":204,"amount":5000000,"shield_points":10,"attack_power":50,"hull_plating":400,"rapidfire":{"210":5,"212":5}}},"defender_units":{"401": {"unit_id":401,"amount":5000000,"shield_points":20,"attack_power":80,"hull_plating":200,"rapidfire":{}}}}
-
-     */
-
-    let json_input = r#"
-    {"attacker_units":{"204": {"unit_id":204,"amount":100000,"shield_points":10,"attack_power":50,"hull_plating":400,"rapidfire":{"210":5,"212":5}}},"defender_units":{"401": {"unit_id":401,"amount":100000,"shield_points":20,"attack_power":80,"hull_plating":200,"rapidfire":{}}}}
-"#;
-
-    // Convert input string to CString for FFI call
     let c_input = std::ffi::CString::new(json_input).unwrap();
 
-    // Call the FFI interface directly
-    let output_ptr = battle_engine_ffi::fight_battle_rounds(c_input.as_ptr());
+    let start = std::time::Instant::now();
+    let mut last_output = String::new();
+    for _ in 0..iterations {
+        // Call the FFI interface directly, the same way the PHP client does.
+        let output_ptr = battle_engine_ffi::fight_battle_rounds(c_input.as_ptr());
+        last_output = unsafe {
+            std::ffi::CStr::from_ptr(output_ptr).to_string_lossy().into_owned()
+        };
+        // Free the result via the engine's own allocator.
+        battle_engine_ffi::free_battle_result(output_ptr);
+    }
+    let elapsed = start.elapsed();
+    eprintln!(
+        "{} iteration(s) in {:?} ({:.3} ms/battle)",
+        iterations,
+        elapsed,
+        elapsed.as_secs_f64() * 1000.0 / iterations as f64
+    );
 
-    // Convert output back to string and free memory
-    let output = unsafe {
-        let output_str = std::ffi::CStr::from_ptr(output_ptr).to_string_lossy().into_owned();
-        libc::free(output_ptr as *mut libc::c_void);
-        output_str
-    };
-
-    // Pretty print the JSON output
-    let json: serde_json::Value = serde_json::from_str(&output)?;
+    // Pretty print the JSON output of the last battle.
+    let json: serde_json::Value = serde_json::from_str(&last_output)?;
     println!("{}", serde_json::to_string_pretty(&json).unwrap());
 
     Ok(())

--- a/rust/battle_engine_ffi/Cargo.toml
+++ b/rust/battle_engine_ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "battle_engine_ffi"
-version = "0.1.0"
+version = "2.0.0"
 edition = "2021"
 
 [lib]
@@ -10,6 +10,13 @@ crate-type = ["cdylib", "rlib"]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 rand = "0.9"
-memory-stats = "1.2.0"
+memory-stats = { version = "1.2.0", optional = true }
+
+[features]
+default = []
+# Peak-memory tracking for debugging. Reads /proc/self/smaps on every round,
+# which scales with mapped memory and slows battles down in long-running
+# processes - keep disabled for production builds.
+memory-metrics = ["dep:memory-stats"]
 
 

--- a/rust/battle_engine_ffi/src/lib.rs
+++ b/rust/battle_engine_ffi/src/lib.rs
@@ -576,3 +576,125 @@ fn update_peak_memory(current_peak: &mut u64) {
 
 #[cfg(not(feature = "memory-metrics"))]
 fn update_peak_memory(_current_peak: &mut u64) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a combat unit info for a single unit type without rapidfire against the
+    /// opposing side.
+    fn info(attack_power: f32, shield_points: f32, hull_plating: f32, amount_start: u32) -> CombatUnitInfo {
+        CombatUnitInfo {
+            unit_id: 1,
+            fleet_mission_id: 0,
+            owner_id: 0,
+            amount_start,
+            attack_power,
+            shield_points,
+            hull_plating,
+            // NaN marks "no rapidfire", so every attacker fires exactly one shot.
+            rapidfire_chance: vec![f64::NAN],
+        }
+    }
+
+    /// Fire `shots` shots of `attacker_info` at a single defending unit and return the round.
+    ///
+    /// The full battle entry point cannot set up the state these tests need (a damaged hull
+    /// behind an intact shield only occurs after a shield regenerated in a later round, which
+    /// is not deterministic), so combat is driven directly for a single phase.
+    fn fire_shots(
+        shots: u32,
+        attacker_info: CombatUnitInfo,
+        defender_info: CombatUnitInfo,
+        defender: CombatUnit,
+    ) -> (BattleRound, Vec<CombatUnit>) {
+        let attackers: Vec<CombatUnit> = (0..shots)
+            .map(|_| CombatUnit { info: 0, shield: 0.0, hull: 1.0 })
+            .collect();
+        let mut defenders = vec![defender];
+        let mut round = BattleRound::new();
+
+        process_combat(
+            &attackers,
+            &mut defenders,
+            &[attacker_info],
+            &[defender_info],
+            &mut round,
+            true,
+        );
+
+        (round, defenders)
+    }
+
+    /// The unit types of a fleet must fire by ascending unit id.
+    ///
+    /// `FleetInput::units` is a HashMap, so without the sort the firing order is whatever
+    /// iteration order the process happens to produce. Eight unit types are used here so an
+    /// unsorted order only matches the expected one in 1 out of 8! runs.
+    #[test]
+    fn fleet_units_are_ordered_by_ascending_unit_id() {
+        let unit_ids: [i16; 8] = [214, 204, 206, 205, 218, 207, 213, 211];
+
+        let mut units = HashMap::new();
+        for unit_id in unit_ids {
+            units.insert(unit_id, BattleUnitInfo {
+                unit_id,
+                amount: 1,
+                attack_power: 1.0,
+                shield_points: 1.0,
+                hull_plating: 1.0,
+                rapidfire: HashMap::new(),
+            });
+        }
+
+        let fleet = FleetInput { fleet_mission_id: 0, owner_id: 0, units };
+        let sorted: Vec<i16> = sorted_fleet_units(&fleet).iter().map(|unit| unit.unit_id).collect();
+
+        assert_eq!(sorted, vec![204, 205, 206, 207, 211, 213, 214, 218]);
+    }
+
+    /// A bounced shot must never trigger the hull explosion roll of a damaged unit, otherwise
+    /// massed weak shots could explode a damaged unit straight through an intact shield.
+    #[test]
+    fn bounced_shot_never_triggers_hull_explosion_roll() {
+        // The attacker deals 50 damage, which is below 1% of the defender's 10.000 max shield
+        // points, so every shot bounces off the intact shield.
+        let attacker_info = info(50.0, 10.0, 400.0, 300);
+        let defender_info = info(1.0, 10000.0, 10000.0, 1);
+
+        // The hull is damaged to 10% of its original value: every explosion roll would succeed
+        // with a 90% chance, so 300 bounced shots would destroy the unit with certainty if
+        // bounced shots were allowed to trigger the roll.
+        let defender = CombatUnit { info: 0, shield: 10000.0, hull: 1000.0 };
+
+        let (round, defenders) = fire_shots(300, attacker_info, defender_info, defender);
+
+        // The defender is untouched: no hull damage, no depleted shield and no explosion.
+        assert_eq!(defenders[0].hull, 1000.0);
+        assert_eq!(defenders[0].shield, 10000.0);
+
+        // The bounced shots do count towards the round statistics and are fully absorbed.
+        assert_eq!(round.hits_attacker, 300);
+        assert_eq!(round.full_strength_attacker, 300.0 * 50.0);
+        assert_eq!(round.absorbed_damage_defender, 300.0 * 50.0);
+    }
+
+    /// The counterpart of the test above: the explosion roll is skipped for bounced shots only,
+    /// not for weak shots in general.
+    #[test]
+    fn shot_on_stripped_shield_still_triggers_hull_explosion_roll() {
+        let attacker_info = info(50.0, 10.0, 400.0, 10);
+        let defender_info = info(1.0, 10000.0, 10000.0, 1);
+
+        // Same damaged hull as above, but with the shield already stripped. The shots now hit
+        // the hull in full and are therefore not bounced, so they do roll for an explosion.
+        let defender = CombatUnit { info: 0, shield: 0.0, hull: 1000.0 };
+
+        let (_round, defenders) = fire_shots(10, attacker_info, defender_info, defender);
+
+        // The defender must be destroyed: 10 shots x 50 damage only remove half of the
+        // remaining 1.000 hull plating, so only a successful explosion roll (~90% chance per
+        // shot) can have destroyed it.
+        assert_eq!(defenders[0].hull, 0.0);
+    }
+}

--- a/rust/battle_engine_ffi/src/lib.rs
+++ b/rust/battle_engine_ffi/src/lib.rs
@@ -6,38 +6,55 @@
 //! and takes the battle input in JSON, processes the battle rounds and returns the battle output in JSON.
 //!
 //! This battle engine is functionally equivalent to the OGameX PHP battle engine but is optimized
-//! for performance and memory usage. It is up to 200x faster than the equivalent PHP implementation
-//! and uses up to 10x less memory.
+//! for performance and memory usage.
 //!
 //! # Multi-Attacker Support
 //! This engine supports multiple attacker fleets (ACS Attack) and multiple defender fleets (ACS Defend).
 //! Each fleet's units are tracked with their fleet_mission_id and owner_id, allowing for accurate
 //! per-fleet result reporting.
+//!
+//! # Engine v2 design
+//! All static unit values are resolved once per battle into a flat `Vec<CombatUnitInfo>` with one
+//! entry per (fleet, unit type) pair. Each individual unit instance carries only a `u16` index into
+//! that array plus its current shield/hull, so the combat hot loop performs direct slice indexing
+//! instead of per-shot HashMap lookups. Rapidfire chances are precomputed into a cross table
+//! (attacker info index x defender info index) using the exact same formula previously evaluated
+//! per shot. Round statistics are derived from maintained per-type alive counters instead of
+//! rescanning all unit instances every round.
+//!
+//! Keeping unit values per (fleet, unit type) also fixes a v1 bug where metadata of fleets sharing
+//! the same unit type was merged with last-insert-wins semantics: in ACS battles with differing
+//! tech levels, all units of a shared type silently fought with one (arbitrary) fleet's values.
+//!
+//! # Combat fidelity (verified against the original OGame v0.84 battle engine source)
+//! - Shield damage is applied in whole multiples of 1% of the unit's max shield. Shots weaker
+//!   than 1% of max shield therefore deplete nothing (the classic "bounce" rule), but they only
+//!   bounce while the shield is up: once the shield is stripped within a round, every shot
+//!   damages the hull in full.
+//! - Units fire in deterministic order: fleets in input (slot) order, unit types within a fleet
+//!   by ascending unit id. This makes ACS shield-stripping tactics work like the original game
+//!   (e.g. one fleet's destroyers break a Deathstar's shield so another fleet's light fighters
+//!   no longer bounce in the same round).
+//! - Rapidfire is rolled after every shot, including bounced shots and shots wasted on units
+//!   already destroyed this round, with probability (n - 1) / n.
 use serde::{Deserialize, Serialize};
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
 use rand::Rng;
 use std::collections::HashMap;
+#[cfg(feature = "memory-metrics")]
 use memory_stats::memory_stats;
 
 /// Battle input which is provided by the PHP client.
 #[derive(Serialize, Deserialize)]
 pub struct BattleInput {
-    attacker_fleets: Vec<AttackerFleetInput>,
-    defender_fleets: Vec<DefenderFleetInput>,
+    attacker_fleets: Vec<FleetInput>,
+    defender_fleets: Vec<FleetInput>,
 }
 
-/// Input structure for a single attacker fleet.
+/// Input structure for a single fleet (attacker or defender).
 #[derive(Serialize, Deserialize, Clone)]
-struct AttackerFleetInput {
-    fleet_mission_id: u32,
-    owner_id: u32,
-    units: HashMap<i16, BattleUnitInfo>,
-}
-
-/// Input structure for a single defender fleet.
-#[derive(Serialize, Deserialize, Clone)]
-struct DefenderFleetInput {
+struct FleetInput {
     fleet_mission_id: u32,
     owner_id: u32,
     units: HashMap<i16, BattleUnitInfo>,
@@ -63,14 +80,32 @@ struct BattleUnitCount {
     amount: u32,
 }
 
-/// Battle unit instance which is used to keep track of individual units and their current health during battle.
-#[derive(Serialize, Deserialize, Clone)]
-struct BattleUnitInstance {
+/// Static combat values for one unit type within one fleet.
+///
+/// One entry exists per (fleet, unit type) pair. Individual units reference their
+/// entry by index, so all hot-loop lookups are direct slice accesses.
+struct CombatUnitInfo {
     unit_id: i16,
     fleet_mission_id: u32,
     owner_id: u32,
-    current_shield_points: f32,
-    current_hull_plating: f32,
+    /// Amount of units of this type the fleet started the battle with.
+    amount_start: u32,
+    attack_power: f32,
+    shield_points: f32,
+    hull_plating: f32,
+    /// Precomputed rapidfire chance against each opposing unit info (indexed by the
+    /// opposing side's info index). NaN means no rapidfire against that unit type.
+    /// The chance is (n - 1) / n for a rapidfire amount of n, matching the original game.
+    rapidfire_chance: Vec<f64>,
+}
+
+/// A single unit instance and its current health during battle.
+///
+/// `info` indexes into the side's `Vec<CombatUnitInfo>`.
+struct CombatUnit {
+    info: u16,
+    shield: f32,
+    hull: f32,
 }
 
 /// Battle round which is used to keep track of the battle statistics for a single round.
@@ -101,24 +136,35 @@ struct BattleRound {
     /// Total amount of hits the defender made this round.
     hits_defender: u32,
     /// Per-fleet attacker results keyed by fleet_mission_id.
-    attacker_fleet_results: HashMap<u32, AttackerFleetResult>,
+    attacker_fleet_results: HashMap<u32, FleetResult>,
     /// Per-fleet defender results keyed by fleet_mission_id.
-    defender_fleet_results: HashMap<u32, DefenderFleetResult>,
+    defender_fleet_results: HashMap<u32, FleetResult>,
 }
 
-/// Result for a single attacker fleet.
-#[derive(Serialize, Deserialize, Clone)]
-struct AttackerFleetResult {
-    fleet_mission_id: u32,
-    owner_id: u32,
-    units_start: HashMap<i16, BattleUnitCount>,
-    units_result: HashMap<i16, BattleUnitCount>,
-    units_lost: HashMap<i16, BattleUnitCount>,
+impl BattleRound {
+    fn new() -> Self {
+        BattleRound {
+            attacker_ships: HashMap::new(),
+            defender_ships: HashMap::new(),
+            attacker_losses: HashMap::new(),
+            defender_losses: HashMap::new(),
+            attacker_losses_in_round: HashMap::new(),
+            defender_losses_in_round: HashMap::new(),
+            absorbed_damage_attacker: 0.0,
+            absorbed_damage_defender: 0.0,
+            full_strength_attacker: 0.0,
+            full_strength_defender: 0.0,
+            hits_attacker: 0,
+            hits_defender: 0,
+            attacker_fleet_results: HashMap::new(),
+            defender_fleet_results: HashMap::new(),
+        }
+    }
 }
 
-/// Result for a single defender fleet.
+/// Result for a single fleet (attacker or defender).
 #[derive(Serialize, Deserialize, Clone)]
-struct DefenderFleetResult {
+struct FleetResult {
     fleet_mission_id: u32,
     owner_id: u32,
     units_start: HashMap<i16, BattleUnitCount>,
@@ -157,29 +203,38 @@ pub extern "C" fn fight_battle_rounds(input_json: *const c_char) -> *mut c_char 
     c_str.into_raw()
 }
 
+/// Free a battle result string previously returned by `fight_battle_rounds`.
+///
+/// The result is allocated by Rust and must be freed by Rust. Callers (PHP FFI)
+/// must invoke this after copying the result string, otherwise every battle
+/// leaks its output buffer for the lifetime of the process.
+#[no_mangle]
+pub extern "C" fn free_battle_result(ptr: *mut c_char) {
+    if !ptr.is_null() {
+        unsafe {
+            let _ = CString::from_raw(ptr);
+        }
+    }
+}
+
 /// Process the battle rounds and return the battle output.
 fn process_battle_rounds(input: BattleInput) -> BattleOutput {
     let mut peak_memory = 0;
-    let mut rounds = Vec::new();
+    let mut rounds: Vec<BattleRound> = Vec::new();
 
-    // Build fleet metadata maps for ownership tracking
-    let mut attacker_fleet_metadata: HashMap<u32, HashMap<i16, BattleUnitInfo>> = HashMap::new();
-    let mut attacker_fleet_owners: HashMap<u32, u32> = HashMap::new();
-    for fleet in &input.attacker_fleets {
-        attacker_fleet_metadata.insert(fleet.fleet_mission_id, fleet.units.clone());
-        attacker_fleet_owners.insert(fleet.fleet_mission_id, fleet.owner_id);
-    }
+    // Resolve all static unit values once. Rapidfire chances are precomputed
+    // against the opposing side's unit infos.
+    let attacker_infos = build_combat_infos(&input.attacker_fleets, &input.defender_fleets);
+    let defender_infos = build_combat_infos(&input.defender_fleets, &input.attacker_fleets);
 
-    let mut defender_fleet_metadata: HashMap<u32, HashMap<i16, BattleUnitInfo>> = HashMap::new();
-    let mut defender_fleet_owners: HashMap<u32, u32> = HashMap::new();
-    for fleet in &input.defender_fleets {
-        defender_fleet_metadata.insert(fleet.fleet_mission_id, fleet.units.clone());
-        defender_fleet_owners.insert(fleet.fleet_mission_id, fleet.owner_id);
-    }
+    // Create the individual unit instances from the per-type amounts.
+    let mut attacker_units = expand_units(&attacker_infos);
+    let mut defender_units = expand_units(&defender_infos);
 
-    // Create individual ships from provided battle unit info which contains the amount
-    let mut attacker_units = expand_fleets(&input.attacker_fleets);
-    let mut defender_units = expand_fleets(&input.defender_fleets);
+    // Alive counters per info index, kept in sync with the unit vectors so the
+    // per-round statistics never have to rescan all instances.
+    let mut attacker_alive: Vec<u32> = attacker_infos.iter().map(|info| info.amount_start).collect();
+    let mut defender_alive: Vec<u32> = defender_infos.iter().map(|info| info.amount_start).collect();
 
     // Track peak memory usage for debugging purposes
     update_peak_memory(&mut peak_memory);
@@ -190,58 +245,27 @@ fn process_battle_rounds(input: BattleInput) -> BattleOutput {
             break;
         }
 
-        let mut round = BattleRound {
-            attacker_ships: HashMap::new(),
-            defender_ships: HashMap::new(),
-            attacker_losses: HashMap::new(),
-            defender_losses: HashMap::new(),
-            attacker_losses_in_round: HashMap::new(),
-            defender_losses_in_round: HashMap::new(),
-            absorbed_damage_attacker: 0.0,
-            absorbed_damage_defender: 0.0,
-            full_strength_attacker: 0.0,
-            full_strength_defender: 0.0,
-            hits_attacker: 0,
-            hits_defender: 0,
-            attacker_fleet_results: HashMap::new(),
-            defender_fleet_results: HashMap::new(),
-        };
-
-        // Merge all fleet units for the metadata lookup (needed for combat calculations)
-        let mut attacker_units_metadata: HashMap<i16, BattleUnitInfo> = HashMap::new();
-        for fleet_units in attacker_fleet_metadata.values() {
-            for (unit_id, unit_info) in fleet_units {
-                attacker_units_metadata.insert(*unit_id, unit_info.clone());
-            }
-        }
-
-        let mut defender_units_metadata: HashMap<i16, BattleUnitInfo> = HashMap::new();
-        for fleet_units in defender_fleet_metadata.values() {
-            for (unit_id, unit_info) in fleet_units {
-                defender_units_metadata.insert(*unit_id, unit_info.clone());
-            }
-        }
+        let mut round = BattleRound::new();
 
         // Process combat
-        process_combat(&mut attacker_units, &mut defender_units, &mut round, &attacker_units_metadata, &defender_units_metadata, true);
-        process_combat(&mut defender_units, &mut attacker_units, &mut round, &defender_units_metadata, &attacker_units_metadata, false);
+        process_combat(&attacker_units, &mut defender_units, &attacker_infos, &defender_infos, &mut round, true);
+        process_combat(&defender_units, &mut attacker_units, &defender_infos, &attacker_infos, &mut round, false);
 
-        // Cleanup round
-        cleanup_round(&mut round, &mut attacker_units, &mut defender_units, &attacker_units_metadata, &defender_units_metadata);
+        // Remove destroyed units, record per-round losses and regenerate shields.
+        cleanup_units(&mut attacker_units, &attacker_infos, &mut attacker_alive, &mut round.attacker_losses_in_round);
+        cleanup_units(&mut defender_units, &defender_infos, &mut defender_alive, &mut round.defender_losses_in_round);
 
-        // Update round statistics
-        round.attacker_ships = compress_units(&attacker_units);
-        round.defender_ships = compress_units(&defender_units);
-
-        // Calculate accumulated losses
-        calculate_losses(&mut round, &attacker_units_metadata, &defender_units_metadata);
-
-        // Calculate per-fleet results
-        calculate_fleet_results(&mut round, &attacker_units, &defender_units, &attacker_fleet_metadata, &defender_fleet_metadata, &attacker_fleet_owners, &defender_fleet_owners);
+        // Update round statistics from the alive counters.
+        round.attacker_ships = count_ships(&attacker_infos, &attacker_alive);
+        round.defender_ships = count_ships(&defender_infos, &defender_alive);
+        round.attacker_losses = count_losses(&attacker_infos, &attacker_alive);
+        round.defender_losses = count_losses(&defender_infos, &defender_alive);
+        round.attacker_fleet_results = fleet_results(&attacker_infos, &attacker_alive);
+        round.defender_fleet_results = fleet_results(&defender_infos, &defender_alive);
 
         rounds.push(round);
 
-         // Track peak memory usage for debugging purposes
+        // Track peak memory usage for debugging purposes
         update_peak_memory(&mut peak_memory);
     }
 
@@ -253,117 +277,78 @@ fn process_battle_rounds(input: BattleInput) -> BattleOutput {
     }
 }
 
-/// Expand fleet inputs into individual unit instances with ownership tracking.
-fn expand_fleets(fleets: &Vec<impl FleetInput>) -> Vec<BattleUnitInstance> {
-    let mut expanded = Vec::new();
-    for fleet in fleets {
-        for (_, unit) in fleet.get_units() {
-            for _ in 0..unit.amount {
-                expanded.push(BattleUnitInstance {
-                    unit_id: unit.unit_id.clone(),
-                    fleet_mission_id: fleet.get_fleet_mission_id(),
-                    owner_id: fleet.get_owner_id(),
-                    current_shield_points: unit.shield_points,
-                    current_hull_plating: unit.hull_plating
-                });
-            }
+/// Resolve the static combat values of all fleets on one side into a flat array with
+/// one entry per (fleet, unit type) pair.
+///
+/// The rapidfire chance of each unit is precomputed against every unit info of the
+/// opposing side so the hot loop can look it up by index. The chance value is derived
+/// with the same formula the engine previously evaluated per shot:
+/// 100 - floor((100 / amount) * 100) / 100. NaN marks "no rapidfire against this type".
+fn build_combat_infos(own_fleets: &[FleetInput], opposing_fleets: &[FleetInput]) -> Vec<CombatUnitInfo> {
+    // Collect the opposing unit ids in info order to index the rapidfire table.
+    let mut opposing_unit_ids: Vec<i16> = Vec::new();
+    for fleet in opposing_fleets {
+        for unit in sorted_fleet_units(fleet) {
+            opposing_unit_ids.push(unit.unit_id);
         }
     }
-    expanded
-}
 
-/// Trait for fleet input structures.
-trait FleetInput {
-    fn get_fleet_mission_id(&self) -> u32;
-    fn get_owner_id(&self) -> u32;
-    fn get_units(&self) -> &HashMap<i16, BattleUnitInfo>;
-}
+    let mut infos = Vec::new();
+    for fleet in own_fleets {
+        for unit in sorted_fleet_units(fleet) {
+            let rapidfire_chance = opposing_unit_ids.iter().map(|opposing_id| {
+                match unit.rapidfire.get(opposing_id) {
+                    Some(rapidfire_amount) => {
+                        // Rapidfire continues with probability (n - 1) / n, matching the
+                        // original game. For example:
+                        // - rapidfire amount of 4 means 3/4 = 75% chance.
+                        // - rapidfire amount of 10 means 9/10 = 90% chance.
+                        (*rapidfire_amount as f64 - 1.0) / *rapidfire_amount as f64
+                    }
+                    None => f64::NAN,
+                }
+            }).collect();
 
-impl FleetInput for AttackerFleetInput {
-    fn get_fleet_mission_id(&self) -> u32 {
-        self.fleet_mission_id
-    }
-
-    fn get_owner_id(&self) -> u32 {
-        self.owner_id
-    }
-
-    fn get_units(&self) -> &HashMap<i16, BattleUnitInfo> {
-        &self.units
-    }
-}
-
-impl FleetInput for DefenderFleetInput {
-    fn get_fleet_mission_id(&self) -> u32 {
-        self.fleet_mission_id
-    }
-
-    fn get_owner_id(&self) -> u32 {
-        self.owner_id
-    }
-
-    fn get_units(&self) -> &HashMap<i16, BattleUnitInfo> {
-        &self.units
-    }
-}
-
-/// Compress individual unit instances into a single unit metadata object which stores the amount of units
-/// instead of having a separate object for each unit. This is for only passing data about total amount
-/// of units per type.
-fn compress_units(units: &Vec<BattleUnitInstance>) -> HashMap<i16, BattleUnitCount> {
-    units.iter()
-        // Loop over all units and count the amount of units per unit_id.
-        .fold(HashMap::new(), |mut counts, unit| {
-            // Increment count for each unit_id
-            *counts.entry(unit.unit_id).or_insert(0) += 1;
-            counts
-        })
-        .into_iter()
-        // Convert counts hashmap to expected BattleUnitCount hashmap
-        .map(|(unit_id, count)| {
-            (unit_id, BattleUnitCount {
-                unit_id,
-                amount: count,
-            })
-        })
-        .collect()
-}
-
-/// Compress individual unit instances into per-fleet results.
-fn compress_fleet_results(units: &Vec<BattleUnitInstance>, fleet_mission_id: u32, _owner_id: u32, initial_units: &HashMap<i16, BattleUnitInfo>) -> (HashMap<i16, BattleUnitCount>, HashMap<i16, BattleUnitCount>, HashMap<i16, BattleUnitCount>) {
-    // Filter units by fleet
-    let fleet_units: Vec<&BattleUnitInstance> = units.iter()
-        .filter(|u| u.fleet_mission_id == fleet_mission_id)
-        .collect();
-
-    // Count survivors by unit type
-    let mut units_result: HashMap<i16, BattleUnitCount> = HashMap::new();
-    for unit in &fleet_units {
-        increment_battle_unit_count_amount(&mut units_result, unit.unit_id, 1);
-    }
-
-    // Build units_start from initial metadata
-    let mut units_start: HashMap<i16, BattleUnitCount> = HashMap::new();
-    for (unit_id, unit_info) in initial_units {
-        units_start.insert(*unit_id, BattleUnitCount {
-            unit_id: *unit_id,
-            amount: unit_info.amount,
-        });
-    }
-
-    // Calculate losses
-    let mut units_lost: HashMap<i16, BattleUnitCount> = HashMap::new();
-    for (unit_id, start_unit) in &units_start {
-        let result_amount = units_result.get(unit_id).map(|u| u.amount).unwrap_or(0);
-        if start_unit.amount > result_amount {
-            units_lost.insert(*unit_id, BattleUnitCount {
-                unit_id: *unit_id,
-                amount: start_unit.amount - result_amount,
+            infos.push(CombatUnitInfo {
+                unit_id: unit.unit_id,
+                fleet_mission_id: fleet.fleet_mission_id,
+                owner_id: fleet.owner_id,
+                amount_start: unit.amount,
+                attack_power: unit.attack_power,
+                shield_points: unit.shield_points,
+                hull_plating: unit.hull_plating,
+                rapidfire_chance,
             });
         }
     }
+    infos
+}
 
-    (units_start, units_result, units_lost)
+/// Return the units of a fleet ordered by ascending unit id.
+///
+/// Units fire in this deterministic order, matching the original game where unit
+/// types shoot in fixed positional order. Combined with fleets firing in input
+/// (slot) order this makes ACS firing order reproducible.
+fn sorted_fleet_units(fleet: &FleetInput) -> Vec<&BattleUnitInfo> {
+    let mut units: Vec<&BattleUnitInfo> = fleet.units.values().collect();
+    units.sort_by_key(|unit| unit.unit_id);
+    units
+}
+
+/// Expand the unit infos into individual unit instances.
+fn expand_units(infos: &[CombatUnitInfo]) -> Vec<CombatUnit> {
+    let total: u32 = infos.iter().map(|info| info.amount_start).sum();
+    let mut units = Vec::with_capacity(total as usize);
+    for (idx, info) in infos.iter().enumerate() {
+        for _ in 0..info.amount_start {
+            units.push(CombatUnit {
+                info: idx as u16,
+                shield: info.shield_points,
+                hull: info.hull_plating,
+            });
+        }
+    }
+    units
 }
 
 /// Simulates combat for a single round between two groups of units.
@@ -376,66 +361,79 @@ fn compress_fleet_results(units: &Vec<BattleUnitInstance>, fleet_mission_id: u32
 /// # Parameters:
 /// - `attackers`: Units attacking in this phase.
 /// - `defenders`: Units being attacked in this phase.
+/// - `attacker_infos`: Static values of the attacking units (attack power, rapidfire, etc.).
+/// - `defender_infos`: Static values of the defending units (max shield, max hull, etc.).
 /// - `round`: Stores round statistics, such as hits and absorbed damage.
-/// - `attacker_unit_metadata`: Metadata for attacker units to determine damage, rapidfire, etc.
-/// - `defender_unit_metadata`: Metadata for defender units to determine max shield points etc.
 /// - `is_attacker`: Whether the current phase is attacker-to-defender or vice versa.
 fn process_combat(
-    attackers: &mut Vec<BattleUnitInstance>,
-    defenders: &mut Vec<BattleUnitInstance>,
+    attackers: &[CombatUnit],
+    defenders: &mut Vec<CombatUnit>,
+    attacker_infos: &[CombatUnitInfo],
+    defender_infos: &[CombatUnitInfo],
     round: &mut BattleRound,
-    attacker_unit_metadata: &HashMap<i16, BattleUnitInfo>,
-    defender_unit_metadata: &HashMap<i16, BattleUnitInfo>,
     is_attacker: bool,
 ) {
     let mut rng = rand::thread_rng();
 
     for attacker in attackers.iter() {
-        let mut continue_attacking = true;
+        // Get the static values of the attacking unit.
+        let attacker_info = &attacker_infos[attacker.info as usize];
+        let damage = attacker_info.attack_power;
 
-        // Get metadata of the attacking unit.
-        let attacker_metadata = attacker_unit_metadata.get(&attacker.unit_id).unwrap();
-        let damage = attacker_metadata.attack_power;
-
-        while continue_attacking {
-            continue_attacking = false;
-
+        loop {
             // Select a random defender as a target
             let target_idx = rng.gen_range(0..defenders.len());
             let target = &mut defenders[target_idx];
 
-            // Get metadata of the defending unit.
-            let target_metadata = defender_unit_metadata.get(&target.unit_id).unwrap();
+            // Get the static values of the defending unit.
+            let target_info = &defender_infos[target.info as usize];
 
-            // Check if the damage is less than 1% of the target's shield points. If so,
-            // attack is negated.
-            if damage < (0.01 * target_metadata.shield_points) {
-                continue
-            }
-
-            // Apply damage to shields first, then hull plating
             let mut shield_absorption = 0.0;
-            if target.current_shield_points > 0.0 {
-                if damage <= target.current_shield_points {
-                    shield_absorption = damage;
-                    target.current_shield_points -= damage;
+            let mut bounced = false;
+            if target.hull <= 0.0 {
+                // Target was already destroyed earlier this round: the shot is wasted.
+                // It still counts towards the round statistics and still rolls rapidfire.
+            } else if target.shield <= 0.0 {
+                // Shield is stripped: full damage goes to the hull, however weak the shot.
+                if damage >= target.hull {
+                    target.hull = 0.0;
                 } else {
-                    shield_absorption = target.current_shield_points;
-                    target.current_hull_plating -= damage - target.current_shield_points;
-                    target.current_shield_points = 0.0;
+                    target.hull -= damage;
                 }
             } else {
-                target.current_hull_plating -= damage;
+                // Shield damage is dealt in whole multiples of 1% of the max shield.
+                // A shot weaker than 1% of max shield depletes zero multiples: it is
+                // fully absorbed without effect (the classic "bounce" rule).
+                let shield_percentile = 0.01 * target_info.shield_points;
+                let depleted_percentiles = (damage / shield_percentile).floor();
+                if target.shield < depleted_percentiles * shield_percentile {
+                    // Shield breaks: the overflow beyond the remaining shield hits the hull.
+                    shield_absorption = target.shield;
+                    let hull_damage = damage - target.shield;
+                    if hull_damage >= target.hull {
+                        target.hull = 0.0;
+                    } else {
+                        target.hull -= hull_damage;
+                    }
+                    target.shield = 0.0;
+                } else {
+                    // Shot fully absorbed; the shield only loses whole percentiles.
+                    target.shield -= depleted_percentiles * shield_percentile;
+                    shield_absorption = damage;
+                    bounced = depleted_percentiles == 0.0;
+                }
             }
 
             // If hull integrity < 70%, then unit can explode randomly. Roll dice to see if it does.
-            if target.current_hull_plating / target_metadata.hull_plating < 0.7 {
-                let explosion_chance = 100.0 - ((target.current_hull_plating / target_metadata.hull_plating) * 100.0);
+            // Bounced shots never trigger the roll, otherwise massed weak shots could explode a
+            // damaged unit straight through an intact shield.
+            if !bounced && target.hull > 0.0 && target.hull / target_info.hull_plating < 0.7 {
+                let explosion_chance = 100.0 - ((target.hull / target_info.hull_plating) * 100.0);
                 let roll = rng.gen_range(0..=100);
                 if roll < explosion_chance as i32 {
                     // Unit explodes, set current hull plating and shield points to 0.
-                    target.current_hull_plating = 0.0;
-                    target.current_shield_points = 0.0;
+                    target.hull = 0.0;
+                    target.shield = 0.0;
                 }
             }
 
@@ -451,155 +449,107 @@ fn process_combat(
             }
 
             // Check if the current unit has rapidfire against the target unit. If so, then
-            // roll dice to see if the current unit can attack again.
-            continue_attacking = if let Some(rapidfire_amount) = attacker_metadata.rapidfire.get(&target.unit_id) {
-                // Rapidfire chance is calculated as 100 - (100 / amount). For example:
-                // - rapidfire amount of 4 means 100 - (100 / 4) = 75% chance.
-                // - rapidfire amount of 10 means 100 - (100 / 10) = 90% chance.
-                // - rapidfire amount of 33 means 100 - (100 / 33) = 96.97%
-                let chance = 100.0 / *rapidfire_amount as f64;
-                let rounded_chance = (chance * 100.0).floor() / 100.0;
-                let rapidfire_chance = 100.0 - rounded_chance;
+            // roll dice to see if the current unit can attack again. Like the original game
+            // this roll happens after every shot, including bounced and wasted ones.
+            let rapidfire_chance = attacker_info.rapidfire_chance[target.info as usize];
+            if rapidfire_chance.is_nan() {
+                break;
+            }
 
-                // Roll for rapidfire
-                let roll = rng.gen_range(0.0..100.0);
-
-                // If the roll is less than or equal to the rapidfire chance, the unit can attack again
-                // and continue_attacking is set to true which will cause the loop to continue.
-                roll <= rapidfire_chance
-            } else {
-                false
+            // Roll for rapidfire. If the roll is below the rapidfire chance the unit
+            // attacks again and the loop continues.
+            let roll = rng.gen_range(0.0..1.0);
+            if roll >= rapidfire_chance {
+                break;
             }
         }
     }
 }
 
-/// Clean up the round after all units have attacked each other.
+/// Clean up one side's units after all units have attacked each other.
 ///
 /// This method handles:
-/// - Removing destroyed units from the attacker and defender unit arrays.
-/// - Rolling dice for hull integrity < 70% of original if the unit is also destroyed.
-/// - Applying shield regeneration.
-/// - Calculate the total damage dealt by the attacker and defender and calculate shield absorption stats.
-fn cleanup_round(
-    round: &mut BattleRound,
-    attackers: &mut Vec<BattleUnitInstance>,
-    defenders: &mut Vec<BattleUnitInstance>,
-    units_metadata_attacker: &HashMap<i16, BattleUnitInfo>,
-    units_metadata_defender: &HashMap<i16, BattleUnitInfo>,
+/// - Removing destroyed units and keeping the per-type alive counters in sync.
+/// - Recording the losses of this round.
+/// - Applying shield regeneration for the surviving units.
+fn cleanup_units(
+    units: &mut Vec<CombatUnit>,
+    infos: &[CombatUnitInfo],
+    alive: &mut [u32],
+    losses_in_round: &mut HashMap<i16, BattleUnitCount>,
 ) {
-    // -------
-    // Cleanup attacker units.
-    // -------
-    // First remove destroyed units.
-    attackers.retain(|unit| {
+    // Remove destroyed units and regenerate the shields of the survivors in a
+    // single sweep, so the unit vector is only traversed once per round.
+    units.retain_mut(|unit| {
         // Check if unit is fully destroyed.
-        if unit.current_hull_plating <= 0.0 {
-            increment_battle_unit_count_amount(&mut round.attacker_losses_in_round, unit.unit_id, 1);
+        if unit.hull <= 0.0 {
+            let info = &infos[unit.info as usize];
+            alive[unit.info as usize] -= 1;
+            increment_battle_unit_count_amount(losses_in_round, info.unit_id, 1);
             return false;
         }
 
+        unit.shield = infos[unit.info as usize].shield_points;
         true
     });
-
-    // Then update shields in separate pass
-    for unit in attackers.iter_mut() {
-        let unit_metadata = units_metadata_attacker.get(&unit.unit_id).unwrap();
-        unit.current_shield_points = unit_metadata.shield_points;
-    }
-
-    // -------
-    // Cleanup defender units.
-    // -------
-    // First remove destroyed units.
-    defenders.retain(|unit| {
-        // Check if unit is fully destroyed.
-        if unit.current_hull_plating <= 0.0 {
-            increment_battle_unit_count_amount(&mut round.defender_losses_in_round, unit.unit_id, 1);
-            return false;
-        }
-
-        true
-    });
-
-    // Then update shields in separate pass for remaining units.
-    for unit in defenders.iter_mut() {
-        let unit_metadata = units_metadata_defender.get(&unit.unit_id).unwrap();
-        unit.current_shield_points = unit_metadata.shield_points;
-    }
 }
 
-/// Calculate the losses for the attacker and defender in this round compared to the starting
-/// units before the battle.
-fn calculate_losses(
-    round: &mut BattleRound,
-    initial_attacker: &HashMap<i16, BattleUnitInfo>,
-    initial_defender: &HashMap<i16, BattleUnitInfo>,
-) {
-    // Calculate losses by comparing current counts with initial counts
-    for (_, unit) in initial_attacker {
-        let initial_count = unit.amount;
-        let current_count = round.attacker_ships.get(&unit.unit_id).map(|unit| unit.amount).unwrap_or(0);
-
-        if current_count < initial_count {
-            let loss_amount = initial_count - current_count;
-            increment_battle_unit_count_amount(&mut round.attacker_losses, unit.unit_id, loss_amount);
+/// Build the remaining-ships map (per unit type, summed across fleets) from the alive counters.
+fn count_ships(infos: &[CombatUnitInfo], alive: &[u32]) -> HashMap<i16, BattleUnitCount> {
+    let mut ships: HashMap<i16, BattleUnitCount> = HashMap::new();
+    for (idx, info) in infos.iter().enumerate() {
+        if alive[idx] > 0 {
+            increment_battle_unit_count_amount(&mut ships, info.unit_id, alive[idx]);
         }
     }
-
-    // Do the same for defender
-    for (_, unit) in initial_defender {
-        let initial_count = unit.amount;
-        let current_count = round.defender_ships.get(&unit.unit_id).map(|unit| unit.amount).unwrap_or(0);
-
-        if current_count < initial_count {
-            let loss_amount = initial_count - current_count;
-            increment_battle_unit_count_amount(&mut round.defender_losses, unit.unit_id, loss_amount);
-        }
-    }
+    ships
 }
 
-/// Calculate per-fleet results for attackers and defenders.
-fn calculate_fleet_results(
-    round: &mut BattleRound,
-    attacker_units: &Vec<BattleUnitInstance>,
-    defender_units: &Vec<BattleUnitInstance>,
-    attacker_fleets: &HashMap<u32, HashMap<i16, BattleUnitInfo>>,
-    defender_fleets: &HashMap<u32, HashMap<i16, BattleUnitInfo>>,
-    attacker_fleet_owners: &HashMap<u32, u32>,
-    defender_fleet_owners: &HashMap<u32, u32>,
-) {
-    // Calculate attacker fleet results
-    for (&fleet_mission_id, initial_units) in attacker_fleets {
-        let owner_id = *attacker_fleet_owners.get(&fleet_mission_id).unwrap_or(&0);
-
-        let (units_start, units_result, units_lost) =
-            compress_fleet_results(attacker_units, fleet_mission_id, owner_id, initial_units);
-
-        round.attacker_fleet_results.insert(fleet_mission_id, AttackerFleetResult {
-            fleet_mission_id,
-            owner_id,
-            units_start,
-            units_result,
-            units_lost,
-        });
+/// Build the accumulated losses map (per unit type, summed across fleets) by comparing
+/// the alive counters with the starting amounts.
+fn count_losses(infos: &[CombatUnitInfo], alive: &[u32]) -> HashMap<i16, BattleUnitCount> {
+    let mut losses: HashMap<i16, BattleUnitCount> = HashMap::new();
+    for (idx, info) in infos.iter().enumerate() {
+        let lost = info.amount_start - alive[idx];
+        if lost > 0 {
+            increment_battle_unit_count_amount(&mut losses, info.unit_id, lost);
+        }
     }
+    losses
+}
 
-    // Calculate defender fleet results
-    for (&fleet_mission_id, initial_units) in defender_fleets {
-        let owner_id = *defender_fleet_owners.get(&fleet_mission_id).unwrap_or(&0);
-
-        let (units_start, units_result, units_lost) =
-            compress_fleet_results(defender_units, fleet_mission_id, owner_id, initial_units);
-
-        round.defender_fleet_results.insert(fleet_mission_id, DefenderFleetResult {
-            fleet_mission_id,
-            owner_id,
-            units_start,
-            units_result,
-            units_lost,
+/// Build the per-fleet results (units at battle start, units remaining, units lost)
+/// from the alive counters.
+fn fleet_results(infos: &[CombatUnitInfo], alive: &[u32]) -> HashMap<u32, FleetResult> {
+    let mut results: HashMap<u32, FleetResult> = HashMap::new();
+    for (idx, info) in infos.iter().enumerate() {
+        let result = results.entry(info.fleet_mission_id).or_insert_with(|| FleetResult {
+            fleet_mission_id: info.fleet_mission_id,
+            owner_id: info.owner_id,
+            units_start: HashMap::new(),
+            units_result: HashMap::new(),
+            units_lost: HashMap::new(),
         });
+
+        result.units_start.insert(info.unit_id, BattleUnitCount {
+            unit_id: info.unit_id,
+            amount: info.amount_start,
+        });
+        if alive[idx] > 0 {
+            result.units_result.insert(info.unit_id, BattleUnitCount {
+                unit_id: info.unit_id,
+                amount: alive[idx],
+            });
+        }
+        let lost = info.amount_start - alive[idx];
+        if lost > 0 {
+            result.units_lost.insert(info.unit_id, BattleUnitCount {
+                unit_id: info.unit_id,
+                amount: lost,
+            });
+        }
     }
+    results
 }
 
 /// Helper method to increment the amount property of a BattleUnitCount struct.
@@ -612,8 +562,17 @@ fn increment_battle_unit_count_amount(hash_map: &mut HashMap<i16, BattleUnitCoun
 }
 
 /// Update the peak memory usage statistics. Only used for debugging purposes.
+///
+/// Gated behind the `memory-metrics` feature: memory_stats() reads /proc/self/smaps
+/// which the kernel generates by walking all process memory mappings. That makes
+/// every battle progressively slower in long-running processes, so production
+/// builds skip it entirely and report a peak of 0.
+#[cfg(feature = "memory-metrics")]
 fn update_peak_memory(current_peak: &mut u64) {
     if let Some(usage) = memory_stats() {
         *current_peak = (*current_peak).max(usage.physical_mem as u64 / 1024);
     }
 }
+
+#[cfg(not(feature = "memory-metrics"))]
+fn update_peak_memory(_current_peak: &mut u64) {}

--- a/rust/compile.sh
+++ b/rust/compile.sh
@@ -1,19 +1,31 @@
 #!/bin/sh
 
-# Compile the rust workspace
-echo "Compiling Rust workspace..."
-if ! cargo build "--manifest-path=rust/Cargo.toml" "--release"; then
+# Compile the production battle engine library in its own cargo invocation.
+# A workspace-wide build would unify features across all member crates, so any
+# debug/test crate enabling e.g. memory-metrics would silently compile that
+# feature into the production .so as well.
+echo "Compiling battle_engine_ffi (production)..."
+if ! cargo build "--manifest-path=rust/Cargo.toml" "--release" "-p" "battle_engine_ffi"; then
     echo "ERROR: Rust compilation failed!"
     exit 1
 fi
 
 # Copy the compiled rust libraries to the storage/rust-libs directory.
-# The .so files are called by Laravel.
+# The .so files are called by Laravel. Copy before building the rest of the
+# workspace so the production artifact cannot be overwritten by a
+# feature-unified build.
 if [ -f rust/target/release/libbattle_engine_ffi.so ]; then
     cp rust/target/release/libbattle_engine_ffi.so storage/rust-libs/
     echo "Copied libbattle_engine_ffi.so"
 else
     echo "ERROR: libbattle_engine_ffi.so not found after compilation!"
+    exit 1
+fi
+
+# Compile the remaining workspace members (test_ffi, battle_engine_debug).
+echo "Compiling Rust workspace..."
+if ! cargo build "--manifest-path=rust/Cargo.toml" "--release"; then
+    echo "ERROR: Rust compilation failed!"
     exit 1
 fi
 

--- a/tests/Unit/BattleEngine/BattleEngineTestAbstract.php
+++ b/tests/Unit/BattleEngine/BattleEngineTestAbstract.php
@@ -4,6 +4,8 @@ namespace Tests\Unit\BattleEngine;
 
 use OGame\GameMissions\BattleEngine\BattleEngine;
 use OGame\GameMissions\BattleEngine\Models\AttackerFleet;
+use OGame\GameMissions\BattleEngine\Models\BattleResult;
+use OGame\GameMissions\BattleEngine\Models\BattleResultRound;
 use OGame\GameObjects\Models\Units\UnitCollection;
 use OGame\Models\Resources;
 use OGame\Models\UserTech;
@@ -49,6 +51,19 @@ abstract class BattleEngineTestAbstract extends UnitTestCase
         $attacker->fleetMission = null;
 
         return $attacker;
+    }
+
+    /**
+     * Return the last round that was fought in the given battle result.
+     */
+    protected function lastRound(BattleResult $battleResult): BattleResultRound
+    {
+        $lastRound = end($battleResult->rounds);
+        if ($lastRound === false) {
+            $this->fail('The battle result does not contain any rounds.');
+        }
+
+        return $lastRound;
     }
 
     /**
@@ -266,7 +281,7 @@ abstract class BattleEngineTestAbstract extends UnitTestCase
         $this->assertNotEmpty($battleResult->rounds);
 
         // Check last round.
-        $lastRound = end($battleResult->rounds);
+        $lastRound = $this->lastRound($battleResult);
         $this->assertNotEmpty($lastRound->attackerShips);
 
         $this->assertNotEquals($attackerFleet->getAmountByMachineName($smallCargo->machine_name), $lastRound->attackerShips->getAmountByMachineName($smallCargo->machine_name));
@@ -336,7 +351,7 @@ abstract class BattleEngineTestAbstract extends UnitTestCase
         $this->assertNotEmpty($battleResult->rounds);
 
         // Get last round with result.
-        $lastRound = end($battleResult->rounds);
+        $lastRound = $this->lastRound($battleResult);
         $this->assertNotEmpty($lastRound->attackerShips);
         $this->assertNotEmpty($lastRound->defenderShips);
         $this->assertEquals(0, $lastRound->attackerShips->getAmountByMachineName($lightFighter->machine_name));
@@ -385,7 +400,7 @@ abstract class BattleEngineTestAbstract extends UnitTestCase
         $this->assertNotEmpty($battleResult->rounds);
 
         // Get last round with result.
-        $lastRound = end($battleResult->rounds);
+        $lastRound = $this->lastRound($battleResult);
         $this->assertNotEmpty($lastRound->attackerShips);
         $this->assertNotEmpty($lastRound->defenderShips);
         $this->assertEquals(1, $lastRound->attackerShips->getAmountByMachineName($deathStar->machine_name));
@@ -452,7 +467,7 @@ abstract class BattleEngineTestAbstract extends UnitTestCase
         $this->assertGreaterThan(30, $firstRound->hitsAttacker);
 
         // Get last round with result.
-        $lastRound = end($battleResult->rounds);
+        $lastRound = $this->lastRound($battleResult);
         // Expected result: attacker loses, defender rocket launchers remaining < 400. Without rapidfire the estimated
         // remaining rocket launchers would be between 450-500.
         $this->assertLessThan(400, $lastRound->defenderShips->getAmountByMachineName('rocket_launcher'));
@@ -482,7 +497,7 @@ abstract class BattleEngineTestAbstract extends UnitTestCase
         $this->assertCount(6, $battleResult->rounds);
 
         // Get last round.
-        $lastRound = end($battleResult->rounds);
+        $lastRound = $this->lastRound($battleResult);
         $this->assertNotEmpty($lastRound);
         // Assert that attacker has all light fighters remaining.
         $this->assertEquals(5000, $lastRound->attackerShips->getAmountByMachineName('light_fighter'));
@@ -522,7 +537,7 @@ abstract class BattleEngineTestAbstract extends UnitTestCase
         $this->assertCount(1, $battleResult->rounds);
 
         // Get last round.
-        $lastRound = end($battleResult->rounds);
+        $lastRound = $this->lastRound($battleResult);
         $this->assertNotEmpty($lastRound);
         // Assert that attacker has all light fighters remaining.
         $this->assertEquals(5000, $lastRound->attackerShips->getAmountByMachineName('light_fighter'));
@@ -555,7 +570,7 @@ abstract class BattleEngineTestAbstract extends UnitTestCase
 
         // Assert the rounds are not empty and contain valid data.
         $this->assertNotEmpty($battleResult->rounds);
-        $lastRound = end($battleResult->rounds);
+        $lastRound = $this->lastRound($battleResult);
 
         // Expect attacker to have lost all ships, defender to have all heavy lasers remaining.
         $this->assertEquals(0, $lastRound->attackerShips->getAmountByMachineName($lightFighter->machine_name));
@@ -696,7 +711,7 @@ abstract class BattleEngineTestAbstract extends UnitTestCase
         $this->assertGreaterThan(1, count($battleResult->rounds));
 
         // Get last round.
-        $lastRound = end($battleResult->rounds);
+        $lastRound = $this->lastRound($battleResult);
         $this->assertNotEmpty($lastRound);
         // Assert that attacker lost some light fighters.
         $this->assertLessThan($start_light_fighter, $lastRound->attackerShips->getAmountByMachineName('light_fighter'));

--- a/tests/Unit/BattleEngine/BattleEngineTestAbstract.php
+++ b/tests/Unit/BattleEngine/BattleEngineTestAbstract.php
@@ -2,16 +2,68 @@
 
 namespace Tests\Unit\BattleEngine;
 
+use OGame\GameMissions\BattleEngine\BattleEngine;
+use OGame\GameMissions\BattleEngine\Models\AttackerFleet;
 use OGame\GameObjects\Models\Units\UnitCollection;
+use OGame\Models\Resources;
+use OGame\Models\UserTech;
 use OGame\Services\ObjectService;
+use OGame\Services\PlayerService;
 use Tests\UnitTestCase;
 
 abstract class BattleEngineTestAbstract extends UnitTestCase
 {
     /**
-     * Factory method that should return the battle engine instance to test.
+     * Factory method that should return the battle engine instance to test for one or
+     * more attacking fleets.
+     *
+     * @param array<AttackerFleet> $attackers
      */
-    abstract protected function createBattleEngine(UnitCollection $attackerFleet): mixed;
+    abstract protected function createBattleEngineForAttackers(array $attackers): BattleEngine;
+
+    /**
+     * Return the battle engine instance to test for a single attacking fleet of the default player.
+     */
+    protected function createBattleEngine(UnitCollection $attackerFleet): BattleEngine
+    {
+        return $this->createBattleEngineForAttackers([$this->makeAttackerFleet($attackerFleet, $this->playerService)]);
+    }
+
+    /**
+     * Create an attacking fleet for the given units and owner.
+     *
+     * @param UnitCollection $units The units in this fleet.
+     * @param PlayerService $player The owner of this fleet, whose tech levels the fleet fights with.
+     * @param int $fleetMissionId Fleet mission id, 0 for test battles without a real fleet mission.
+     * @param bool $isInitiator Whether this fleet initiated the (ACS) attack.
+     */
+    protected function makeAttackerFleet(UnitCollection $units, PlayerService $player, int $fleetMissionId = 0, bool $isInitiator = true): AttackerFleet
+    {
+        $attacker = new AttackerFleet();
+        $attacker->units = $units;
+        $attacker->player = $player;
+        $attacker->fleetMissionId = $fleetMissionId;
+        $attacker->ownerId = $player->getId();
+        $attacker->cargoResources = new Resources(0, 0, 0, 0);
+        $attacker->isInitiator = $isInitiator;
+        $attacker->fleetMission = null;
+
+        return $attacker;
+    }
+
+    /**
+     * Create an additional player with the given research levels, used for ACS battles where
+     * every fleet fights with the tech levels of its own owner.
+     *
+     * @param array<string, int> $researchLevels
+     */
+    protected function createPlayerWithResearchLevels(array $researchLevels): PlayerService
+    {
+        $player = resolve(PlayerService::class, ['player_id' => 0]);
+        $player->setUserTech(UserTech::factory()->make($researchLevels));
+
+        return $player;
+    }
 
     /**
      * Set up common test components.
@@ -650,5 +702,194 @@ abstract class BattleEngineTestAbstract extends UnitTestCase
         $this->assertLessThan($start_light_fighter, $lastRound->attackerShips->getAmountByMachineName('light_fighter'));
         // Assert that defender has lost some rocket launchers.
         $this->assertLessThan($start_rocket_launcher, $lastRound->defenderShips->getAmountByMachineName('rocket_launcher'));
+    }
+
+    /**
+     * Test that a shot weaker than 1% of the target's max shield bounces as long as the shield is up.
+     *
+     * This is the counterpart of testWeakShotDamagesHullInFullAfterShieldIsStrippedInSameRound and
+     * additionally verifies that a bounced shot is fully absorbed by the shield and still shows up
+     * in the round statistics.
+     */
+    public function testWeakShotBouncesOffIntactShield(): void
+    {
+        // A large shield dome has 10.000 shield points and 10.000 hull plating, so a shot needs
+        // to deal at least 100 damage (1% of the max shield) to deplete anything. A light fighter
+        // only deals 50 damage, so every single shot bounces and the dome stays untouched.
+        $this->createAndSetPlanetModel([
+            'large_shield_dome' => 1,
+        ]);
+
+        // Create fleet of attacker player.
+        $attackerFleet = new UnitCollection();
+        $lightFighter = ObjectService::getUnitObjectByMachineName('light_fighter');
+        $attackerFleet->addUnit($lightFighter, 400);
+
+        // Simulate battle.
+        $battleResult = $this->createBattleEngine($attackerFleet)->simulateBattle();
+
+        // Neither side can destroy anything (the dome deals 1 damage per round against 400 hull
+        // plating), so the battle runs the full six rounds without a single loss.
+        $this->assertCount(6, $battleResult->rounds);
+
+        foreach ($battleResult->rounds as $round) {
+            // Every light fighter fires exactly once, light fighters have no rapidfire
+            // against a large shield dome.
+            $this->assertEquals(400, $round->hitsAttacker);
+            $this->assertEquals(400 * 50, $round->fullStrengthAttacker);
+
+            // All damage is absorbed by the shield: bounced shots deplete nothing at all.
+            $this->assertEquals(400 * 50, $round->absorbedDamageDefender);
+
+            $this->assertEquals(0, $round->defenderLossesInRound->getAmount());
+            $this->assertEquals(0, $round->attackerLossesInRound->getAmount());
+        }
+
+        $this->assertEquals(1, $battleResult->defenderUnitsResult->getAmountByMachineName('large_shield_dome'));
+        $this->assertEquals(400, $battleResult->attackerUnitsResult->getAmountByMachineName('light_fighter'));
+    }
+
+    /**
+     * Test that shots which would bounce off an intact shield damage the hull in full once the
+     * shield has been stripped earlier in the same round.
+     */
+    public function testWeakShotDamagesHullInFullAfterShieldIsStrippedInSameRound(): void
+    {
+        // Fleets fire in slot order, so this is the classic ACS shield stripping tactic: the
+        // first fleet breaks the shield and the weak ships of the second fleet no longer bounce.
+        $this->createAndSetPlanetModel([
+            'large_shield_dome' => 1,
+        ]);
+
+        // Fleet 1 fires first: 25 cruisers x 400 damage strip the dome's 10.000 shield exactly,
+        // without dealing any hull damage.
+        $cruiserFleet = new UnitCollection();
+        $cruiser = ObjectService::getUnitObjectByMachineName('cruiser');
+        $cruiserFleet->addUnit($cruiser, 25);
+
+        // Fleet 2 fires second: 400 light fighters x 50 damage. Each of those shots would bounce
+        // off the intact shield, but against the stripped shield they hit the hull in full:
+        // 20.000 damage against 10.000 hull plating destroys the dome in the first round.
+        $lightFighterFleet = new UnitCollection();
+        $lightFighter = ObjectService::getUnitObjectByMachineName('light_fighter');
+        $lightFighterFleet->addUnit($lightFighter, 400);
+
+        // Simulate battle.
+        $battleResult = $this->createBattleEngineForAttackers([
+            $this->makeAttackerFleet($cruiserFleet, $this->playerService, 1),
+            $this->makeAttackerFleet($lightFighterFleet, $this->playerService, 2, false),
+        ])->simulateBattle();
+
+        // The defender is wiped out in the first round, so the battle stops after one round.
+        $this->assertCount(1, $battleResult->rounds);
+        $this->assertEquals(1, $battleResult->rounds[0]->defenderLossesInRound->getAmountByMachineName('large_shield_dome'));
+        $this->assertEquals(0, $battleResult->defenderUnitsResult->getAmount());
+    }
+
+    /**
+     * Test that shots fired at a unit that was already destroyed earlier in the round are wasted
+     * but still count towards the round statistics.
+     */
+    public function testShotAtDestroyedUnitIsWastedButStillCounted(): void
+    {
+        // A single rocket launcher (20 shield points, 200 hull plating) is destroyed after a
+        // handful of light fighter shots. The remaining shots of the round are wasted on the
+        // wreck: they are not retargeted at another unit, but they do count as hits.
+        $this->createAndSetPlanetModel([
+            'rocket_launcher' => 1,
+        ]);
+
+        // Create fleet of attacker player.
+        $attackerFleet = new UnitCollection();
+        $lightFighter = ObjectService::getUnitObjectByMachineName('light_fighter');
+        $attackerFleet->addUnit($lightFighter, 100);
+
+        // Simulate battle.
+        $battleResult = $this->createBattleEngine($attackerFleet)->simulateBattle();
+
+        // The defender is wiped out in the first round, so the battle stops after one round.
+        $this->assertCount(1, $battleResult->rounds);
+        $round = $battleResult->rounds[0];
+
+        // All 100 light fighters fire exactly once, including the ones shooting at the wreck.
+        // Light fighters have no rapidfire against a rocket launcher.
+        $this->assertEquals(100, $round->hitsAttacker);
+        $this->assertEquals(100 * 50, $round->fullStrengthAttacker);
+
+        // Only the single rocket launcher is lost, the wasted damage does not spill over.
+        $this->assertEquals(1, $round->defenderLossesInRound->getAmountByMachineName('rocket_launcher'));
+        $this->assertEquals(0, $battleResult->defenderUnitsResult->getAmount());
+    }
+
+    /**
+     * Test that a shot fired at an already destroyed unit still rolls for rapidfire.
+     */
+    public function testShotAtDestroyedUnitStillRollsRapidfire(): void
+    {
+        // A single cruiser shot (400 damage) already destroys a rocket launcher (20 shield
+        // points, 200 hull plating), so every following shot of the round hits the wreck.
+        $this->createAndSetPlanetModel([
+            'rocket_launcher' => 1,
+        ]);
+
+        // Create fleet of attacker player.
+        $attackerFleet = new UnitCollection();
+        $cruiser = ObjectService::getUnitObjectByMachineName('cruiser');
+        $attackerFleet->addUnit($cruiser, 20);
+
+        // Simulate battle.
+        $battleResult = $this->createBattleEngine($attackerFleet)->simulateBattle();
+
+        $round = $battleResult->rounds[0];
+
+        // Cruisers have rapidfire 10 against rocket launchers, so every cruiser keeps firing
+        // with a 9/10 chance per shot: ~200 hits are expected for 20 cruisers. If rapidfire
+        // was not rolled on destroyed targets the round could never exceed 21 hits (one roll
+        // on the living target plus a single wasted shot per cruiser), so the 40 hits asserted
+        // here separate both behaviours with a vanishing chance of a false failure.
+        $this->assertGreaterThan(40, $round->hitsAttacker);
+
+        // Only the single rocket launcher is lost, the wasted damage does not spill over.
+        $this->assertEquals(1, $round->defenderLossesInRound->getAmountByMachineName('rocket_launcher'));
+    }
+
+    /**
+     * Test that two ACS fleets that share a unit type each fight with their own tech levels.
+     */
+    public function testAcsFleetsSharingUnitTypeFightWithOwnTechLevels(): void
+    {
+        // Both allied fleets bring light fighters, but the owner of the second fleet has weapon
+        // technology 20 (+200% attack). Each fleet has to fight with the tech levels of its own
+        // owner: 50 damage per shot for fleet 1 and 150 damage per shot for fleet 2.
+        $this->createAndSetPlanetModel([
+            'rocket_launcher' => 1,
+        ]);
+
+        $lightFighter = ObjectService::getUnitObjectByMachineName('light_fighter');
+
+        $firstFleet = new UnitCollection();
+        $firstFleet->addUnit($lightFighter, 100);
+
+        $secondFleet = new UnitCollection();
+        $secondFleet->addUnit($lightFighter, 100);
+
+        $secondPlayer = $this->createPlayerWithResearchLevels(['weapon_technology' => 20]);
+
+        // Simulate battle.
+        $battleResult = $this->createBattleEngineForAttackers([
+            $this->makeAttackerFleet($firstFleet, $this->playerService, 1),
+            $this->makeAttackerFleet($secondFleet, $secondPlayer, 2, false),
+        ])->simulateBattle();
+
+        $round = $battleResult->rounds[0];
+
+        // Every light fighter fires exactly once, light fighters have no rapidfire against a
+        // rocket launcher.
+        $this->assertEquals(200, $round->hitsAttacker);
+
+        // 100 shots x 50 damage + 100 shots x 150 damage. If both fleets shared one set of
+        // combat values the total would be 10.000 (everything at tech level 0) or 30.000
+        // (everything at tech level 20) instead.
+        $this->assertEquals(100 * 50 + 100 * 150, $round->fullStrengthAttacker);
     }
 }

--- a/tests/Unit/BattleEngine/BattleEngineTestAbstract.php
+++ b/tests/Unit/BattleEngine/BattleEngineTestAbstract.php
@@ -907,4 +907,60 @@ abstract class BattleEngineTestAbstract extends UnitTestCase
         // (everything at tech level 20) instead.
         $this->assertEquals(100 * 50 + 100 * 150, $round->fullStrengthAttacker);
     }
+
+    /**
+     * Test that the unit types within a single fleet fire in ascending unit id order.
+     *
+     * This is the within-fleet counterpart of the fleet (slot) order that
+     * testWeakShotDamagesHullInFullAfterShieldIsStrippedInSameRound covers: the firing order
+     * decides whether the weak ships of a fleet still bounce off the target's shield.
+     */
+    public function testUnitsWithinFleetFireInAscendingUnitIdOrder(): void
+    {
+        // A large shield dome has 10.000 shield points and 10.000 hull plating.
+        $this->createAndSetPlanetModel([
+            'large_shield_dome' => 1,
+        ]);
+
+        // The cruisers are added to the fleet first, but the light fighters have the lower unit
+        // id (204 against 206) and therefore fire first, before the shield is stripped:
+        //
+        // - 400 light fighters x 50 damage all bounce, as 50 is below 1% of the max shield.
+        // - 25 cruisers x 400 damage then deplete 4 shield percentiles each, which strips the
+        //   remaining 10.000 shield points exactly without any of it spilling over to the hull.
+        //
+        // The dome therefore ends every round with an untouched hull. If the units fired in
+        // insertion order instead, the cruisers would strip the shield first and the 400 light
+        // fighters would deal 20.000 hull damage against 10.000 hull plating, destroying the
+        // dome in the first round.
+        $attackerFleet = new UnitCollection();
+        $cruiser = ObjectService::getUnitObjectByMachineName('cruiser');
+        $attackerFleet->addUnit($cruiser, 25);
+        $lightFighter = ObjectService::getUnitObjectByMachineName('light_fighter');
+        $attackerFleet->addUnit($lightFighter, 400);
+
+        // Simulate battle.
+        $battleResult = $this->createBattleEngine($attackerFleet)->simulateBattle();
+
+        // The dome only deals 1 damage per round, so neither side can destroy anything and the
+        // battle runs the full six rounds.
+        $this->assertCount(6, $battleResult->rounds);
+
+        foreach ($battleResult->rounds as $round) {
+            // Every ship fires exactly once, neither light fighters nor cruisers have rapidfire
+            // against a large shield dome.
+            $this->assertEquals(425, $round->hitsAttacker);
+
+            // All damage ends up in the shield: the bounced light fighter shots are absorbed
+            // without effect and the cruiser shots deplete the shield exactly.
+            $this->assertEquals(400 * 50 + 25 * 400, $round->absorbedDamageDefender);
+
+            $this->assertEquals(0, $round->defenderLossesInRound->getAmount());
+            $this->assertEquals(0, $round->attackerLossesInRound->getAmount());
+        }
+
+        $this->assertEquals(1, $battleResult->defenderUnitsResult->getAmountByMachineName('large_shield_dome'));
+        $this->assertEquals(400, $battleResult->attackerUnitsResult->getAmountByMachineName('light_fighter'));
+        $this->assertEquals(25, $battleResult->attackerUnitsResult->getAmountByMachineName('cruiser'));
+    }
 }

--- a/tests/Unit/BattleEngine/PhpBattleEngineTest.php
+++ b/tests/Unit/BattleEngine/PhpBattleEngineTest.php
@@ -3,10 +3,13 @@
 namespace Tests\Unit\BattleEngine;
 
 use OGame\GameMissions\BattleEngine\BattleEngine;
-use OGame\GameMissions\BattleEngine\Models\AttackerFleet;
+use OGame\GameMissions\BattleEngine\Models\BattleResultRound;
+use OGame\GameMissions\BattleEngine\Models\BattleUnit;
+use OGame\GameMissions\BattleEngine\Models\DefenderFleet;
 use OGame\GameMissions\BattleEngine\PhpBattleEngine;
 use OGame\GameObjects\Models\Units\UnitCollection;
-use OGame\Models\Resources;
+use OGame\Services\ObjectService;
+use ReflectionMethod;
 
 /**
  * Test class for the PHP BattleEngine. The actual tests that create the simulated battles
@@ -18,29 +21,96 @@ class PhpBattleEngineTest extends BattleEngineTestAbstract
      * Create a new BattleEngine instance. This allows the test class itself to change the BattleEngine
      * that is used for the actual tests defined in the abstract test class.
      *
-     * @param UnitCollection $attackerFleet
-     * @return BattleEngine
+     * @inheritdoc
      */
-    protected function createBattleEngine(UnitCollection $attackerFleet): BattleEngine
+    protected function createBattleEngineForAttackers(array $attackers): BattleEngine
     {
         // Create defenders array with planet's stationary forces
-        $defenders = [\OGame\GameMissions\BattleEngine\Models\DefenderFleet::fromPlanet($this->planetService)];
-
-        // Convert UnitCollection to AttackerFleet for the new multi-attacker architecture
-        $attacker = new AttackerFleet();
-        $attacker->units = $attackerFleet;
-        $attacker->player = $this->playerService;
-        $attacker->fleetMissionId = 0; // 0 for test battles without a real fleet mission
-        $attacker->ownerId = $this->playerService->getId();
-        $attacker->cargoResources = new Resources(0, 0, 0, 0);
-        $attacker->isInitiator = true;
-        $attacker->fleetMission = null;
+        $defenders = [DefenderFleet::fromPlanet($this->planetService)];
 
         return new PhpBattleEngine(
-            [$attacker],
+            $attackers,
             $this->planetService,
             $defenders,
             $this->settingsService
         );
+    }
+
+    /**
+     * Test that a bounced shot never triggers the hull explosion roll of a damaged unit.
+     *
+     * This is tested on the individual shot instead of on a full battle: a unit only has a
+     * damaged hull once its shield has been stripped, so within a battle the combination of
+     * "damaged hull, intact shield and incoming bounced shots" only occurs after the shield
+     * regenerated in a later round, which cannot be set up deterministically.
+     */
+    public function testBouncedShotNeverTriggersHullExplosionRoll(): void
+    {
+        $lightFighter = ObjectService::getUnitObjectByMachineName('light_fighter');
+        $shieldDome = ObjectService::getUnitObjectByMachineName('large_shield_dome');
+
+        // The light fighter deals 50 damage, which is below 1% of the dome's 10.000 max shield
+        // points, so all of its shots bounce off the intact shield.
+        $attacker = new BattleUnit($lightFighter, 4000, 10, 50, 0, 0);
+        $defender = new BattleUnit($shieldDome, 100000, 10000, 1, 0, 0);
+
+        // Damage the hull of the dome to 10% of its original value. Every explosion roll on it
+        // would succeed with a 90% chance, so 300 bounced shots would destroy it with certainty
+        // if bounced shots were allowed to trigger the roll.
+        $defender->currentHullPlating = $defender->originalHullPlating * 0.1;
+
+        $round = new BattleResultRound();
+        $this->fireShots(300, $round, $attacker, $defender);
+
+        // The dome is untouched: no hull damage, no depleted shield and no explosion.
+        $this->assertEquals(1000, $defender->currentHullPlating);
+        $this->assertEquals(10000, $defender->currentShieldPoints);
+
+        // The bounced shots do count towards the round statistics.
+        $this->assertEquals(300, $round->hitsAttacker);
+        $this->assertEquals(300 * 50, $round->fullStrengthAttacker);
+    }
+
+    /**
+     * Test that a shot which is not bounced does trigger the hull explosion roll of a damaged
+     * unit. This guards the counterpart of testBouncedShotNeverTriggersHullExplosionRoll: the
+     * explosion roll is skipped for bounced shots only, not for weak shots in general.
+     */
+    public function testShotOnStrippedShieldStillTriggersHullExplosionRoll(): void
+    {
+        $lightFighter = ObjectService::getUnitObjectByMachineName('light_fighter');
+        $shieldDome = ObjectService::getUnitObjectByMachineName('large_shield_dome');
+
+        $attacker = new BattleUnit($lightFighter, 4000, 10, 50, 0, 0);
+        $defender = new BattleUnit($shieldDome, 100000, 10000, 1, 0, 0);
+
+        // Same damaged hull as above, but with the shield already stripped. The shots now hit
+        // the hull in full and are therefore not bounced, so they do roll for an explosion.
+        $defender->currentHullPlating = $defender->originalHullPlating * 0.1;
+        $defender->currentShieldPoints = 0;
+
+        $round = new BattleResultRound();
+        $this->fireShots(10, $round, $attacker, $defender);
+
+        // The dome must be destroyed: 10 shots x 50 damage only remove half of the remaining
+        // 1.000 hull plating, so only a successful explosion roll (~90% chance per shot) can
+        // have destroyed it.
+        $this->assertEquals(0, $defender->currentHullPlating);
+    }
+
+    /**
+     * Let an attacking unit fire the given amount of shots at a defending unit.
+     *
+     * The engine has no public entry point for a single shot, so the private method is called
+     * through reflection to be able to test shots in isolation.
+     */
+    private function fireShots(int $amount, BattleResultRound $round, BattleUnit $attacker, BattleUnit $defender): void
+    {
+        $engine = $this->createBattleEngine(new UnitCollection());
+        $attackUnit = new ReflectionMethod(PhpBattleEngine::class, 'attackUnit');
+
+        for ($i = 0; $i < $amount; $i++) {
+            $attackUnit->invoke($engine, true, $round, $attacker, $defender);
+        }
     }
 }

--- a/tests/Unit/BattleEngine/RustBattleEngineTest.php
+++ b/tests/Unit/BattleEngine/RustBattleEngineTest.php
@@ -3,10 +3,8 @@
 namespace Tests\Unit\BattleEngine;
 
 use OGame\GameMissions\BattleEngine\BattleEngine;
-use OGame\GameMissions\BattleEngine\Models\AttackerFleet;
+use OGame\GameMissions\BattleEngine\Models\DefenderFleet;
 use OGame\GameMissions\BattleEngine\RustBattleEngine;
-use OGame\GameObjects\Models\Units\UnitCollection;
-use OGame\Models\Resources;
 
 class RustBattleEngineTest extends BattleEngineTestAbstract
 {
@@ -14,26 +12,15 @@ class RustBattleEngineTest extends BattleEngineTestAbstract
      * Create a new BattleEngine instance. This allows the test class itself to change the BattleEngine
      * that is used for the actual tests defined in the abstract test class.
      *
-     * @param UnitCollection $attackerFleet
-     * @return BattleEngine
+     * @inheritdoc
      */
-    protected function createBattleEngine(UnitCollection $attackerFleet): BattleEngine
+    protected function createBattleEngineForAttackers(array $attackers): BattleEngine
     {
         // Create defenders array with planet's stationary forces
-        $defenders = [\OGame\GameMissions\BattleEngine\Models\DefenderFleet::fromPlanet($this->planetService)];
-
-        // Convert UnitCollection to AttackerFleet for the new multi-attacker architecture
-        $attacker = new AttackerFleet();
-        $attacker->units = $attackerFleet;
-        $attacker->player = $this->playerService;
-        $attacker->fleetMissionId = 0; // 0 for test battles without a real fleet mission
-        $attacker->ownerId = $this->playerService->getId();
-        $attacker->cargoResources = new Resources(0, 0, 0, 0);
-        $attacker->isInitiator = true;
-        $attacker->fleetMission = null;
+        $defenders = [DefenderFleet::fromPlanet($this->planetService)];
 
         return new RustBattleEngine(
-            [$attacker],
+            $attackers,
             $this->planetService,
             $defenders,
             $this->settingsService


### PR DESCRIPTION
…erformance and OGame fidelity

Memory fixes:
- Free the Rust-allocated result buffer after each battle via new free_battle_result() FFI export; previously every battle leaked its full JSON output for the lifetime of the PHP process.
- Gate peak-memory tracking behind an opt-in memory-metrics feature. battle_engine_debug force-enabled it and cargo feature unification compiled /proc/self/smaps polling into the production .so, making small battles ~30x slower. compile.sh now builds the production library in an isolated cargo invocation as defense in depth.

Engine v2 rewrite (Rust):
- Resolve static unit values once into a flat per-(fleet, unit type) array; unit instances carry a u16 index plus current shield/hull, so the shot loop does direct slice indexing instead of HashMap lookups.
- Precompute rapidfire chances into an attacker x defender cross table.
- Derive round statistics from per-type alive counters instead of rescanning all unit instances every round.
- Remove destroyed units and regenerate survivor shields in a single retain_mut sweep.
- Fixes a v1 ACS bug where fleets sharing a unit type had their combat values merged last-insert-wins, so shared types silently fought with one arbitrary fleet's tech levels.

Combat fidelity, verified against the original OGame v0.84 battle.c and implemented identically in the PHP and Rust engines:
- Shield damage is dealt in whole multiples of 1% of max shield; shots under 1% bounce, but only while the shield is up. Once the shield is stripped within a round, every shot damages the hull in full.
- Shots on units already destroyed this round are wasted but still count towards statistics and still roll rapidfire.
- Bounced shots never trigger the hull-explosion roll.
- Units fire in deterministic order (fleet slot order, ascending unit id) so ACS shield-stripping tactics work like the original game.
- Exact (n-1)/n rapidfire probability in the PHP engine; BattleUnit hull/shield switched to float for the shield percentile math.

Build: enable fat LTO and a single codegen unit for release builds. Tooling: battle_engine_debug rewritten as a CLI bench driver (input file + iteration count, reports ms/battle).

Measured impact (325k-unit mixed battle / 225-unit battle): 63.4 -> 14.1 ms and 0.469 -> 0.015 ms per battle, ~40% lower peak engine memory, zero leaked memory per battle.

## Description
Please include a summary of the changes made to OGameX and their purpose. Clearly describe what this PR does and why it is necessary.

### Type of Change:
- [x] Bug fix
- [x] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [ ] **Automated Refactoring:** Rector has been run and no outstanding issues remain.
- [ ] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [ ] **Static Analysis:** Code passes PHPStan static code analysis.
- [ ] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [ ] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
- [ ] **Documentation:** Documentation has been updated to reflect any changes made.

## Additional Information
Add any additional context, screenshots, or explanations to help reviewers understand your PR. If this change introduces any breaking changes or significant impacts, please detail them here.
