### PR TITLE
fix: use correct singular translation keys for missile types in destroy rockets modal

### DIFF
--- a/resources/views/ingame/facilities/destroyrockets.blade.php
+++ b/resources/views/ingame/facilities/destroyrockets.blade.php
@@ -14,13 +14,13 @@
                             <th></th>
                         </tr>
                         <tr>
-                            <td>{{ __('t_resources.anti_ballistic_missiles.title') }}</td>
+                            <td>{{ __('t_resources.anti_ballistic_missile.title') }}</td>
                             <td class="textCenter">{{ $abm_count }}</td>
                             <td class="textCenter"><input type="text" pattern="[0-9]*" value="" class="txt" size="4" maxlength="4" name="destroy_502" id="destroy_502"></td>
                             <td></td>
                         </tr>
                         <tr>
-                            <td>{{ __('t_resources.interplanetary_missiles.title') }}</td>
+                            <td>{{ __('t_resources.interplanetary_missile.title') }}</td>
                             <td class="textCenter">{{ $ipm_count }}</td>
                             <td class="textCenter"><input type="text" pattern="[0-9]*" value="" class="txt" size="4" maxlength="4" name="destroy_503" id="destroy_503"></td>
                             <td></td>


### PR DESCRIPTION
anti_ballistic_missiles and interplanetary_missiles were plural but t_resources.php only defines the singular keys, so the modal rendered raw translation strings instead of the missile names.

Fixes #1286