### PR TITLE
Fix flaky ReaperDebrisCollectionTest: stale PlayerService cache and test pollution

### DIFF
--- a/tests/Feature/FleetDispatch/ReaperDebrisCollectionTest.php
+++ b/tests/Feature/FleetDispatch/ReaperDebrisCollectionTest.php
@@ -47,9 +47,7 @@ class ReaperDebrisCollectionTest extends FleetDispatchTestCase
      */
     public function testReaperCollectsDebris(): void
     {
-        // Clear all battle reports to ensure test isolation
-        Message::where('battle_report_id', '!=', null)->delete();
-        BattleReport::query()->delete();
+        $this->basicSetup();
 
         // Set up: attacker with any class (Reaper collection works for all classes)
         $attacker = $this->planetService;
@@ -174,9 +172,7 @@ class ReaperDebrisCollectionTest extends FleetDispatchTestCase
      */
     public function testReaperCollectsDebrisWithNonGeneralClass(): void
     {
-        // Clear all battle reports to ensure test isolation
-        Message::where('battle_report_id', '!=', null)->delete();
-        BattleReport::query()->delete();
+        $this->basicSetup();
 
         // Set up: attacker is NOT General class (using Collector to prove it works for all classes)
         $attacker = $this->planetService;
@@ -272,9 +268,7 @@ class ReaperDebrisCollectionTest extends FleetDispatchTestCase
      */
     public function testNoDebrisCollectionWithoutReapers(): void
     {
-        // Clear all battle reports to ensure test isolation
-        Message::where('battle_report_id', '!=', null)->delete();
-        BattleReport::query()->delete();
+        $this->basicSetup();
 
         // Set up: attacker has no Reapers (only other ships)
         $attacker = $this->planetService;

--- a/tests/Feature/FleetDispatch/ReaperDebrisCollectionTest.php
+++ b/tests/Feature/FleetDispatch/ReaperDebrisCollectionTest.php
@@ -89,6 +89,11 @@ class ReaperDebrisCollectionTest extends FleetDispatchTestCase
         $foreignPlayer->getUser()->tactical_retreat_ratio = 0;
         $foreignPlayer->getUser()->save();
 
+        // Refresh the application: the fleet event requests during dispatch cached a
+        // PlayerService for the defender with the pre-write retreat ratio, and battle
+        // processing would reuse that stale instance instead of reading the ratio above.
+        $this->reloadApplication();
+
         // Clear foreign planet units from previous tests to ensure isolation
         $foreignPlanet->removeUnits($foreignPlanet->getShipUnits(), true);
         $foreignPlanet->removeUnits($foreignPlanet->getDefenseUnits(), true);
@@ -213,6 +218,11 @@ class ReaperDebrisCollectionTest extends FleetDispatchTestCase
         $foreignPlayer->getUser()->tactical_retreat_ratio = 0;
         $foreignPlayer->getUser()->save();
 
+        // Refresh the application: the fleet event requests during dispatch cached a
+        // PlayerService for the defender with the pre-write retreat ratio, and battle
+        // processing would reuse that stale instance instead of reading the ratio above.
+        $this->reloadApplication();
+
         // Clear foreign planet units from previous tests to ensure isolation
         $foreignPlanet->removeUnits($foreignPlanet->getShipUnits(), true);
         $foreignPlanet->removeUnits($foreignPlanet->getDefenseUnits(), true);
@@ -297,6 +307,11 @@ class ReaperDebrisCollectionTest extends FleetDispatchTestCase
         }
         $foreignPlayer->getUser()->tactical_retreat_ratio = 0;
         $foreignPlayer->getUser()->save();
+
+        // Refresh the application: the fleet event requests during dispatch cached a
+        // PlayerService for the defender with the pre-write retreat ratio, and battle
+        // processing would reuse that stale instance instead of reading the ratio above.
+        $this->reloadApplication();
 
         // Clear foreign planet units from previous tests to ensure isolation
         $foreignPlanet->removeUnits($foreignPlanet->getShipUnits(), true);

--- a/tests/Unit/BattleEngine/DefenseRepairBattleEngineTest.php
+++ b/tests/Unit/BattleEngine/DefenseRepairBattleEngineTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\BattleEngine;
 
 use OGame\GameMissions\BattleEngine\Models\AttackerFleet;
+use OGame\GameMissions\BattleEngine\Models\DefenderFleet;
 use OGame\GameMissions\BattleEngine\PhpBattleEngine;
 use OGame\GameObjects\Models\Units\UnitCollection;
 use OGame\Models\Resources;
@@ -42,7 +43,7 @@ class DefenseRepairBattleEngineTest extends UnitTestCase
     protected function createBattleEngine(UnitCollection $attackerFleet): PhpBattleEngine
     {
         // Create defenders array with planet's stationary forces
-        $defenders = [\OGame\GameMissions\BattleEngine\Models\DefenderFleet::fromPlanet($this->planetService)];
+        $defenders = [DefenderFleet::fromPlanet($this->planetService)];
 
         // Convert UnitCollection to AttackerFleet for the new multi-attacker architecture
         $attacker = new AttackerFleet();

--- a/tests/Unit/BattleEngine/DefenseRepairBattleEngineTest.php
+++ b/tests/Unit/BattleEngine/DefenseRepairBattleEngineTest.php
@@ -26,6 +26,16 @@ class DefenseRepairBattleEngineTest extends UnitTestCase
         $this->createAndSetUserTechModel([]);
     }
 
+    protected function tearDown(): void
+    {
+        $this->settingsService->set('debris_field_from_ships', 30);
+        $this->settingsService->set('debris_field_from_defense', 0);
+        $this->settingsService->set('debris_field_deuterium_on', 0);
+        $this->settingsService->set('defense_repair_rate', 70);
+
+        parent::tearDown();
+    }
+
     /**
      * Create a battle engine instance for testing.
      */


### PR DESCRIPTION
## Description
The flaky `ReaperDebrisCollectionTest` failures had two independent causes, both fixed here:

**1. Stale PlayerService cache (primary cause of the CI flakiness)**
The tests disable tactical retreat on the defender (`tactical_retreat_ratio = 0`) after dispatching the fleet, but battle processing reused a `PlayerService` cached during the dispatch's fleet event requests, carrying the pre-write ratio of 5. The defender then tactically retreated, no ships were destroyed, and no debris was created (`Failed asserting that 0 is greater than 0`). Whether the retreat actually triggered depended on the randomly selected foreign planet (deuterium stock, activity), which is why failures appeared mostly on freshly provisioned CI databases and vanished on retry.

Fix: `$this->reloadApplication()` after writing the ratio in all three test methods, so battle processing starts with cold factory caches. 

The underlying factory behavior (reloadCache not propagating to the player) is tracked separately in #1581.

**2. Test pollution via shared settings**
- `ReaperDebrisCollectionTest` never called `basicSetup()`, so `debris_field_from_ships` was inherited from whatever test ran before; now called in all three test methods.
- `DefenseRepairBattleEngineTest` sets debris/repair settings but had no `tearDown()`; now resets `debris_field_from_ships`, `debris_field_from_defense`, `debris_field_deuterium_on`, and `defense_repair_rate` to defaults.

### Type of Change:
- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues
Fixes #1579 

## Checklist
Before submitting this pull request, ensure all following requirements as outlined in [CONTRIBUTING.md](https://github.com/lanedirt/OGameX/blob/main/CONTRIBUTING.md) are met:

- [X] **Automated Refactoring:** Rector has been run and no outstanding issues remain.
- [X] **Code Standards:** Code adheres to PSR-12 coding standards. Verified with Laravel Pint.
- [X] **Static Analysis:** Code passes PHPStan static code analysis.
- [X] **Testing:**
    - Relevant unit and feature tests are included or updated.
    - Tests successfully run locally.
- [X] **CSS & JS Build:** CSS and JS assets are compiled using Vite (`npm run build`) if any changes are made to JS/CSS files.
- [X] **Documentation:** Documentation has been updated to reflect any changes made.

## Additional Information
Add any additional context, screenshots, or explanations to help reviewers understand your PR. If this change introduces any breaking changes or significant impacts, please detail them here.
