### PR TITLE
Fix stale contributor docs (Vite + race-test commands)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,7 +19,7 @@ Before submitting this pull request, ensure all following requirements as outlin
 - [ ] **Testing:**
     - Relevant unit and feature tests are included or updated.
     - Tests successfully run locally.
-- [ ] **CSS & JS Build:** CSS and JS assets are compiled using Laravel Mix if any changes are made to JS/CSS files.
+- [ ] **CSS & JS Build:** CSS and JS assets are compiled using Vite (`npm run build`) if any changes are made to JS/CSS files.
 - [ ] **Documentation:** Documentation has been updated to reflect any changes made.
 
 ## Additional Information

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,11 +89,11 @@ $ php artisan test --filter PlanetServiceTest
 ### 6. Custom race condition tests
 If you are working on a feature that might introduce race conditions, please include tests that cover these scenarios. OGameX already contains some custom tests that can be run via php artisan commands. These tests support running multiple requests in parallel and in multiple iterations in order to simulate conditions that could cause race conditions.
 
-These tests are located in the `console/Commands/Tests` directory and can be run using the following command:
+These tests are located in the `app/Console/Commands/Test/` directory and can be run using the following command:
 
 ```bash
-$ php artisan test:race-condition-unitqueue
-$ php artisan test:race-condition-game-mission
+$ php artisan ogamex:test:race-condition-unitqueue
+$ php artisan ogamex:test:race-condition-game-mission
 ```
 
 ### 7. Run CSS and JS build


### PR DESCRIPTION
## Summary
- Closes #1575.
- Update `.github/PULL_REQUEST_TEMPLATE.md` so the CSS/JS checklist points at Vite (`npm run build`) instead of Laravel Mix.
- Update `CONTRIBUTING.md` section 6 so race-condition tests use `app/Console/Commands/Test/` and `php artisan ogamex:test:race-condition-unitqueue` / `php artisan ogamex:test:race-condition-game-mission`.

@jackbayliss as requested on the issue — please take a look when you have a moment.

## Test plan
- [ ] Confirm the PR template no longer mentions Laravel Mix and lists Vite (`npm run build`).
- [ ] Confirm `CONTRIBUTING.md` section 6 uses `app/Console/Commands/Test/` (not `console/Commands/Tests`).
- [ ] Confirm the documented artisan commands match `#[Signature]` on the race-condition test commands.
- [ ] No application/code changes in this PR (docs only).


Made with [Cursor](https://cursor.com)