### PR TITLE
fix: supply complete debris_field_harvest params in preview seed fixture

### DIFF
--- a/app/Console/Commands/Dev/PreviewSeedUsers.php
+++ b/app/Console/Commands/Dev/PreviewSeedUsers.php
@@ -533,13 +533,16 @@ class PreviewSeedUsers extends Command
                     $harvestedMetal = rand(0, $metal);
                     $harvestedCrystal = rand(0, $crystal);
                     $harvestedDeuterium = rand(0, $deuterium);
+                    $shipName = rand(0, 1) === 0 ? 'Recycler' : 'Reaper';
+                    $shipCapacity = $shipName === 'Recycler' ? 20000 : 10000;
+                    $shipAmount = rand(1, 20);
 
                     return [
                         'to' => str_replace(['[coordinates]', '[/coordinates]'], ['[debrisfield]', '[/debrisfield]'], $coordinate),
                         'coordinates' => $coordinate,
-                        'ship_name' => 'Recycler',
-                        'ship_amount' => rand(1, 20),
-                        'storage_capacity' => rand(5000, 50000),
+                        'ship_name' => $shipName,
+                        'ship_amount' => $shipAmount,
+                        'storage_capacity' => $shipAmount * $shipCapacity,
                         'metal' => $metal,
                         'crystal' => $crystal,
                         'deuterium' => $deuterium,

--- a/app/Console/Commands/Dev/PreviewSeedUsers.php
+++ b/app/Console/Commands/Dev/PreviewSeedUsers.php
@@ -525,11 +525,29 @@ class PreviewSeedUsers extends Command
             ],
             [
                 'key' => 'debris_field_harvest',
-                'params' => fn () => [
-                    'coordinates' => '[coordinates]' . rand(1, 5) . ':' . rand(1, 499) . ':' . rand(1, 15) . '[/coordinates]',
-                    'metal' => rand(10000, 500000),
-                    'crystal' => rand(5000, 250000),
-                ],
+                'params' => function () {
+                    $coordinate = '[coordinates]' . rand(1, 5) . ':' . rand(1, 499) . ':' . rand(1, 15) . '[/coordinates]';
+                    $metal = rand(10000, 500000);
+                    $crystal = rand(5000, 250000);
+                    $deuterium = rand(0, 100000);
+                    $harvestedMetal = rand(0, $metal);
+                    $harvestedCrystal = rand(0, $crystal);
+                    $harvestedDeuterium = rand(0, $deuterium);
+
+                    return [
+                        'to' => str_replace(['[coordinates]', '[/coordinates]'], ['[debrisfield]', '[/debrisfield]'], $coordinate),
+                        'coordinates' => $coordinate,
+                        'ship_name' => 'Recycler',
+                        'ship_amount' => rand(1, 20),
+                        'storage_capacity' => rand(5000, 50000),
+                        'metal' => $metal,
+                        'crystal' => $crystal,
+                        'deuterium' => $deuterium,
+                        'harvested_metal' => $harvestedMetal,
+                        'harvested_crystal' => $harvestedCrystal,
+                        'harvested_deuterium' => $harvestedDeuterium,
+                    ];
+                },
             ],
         ];
 

--- a/app/Console/Commands/Dev/PreviewSeedUsers.php
+++ b/app/Console/Commands/Dev/PreviewSeedUsers.php
@@ -525,35 +525,7 @@ class PreviewSeedUsers extends Command
             ],
             [
                 'key' => 'debris_field_harvest',
-                'params' => function () {
-                    $coordinate = '[coordinates]' . rand(1, 5) . ':' . rand(1, 499) . ':' . rand(1, 15) . '[/coordinates]';
-                    $metal = rand(10000, 500000);
-                    $crystal = rand(5000, 250000);
-                    $deuterium = rand(0, 100000);
-
-                    $machineNames = ['recycler', 'reaper', 'pathfinder'];
-                    $ship = ObjectService::getShipObjectByMachineName($machineNames[array_rand($machineNames)]);
-                    $shipAmount = rand(1, 20);
-                    $storageCapacity = $shipAmount * $ship->properties->capacity->rawValue;
-
-                    $harvestedMetal = min($metal, rand(0, $storageCapacity));
-                    $harvestedCrystal = min($crystal, rand(0, max(0, $storageCapacity - $harvestedMetal)));
-                    $harvestedDeuterium = min($deuterium, rand(0, max(0, $storageCapacity - $harvestedMetal - $harvestedCrystal)));
-
-                    return [
-                        'to' => str_replace(['[coordinates]', '[/coordinates]'], ['[debrisfield]', '[/debrisfield]'], $coordinate),
-                        'coordinates' => $coordinate,
-                        'ship_name' => $ship->title,
-                        'ship_amount' => $shipAmount,
-                        'storage_capacity' => $storageCapacity,
-                        'metal' => $metal,
-                        'crystal' => $crystal,
-                        'deuterium' => $deuterium,
-                        'harvested_metal' => $harvestedMetal,
-                        'harvested_crystal' => $harvestedCrystal,
-                        'harvested_deuterium' => $harvestedDeuterium,
-                    ];
-                },
+                'params' => fn () => $this->generateDebrisFieldHarvestParams(),
             ],
         ];
 
@@ -594,6 +566,44 @@ class PreviewSeedUsers extends Command
             $message->created_at = now()->subMinutes(rand(1, 43200));
             $message->save();
         }
+    }
+
+    /**
+     * Generate randomized params for a debris_field_harvest message, using a real
+     * ship object so ship_name, storage_capacity, and harvested amounts stay consistent
+     * with what RecycleMission/AttackMission would actually produce.
+     *
+     * @return array<string, mixed>
+     */
+    public function generateDebrisFieldHarvestParams(): array
+    {
+        $coordinate = '[coordinates]' . rand(1, 5) . ':' . rand(1, 499) . ':' . rand(1, 15) . '[/coordinates]';
+        $metal = rand(10000, 500000);
+        $crystal = rand(5000, 250000);
+        $deuterium = rand(0, 100000);
+
+        $machineNames = ['recycler', 'reaper', 'pathfinder'];
+        $ship = ObjectService::getShipObjectByMachineName($machineNames[array_rand($machineNames)]);
+        $shipAmount = rand(1, 20);
+        $storageCapacity = $shipAmount * $ship->properties->capacity->rawValue;
+
+        $harvestedMetal = min($metal, rand(0, $storageCapacity));
+        $harvestedCrystal = min($crystal, rand(0, max(0, $storageCapacity - $harvestedMetal)));
+        $harvestedDeuterium = min($deuterium, rand(0, max(0, $storageCapacity - $harvestedMetal - $harvestedCrystal)));
+
+        return [
+            'to' => str_replace(['[coordinates]', '[/coordinates]'], ['[debrisfield]', '[/debrisfield]'], $coordinate),
+            'coordinates' => $coordinate,
+            'ship_name' => $ship->title,
+            'ship_amount' => $shipAmount,
+            'storage_capacity' => $storageCapacity,
+            'metal' => $metal,
+            'crystal' => $crystal,
+            'deuterium' => $deuterium,
+            'harvested_metal' => $harvestedMetal,
+            'harvested_crystal' => $harvestedCrystal,
+            'harvested_deuterium' => $harvestedDeuterium,
+        ];
     }
 
     /**

--- a/app/Console/Commands/Dev/PreviewSeedUsers.php
+++ b/app/Console/Commands/Dev/PreviewSeedUsers.php
@@ -523,10 +523,7 @@ class PreviewSeedUsers extends Command
                     'deuterium' => rand(1000, 100000),
                 ],
             ],
-            [
-                'key' => 'debris_field_harvest',
-                'params' => fn () => $this->generateDebrisFieldHarvestParams(),
-            ],
+            $this->getDebrisFieldHarvestTemplate(),
         ];
 
         $this->createMessages($user, $fleetTemplates, 60);
@@ -552,7 +549,7 @@ class PreviewSeedUsers extends Command
      * @param array<int, array{key: string, params: callable}> $templates
      * @param int $count
      */
-    private function createMessages(User $user, array $templates, int $count): void
+    public function createMessages(User $user, array $templates, int $count): void
     {
         for ($i = 0; $i < $count; $i++) {
             $template = $templates[array_rand($templates)];
@@ -566,6 +563,20 @@ class PreviewSeedUsers extends Command
             $message->created_at = now()->subMinutes(rand(1, 43200));
             $message->save();
         }
+    }
+
+    /**
+     * The debris_field_harvest message template entry used by seedMessages(), exposed so
+     * tests can exercise the exact same template wiring the seed command uses.
+     *
+     * @return array{key: string, params: callable}
+     */
+    public function getDebrisFieldHarvestTemplate(): array
+    {
+        return [
+            'key' => 'debris_field_harvest',
+            'params' => fn () => $this->generateDebrisFieldHarvestParams(),
+        ];
     }
 
     /**

--- a/app/Console/Commands/Dev/PreviewSeedUsers.php
+++ b/app/Console/Commands/Dev/PreviewSeedUsers.php
@@ -530,19 +530,22 @@ class PreviewSeedUsers extends Command
                     $metal = rand(10000, 500000);
                     $crystal = rand(5000, 250000);
                     $deuterium = rand(0, 100000);
-                    $harvestedMetal = rand(0, $metal);
-                    $harvestedCrystal = rand(0, $crystal);
-                    $harvestedDeuterium = rand(0, $deuterium);
-                    $shipName = rand(0, 1) === 0 ? 'Recycler' : 'Reaper';
-                    $shipCapacity = $shipName === 'Recycler' ? 20000 : 10000;
+
+                    $machineNames = ['recycler', 'reaper', 'pathfinder'];
+                    $ship = ObjectService::getShipObjectByMachineName($machineNames[array_rand($machineNames)]);
                     $shipAmount = rand(1, 20);
+                    $storageCapacity = $shipAmount * $ship->properties->capacity->rawValue;
+
+                    $harvestedMetal = min($metal, rand(0, $storageCapacity));
+                    $harvestedCrystal = min($crystal, rand(0, max(0, $storageCapacity - $harvestedMetal)));
+                    $harvestedDeuterium = min($deuterium, rand(0, max(0, $storageCapacity - $harvestedMetal - $harvestedCrystal)));
 
                     return [
                         'to' => str_replace(['[coordinates]', '[/coordinates]'], ['[debrisfield]', '[/debrisfield]'], $coordinate),
                         'coordinates' => $coordinate,
-                        'ship_name' => $shipName,
+                        'ship_name' => $ship->title,
                         'ship_amount' => $shipAmount,
-                        'storage_capacity' => $shipAmount * $shipCapacity,
+                        'storage_capacity' => $storageCapacity,
                         'metal' => $metal,
                         'crystal' => $crystal,
                         'deuterium' => $deuterium,

--- a/tests/Feature/PreviewSeedUsersCommandTest.php
+++ b/tests/Feature/PreviewSeedUsersCommandTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Testing\PendingCommand;
 use OGame\Factories\GameMessageFactory;
 use OGame\Models\Message;
 use OGame\Models\User;
@@ -25,7 +26,9 @@ class PreviewSeedUsersCommandTest extends TestCase
 
     public function test_seed_users_creates_valid_debris_field_harvest_messages(): void
     {
-        $this->artisan('ogamex:dev:seed-users')->assertExitCode(0);
+        $command = $this->artisan('ogamex:dev:seed-users');
+        $this->assertInstanceOf(PendingCommand::class, $command);
+        $command->assertSuccessful();
 
         $userIds = User::where('email', 'like', '%@ogamex.dev')->pluck('id');
         $this->assertNotEmpty($userIds, 'Seed command should have created preview test users.');

--- a/tests/Feature/PreviewSeedUsersCommandTest.php
+++ b/tests/Feature/PreviewSeedUsersCommandTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use OGame\Factories\GameMessageFactory;
+use OGame\Models\Message;
+use OGame\Models\User;
+use Tests\TestCase;
+
+class PreviewSeedUsersCommandTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /**
+     * Per-ship debris field harvest storage capacity, mirrored from the real ship
+     * object definitions (recycler / reaper) that the fixture is meant to represent.
+     *
+     * @var array<string, int>
+     */
+    private const SHIP_CAPACITY = [
+        'Recycler' => 20000,
+        'Reaper' => 10000,
+    ];
+
+    public function test_seed_users_creates_valid_debris_field_harvest_messages(): void
+    {
+        $this->artisan('ogamex:dev:seed-users')->assertExitCode(0);
+
+        $userIds = User::where('email', 'like', '%@ogamex.dev')->pluck('id');
+        $this->assertNotEmpty($userIds, 'Seed command should have created preview test users.');
+
+        $messages = Message::whereIn('user_id', $userIds)
+            ->where('key', 'debris_field_harvest')
+            ->get();
+
+        $this->assertNotEmpty($messages, 'Seed command should have created at least one debris_field_harvest message.');
+
+        foreach ($messages as $message) {
+            $params = $message->params;
+
+            // All params required by the DebrisFieldHarvest message must be present.
+            foreach (['to', 'coordinates', 'ship_name', 'ship_amount', 'storage_capacity', 'metal', 'crystal', 'deuterium', 'harvested_metal', 'harvested_crystal', 'harvested_deuterium'] as $param) {
+                $this->assertArrayHasKey($param, $params, "Missing param '{$param}' in debris_field_harvest message.");
+            }
+
+            // Harvested amounts can never exceed the amount available in the debris field.
+            $this->assertLessThanOrEqual((int) $params['metal'], (int) $params['harvested_metal']);
+            $this->assertLessThanOrEqual((int) $params['crystal'], (int) $params['harvested_crystal']);
+            $this->assertLessThanOrEqual((int) $params['deuterium'], (int) $params['harvested_deuterium']);
+
+            // "to" is wrapped in [debrisfield], "coordinates" keeps [coordinates], matching
+            // what RecycleMission/AttackMission send in production.
+            $this->assertStringContainsString('[debrisfield]', $params['to']);
+            $this->assertStringContainsString('[coordinates]', $params['coordinates']);
+
+            // ship_name must be a known harvesting ship, and storage_capacity must scale
+            // with ship_amount using that ship's real cargo capacity.
+            $this->assertArrayHasKey($params['ship_name'], self::SHIP_CAPACITY, "Unexpected ship_name '{$params['ship_name']}'.");
+            $expectedCapacity = (int) $params['ship_amount'] * self::SHIP_CAPACITY[$params['ship_name']];
+            $this->assertEquals($expectedCapacity, (int) $params['storage_capacity']);
+
+            // Rendering the message must not leak any unresolved param placeholders.
+            $gameMessage = GameMessageFactory::createGameMessage($message);
+            $this->assertStringNotContainsString('?undefined?', $gameMessage->getSubject());
+            $this->assertStringNotContainsString('?undefined?', $gameMessage->getBody());
+        }
+    }
+}

--- a/tests/Feature/PreviewSeedUsersCommandTest.php
+++ b/tests/Feature/PreviewSeedUsersCommandTest.php
@@ -36,8 +36,9 @@ class PreviewSeedUsersCommandTest extends TestCase
 
     /**
      * Directly exercises the debris_field_harvest fixture generator without running
-     * the full ogamex:dev:seed-users command (which also creates users/planets and
-     * is slow). This keeps the test focused on the fixture's own correctness.
+     * the full ogamex:dev:seed-users command, which also creates 10 users, planets,
+     * and unrelated message templates. This keeps the test focused on the fixture's
+     * own correctness instead of depending on unrelated seeding to succeed.
      */
     public function test_debris_field_harvest_fixture_produces_valid_messages(): void
     {

--- a/tests/Feature/PreviewSeedUsersCommandTest.php
+++ b/tests/Feature/PreviewSeedUsersCommandTest.php
@@ -2,14 +2,38 @@
 
 namespace Tests\Feature;
 
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 use OGame\Console\Commands\Dev\PreviewSeedUsers;
 use OGame\Factories\GameMessageFactory;
 use OGame\Models\Message;
+use OGame\Models\User;
 use OGame\Services\ObjectService;
 use Tests\TestCase;
 
 class PreviewSeedUsersCommandTest extends TestCase
 {
+    use DatabaseTransactions;
+
+    /**
+     * Exercises the same template wiring seedMessages() uses (a {key, params} entry fed
+     * through createMessages()), so the debris_field_harvest fixture is verified as an
+     * actually-persisted, actually-rendered message, not just as a standalone array.
+     */
+    public function test_debris_field_harvest_template_is_wired_and_renders(): void
+    {
+        $command = new PreviewSeedUsers();
+        $user = User::factory()->create();
+
+        $command->createMessages($user, [$command->getDebrisFieldHarvestTemplate()], 1);
+
+        $message = Message::where('user_id', $user->id)->where('key', 'debris_field_harvest')->first();
+        $this->assertNotNull($message, 'createMessages() should have persisted a debris_field_harvest message.');
+
+        $gameMessage = GameMessageFactory::createGameMessage($message);
+        $this->assertStringNotContainsString('?undefined?', $gameMessage->getSubject());
+        $this->assertStringNotContainsString('?undefined?', $gameMessage->getBody());
+    }
+
     /**
      * Directly exercises the debris_field_harvest fixture generator without running
      * the full ogamex:dev:seed-users command (which also creates users/planets and

--- a/tests/Feature/PreviewSeedUsersCommandTest.php
+++ b/tests/Feature/PreviewSeedUsersCommandTest.php
@@ -7,22 +7,12 @@ use Illuminate\Testing\PendingCommand;
 use OGame\Factories\GameMessageFactory;
 use OGame\Models\Message;
 use OGame\Models\User;
+use OGame\Services\ObjectService;
 use Tests\TestCase;
 
 class PreviewSeedUsersCommandTest extends TestCase
 {
     use DatabaseTransactions;
-
-    /**
-     * Per-ship debris field harvest storage capacity, mirrored from the real ship
-     * object definitions (recycler / reaper) that the fixture is meant to represent.
-     *
-     * @var array<string, int>
-     */
-    private const SHIP_CAPACITY = [
-        'Recycler' => 20000,
-        'Reaper' => 10000,
-    ];
 
     public function test_seed_users_creates_valid_debris_field_harvest_messages(): void
     {
@@ -52,6 +42,10 @@ class PreviewSeedUsersCommandTest extends TestCase
             $this->assertLessThanOrEqual((int) $params['crystal'], (int) $params['harvested_crystal']);
             $this->assertLessThanOrEqual((int) $params['deuterium'], (int) $params['harvested_deuterium']);
 
+            // Harvested amounts can never exceed what the ships have room to carry.
+            $harvestedTotal = (int) $params['harvested_metal'] + (int) $params['harvested_crystal'] + (int) $params['harvested_deuterium'];
+            $this->assertLessThanOrEqual((int) $params['storage_capacity'], $harvestedTotal);
+
             // "to" is wrapped in [debrisfield], "coordinates" keeps [coordinates], matching
             // what RecycleMission/AttackMission send in production.
             $this->assertStringContainsString('[debrisfield]', $params['to']);
@@ -59,8 +53,19 @@ class PreviewSeedUsersCommandTest extends TestCase
 
             // ship_name must be a known harvesting ship, and storage_capacity must scale
             // with ship_amount using that ship's real cargo capacity.
-            $this->assertArrayHasKey($params['ship_name'], self::SHIP_CAPACITY, "Unexpected ship_name '{$params['ship_name']}'.");
-            $expectedCapacity = (int) $params['ship_amount'] * self::SHIP_CAPACITY[$params['ship_name']];
+            $machineNames = ['recycler', 'reaper', 'pathfinder'];
+            $matchedShip = null;
+            foreach ($machineNames as $machineName) {
+                $ship = ObjectService::getShipObjectByMachineName($machineName);
+                if ($ship->title === $params['ship_name']) {
+                    $matchedShip = $ship;
+                    break;
+                }
+            }
+            if ($matchedShip === null) {
+                $this->fail("Unexpected ship_name '{$params['ship_name']}'.");
+            }
+            $expectedCapacity = (int) $params['ship_amount'] * $matchedShip->properties->capacity->rawValue;
             $this->assertEquals($expectedCapacity, (int) $params['storage_capacity']);
 
             // Rendering the message must not leak any unresolved param placeholders.

--- a/tests/Feature/PreviewSeedUsersCommandTest.php
+++ b/tests/Feature/PreviewSeedUsersCommandTest.php
@@ -2,35 +2,25 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\DatabaseTransactions;
-use Illuminate\Testing\PendingCommand;
+use OGame\Console\Commands\Dev\PreviewSeedUsers;
 use OGame\Factories\GameMessageFactory;
 use OGame\Models\Message;
-use OGame\Models\User;
 use OGame\Services\ObjectService;
 use Tests\TestCase;
 
 class PreviewSeedUsersCommandTest extends TestCase
 {
-    use DatabaseTransactions;
-
-    public function test_seed_users_creates_valid_debris_field_harvest_messages(): void
+    /**
+     * Directly exercises the debris_field_harvest fixture generator without running
+     * the full ogamex:dev:seed-users command (which also creates users/planets and
+     * is slow). This keeps the test focused on the fixture's own correctness.
+     */
+    public function test_debris_field_harvest_fixture_produces_valid_messages(): void
     {
-        $command = $this->artisan('ogamex:dev:seed-users');
-        $this->assertInstanceOf(PendingCommand::class, $command);
-        $command->assertSuccessful();
+        $command = new PreviewSeedUsers();
 
-        $userIds = User::where('email', 'like', '%@ogamex.dev')->pluck('id');
-        $this->assertNotEmpty($userIds, 'Seed command should have created preview test users.');
-
-        $messages = Message::whereIn('user_id', $userIds)
-            ->where('key', 'debris_field_harvest')
-            ->get();
-
-        $this->assertNotEmpty($messages, 'Seed command should have created at least one debris_field_harvest message.');
-
-        foreach ($messages as $message) {
-            $params = $message->params;
+        for ($i = 0; $i < 50; $i++) {
+            $params = $command->generateDebrisFieldHarvestParams();
 
             // All params required by the DebrisFieldHarvest message must be present.
             foreach (['to', 'coordinates', 'ship_name', 'ship_amount', 'storage_capacity', 'metal', 'crystal', 'deuterium', 'harvested_metal', 'harvested_crystal', 'harvested_deuterium'] as $param) {
@@ -69,6 +59,9 @@ class PreviewSeedUsersCommandTest extends TestCase
             $this->assertEquals($expectedCapacity, (int) $params['storage_capacity']);
 
             // Rendering the message must not leak any unresolved param placeholders.
+            $message = new Message();
+            $message->key = 'debris_field_harvest';
+            $message->params = $params;
             $gameMessage = GameMessageFactory::createGameMessage($message);
             $this->assertStringNotContainsString('?undefined?', $gameMessage->getSubject());
             $this->assertStringNotContainsString('?undefined?', $gameMessage->getBody());


### PR DESCRIPTION
## Summary
- `debris_field_harvest` fixture in `PreviewSeedUsers.php` omitted `to`, `ship_name`, `ship_amount`, `storage_capacity`, `deuterium`, and `harvested_*` params, so `GameMessage::checkParams()` injected literal `?undefined?` for ship name/target and `formatReservedParams()` cast the rest to `0`
- fixture now supplies the full param set declared in `DebrisFieldHarvest`, mirroring the shape sent by `RecycleMission`

## Test plan
- [x] `php artisan ogamex:dev:seed-users` reseeded, logged in as `test10@ogamex.dev`, opened harvest messages under Messages → Fleets → other — no more `?undefined?`, ship name and target render correctly

Fixes #1562